### PR TITLE
chore(jsonrpc): remove redundant extension logic

### DIFF
--- a/src/opencode_a2a_serve/jsonrpc_ext.py
+++ b/src/opencode_a2a_serve/jsonrpc_ext.py
@@ -885,8 +885,13 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                 _validate_prompt_async_request_payload(raw_request)
             elif base_request.method == self._method_command:
                 _validate_command_request_payload(raw_request)
-            else:
+            elif base_request.method == self._method_shell:
                 _validate_shell_request_payload(raw_request)
+            else:
+                raise _PromptAsyncValidationError(
+                    field="method",
+                    message=f"Unsupported method: {base_request.method}",
+                )
         except _PromptAsyncValidationError as exc:
             return self._generate_error_response(
                 base_request.id,


### PR DESCRIPTION
## 背景
本 PR 聚焦清理 JSON-RPC 扩展实现中的冗余分支与重复逻辑，降低维护成本并保持既有协议行为不变。

## 变更模块
### `src/opencode_a2a_serve/jsonrpc_ext.py`
- 收敛 control hooks 校验与赋值路径：
  - 先用入参校验缺失 hooks，再进行强类型赋值，消除后续重复 `None` 判空。
- 提取分页模式错误响应构造：
  - 新增 `_invalid_pagination_mode_response(...)`，统一 `INVALID_PAGINATION_MODE` 返回内容。
- 精简 session control 分支：
  - 保留显式 method guard（`prompt_async`/`command`/`shell`），并保留 `unsupported method` 兜底报错分支，避免未来扩展时误入错误校验路径。
- 合并 interrupt callback 成功结果构造：
  - 统一 `{"ok": true, "request_id": ...}` 结果赋值，减少重复代码。

## 文档变更
- 无。

## 回归验证
- `uv run pre-commit run --all-files`
- `uv run pytest`（137 passed）

## 关联关系
- Closes #127
- 本 PR 相关提交：`57c4dfc`, `98ade50`

## 风险与兼容性说明
- 不涉及对外 API 字段、错误码与路由语义变更。
- 主要为内部实现去冗余与可维护性优化。
