### PR TITLE
feat: align OpenCode adapter with shared A2A contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Provide a practical adapter layer that lets individuals and small teams expose O
 - A2A HTTP+JSON endpoints (`/v1/message:send`, `/v1/message:stream`, `GET /v1/tasks/{task_id}:subscribe`).
 - A2A JSON-RPC endpoint (`POST /`) for standard methods and OpenCode-oriented extensions.
 - Streaming with incremental task artifacts and terminal status events.
-- Session continuation via `metadata.opencode.session_id`.
-- Session query/control extension methods (`opencode.sessions.*`) and interrupt callback methods.
+- Session continuation via `metadata.shared.session.id`.
+- OpenCode session query/control extension methods (`opencode.sessions.*`) and shared interrupt callback methods.
 
 ## Quick Start & Development
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -47,12 +47,14 @@ Key variables to understand protocol behavior:
 - Streaming (`/v1/message:stream`) emits incremental
   `TaskArtifactUpdateEvent` and then
   `TaskStatusUpdateEvent(final=true)`. Stream artifacts carry
-  `artifact.metadata.opencode.block_type` with values
+  `artifact.metadata.shared.stream.block_type` with values
   `text` / `reasoning` / `tool_call`. All chunks share one stream
   artifact ID and preserve original timeline via
-  `artifact.metadata.opencode.event_id`. `artifact.metadata.opencode.message_id`
-  remains best-effort metadata: when upstream omits `message_id`, service
-  falls back to a stable request-scoped message identity. A final snapshot is
+  `artifact.metadata.shared.stream.event_id`.
+  `artifact.metadata.shared.stream.message_id` remains best-effort metadata:
+  when upstream omits `message_id`, service falls back to a stable
+  request-scoped message identity. `artifact.metadata.shared.stream.sequence`
+  carries the canonical per-request stream sequence. A final snapshot is
   only emitted when stream
   chunks did not already produce the same final text.
   Stream routing is schema-first: the service classifies chunks primarily by
@@ -61,15 +63,15 @@ Key variables to understand protocol behavior:
   out-of-order deltas are buffered and replayed when the corresponding
   `part.updated` arrives. Structured `tool` parts are emitted as `tool_call`
   blocks with normalized state payload. Final status event metadata may include
-  normalized token usage at `metadata.opencode.usage` with fields like
+  normalized token usage at `metadata.shared.usage` with fields like
   `input_tokens`, `output_tokens`, `total_tokens`, and optional `cost`.
   Interrupt events (`permission.asked` / `question.asked`) are mapped to
   `TaskStatusUpdateEvent(final=false, state=input-required)` with details at
-  `metadata.opencode.interrupt` (including `request_id`, interrupt `type`, and
+  `metadata.shared.interrupt` (including `request_id`, interrupt `type`, and
   minimal callback payload).
   Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at
-  `Task.metadata.opencode.usage` with the same field schema.
+  `Task.metadata.shared.usage` with the same field schema.
 - Requests require `Authorization: Bearer <token>`; otherwise `401` is
   returned. Agent Card endpoints are public.
 - Within one `opencode-a2a-serve` instance, all consumers share the same
@@ -96,7 +98,7 @@ Key variables to understand protocol behavior:
 
 To continue a historical OpenCode session, include this metadata key in each invoke request:
 
-- `metadata.opencode.session_id`: target OpenCode session ID
+- `metadata.shared.session.id`: target upstream session ID
 
 Server behavior:
 
@@ -117,8 +119,10 @@ curl -sS http://127.0.0.1:8000/v1/message:send \
       "content": [{"text": "Continue the previous session and restate the key conclusion."}]
     },
     "metadata": {
-      "opencode": {
-        "session_id": "<session_id>"
+      "shared": {
+        "session": {
+          "id": "<session_id>"
+        }
       }
     }
   }'
@@ -142,8 +146,8 @@ This service exposes OpenCode session list/message-history queries and session c
   - message history => `Message`
   - `contextId` is an A2A context key derived by the adapter
     (format: `ctx:opencode-session:<session_id>`, not raw OpenCode session ID)
-  - OpenCode session identity is exposed explicitly at `metadata.opencode.session_id`
-  - session title is available at `metadata.opencode.title`
+  - OpenCode session identity is exposed explicitly at `metadata.shared.session.id`
+  - session title is available at `metadata.shared.session.title`
 
 ### Session List (`opencode.sessions.list`)
 
@@ -286,33 +290,34 @@ Response:
 - disabled => JSON-RPC error `METHOD_DISABLED`
 - notification (no `id`) => HTTP `204 No Content`
 
-## OpenCode Interrupt Callback (A2A Extension)
+## Shared Interrupt Callback (A2A Extension)
 
-When stream metadata reports an interrupt request at `metadata.opencode.interrupt`,
+When stream metadata reports an interrupt request at `metadata.shared.interrupt`,
 clients can reply through JSON-RPC extension methods:
 
-- `opencode.permission.reply`
+- `a2a.interrupt.permission.reply`
   - required: `request_id`
   - required: `reply` (`once` / `always` / `reject`)
   - optional: `message`
   - optional: `metadata.opencode.directory`
-- `opencode.question.reply`
+- `a2a.interrupt.question.reply`
   - required: `request_id`
   - required: `answers` (`Array<Array<string>>`)
   - optional: `metadata.opencode.directory`
-- `opencode.question.reject`
+- `a2a.interrupt.question.reject`
   - required: `request_id`
   - optional: `metadata.opencode.directory`
 
 Notes:
 
 - `request_id` must be a live interrupt request observed from stream metadata
-  (`metadata.opencode.interrupt.request_id`).
+  (`metadata.shared.interrupt.request_id`).
 - The server keeps an in-memory interrupt binding cache; callbacks with unknown
   or expired `request_id` are rejected.
 - Callback requests are validated against interrupt type and caller identity.
-- Callback context variables use nested metadata namespace:
-  `params.metadata.opencode.*` (for example `metadata.opencode.directory`).
+- Callback context variables use the shared method contract plus
+  OpenCode-private metadata when needed
+  (`params.metadata.opencode.directory`).
 - Successful callback responses are minimal: only `ok` and `request_id`.
 - Error types:
   - `INTERRUPT_REQUEST_NOT_FOUND`
@@ -330,7 +335,7 @@ curl -sS http://127.0.0.1:8000/ \
   -d '{
     "jsonrpc": "2.0",
     "id": 3,
-    "method": "opencode.permission.reply",
+    "method": "a2a.interrupt.permission.reply",
     "params": {
       "request_id": "<request_id>",
       "reply": "once",
@@ -420,7 +425,7 @@ uv run pytest
 The contract check fails when any of these drift:
 - SSOT (`extension_contracts.py`)
 - Agent Card extension params
-- OpenAPI `POST /` extension metadata (`x-opencode-extension-contracts`) or examples
+- OpenAPI `POST /` extension metadata (`x-a2a-extension-contracts`) or examples
 - Notification behavior (`204 No Content`) for extension methods
 
 ## Development Setup

--- a/src/opencode_a2a_serve/agent.py
+++ b/src/opencode_a2a_serve/agent.py
@@ -449,7 +449,7 @@ class OpencodeAgentExecutor(AgentExecutor):
 
         streaming_request = self._should_stream(context)
         user_text = context.get_user_input().strip()
-        bound_session_id = _extract_opencode_session_id(context)
+        bound_session_id = _extract_shared_session_id(context)
 
         # Directory validation
         metadata = context.metadata
@@ -606,6 +606,7 @@ class OpencodeAgentExecutor(AgentExecutor):
                             source="final_snapshot",
                             message_id=resolved_message_id,
                             event_id=stream_state.build_event_id(sequence),
+                            sequence=sequence,
                         ),
                     )
                 await event_queue.enqueue_event(
@@ -616,18 +617,15 @@ class OpencodeAgentExecutor(AgentExecutor):
                             state=TaskState.completed,
                         ),
                         final=True,
-                        metadata={
-                            "opencode": {
-                                "session_id": response.session_id,
+                        metadata=_build_output_metadata(
+                            session_id=response.session_id,
+                            usage=resolved_token_usage,
+                            stream={
                                 "message_id": resolved_message_id,
                                 "event_id": f"{stream_state.event_id_namespace}:status",
-                                **(
-                                    {"usage": resolved_token_usage}
-                                    if resolved_token_usage is not None
-                                    else {}
-                                ),
-                            }
-                        },
+                                "source": "status",
+                            },
+                        ),
                     )
                 )
             else:
@@ -650,16 +648,10 @@ class OpencodeAgentExecutor(AgentExecutor):
                     status=TaskStatus(state=TaskState.completed),
                     history=history,
                     artifacts=[artifact],
-                    metadata={
-                        "opencode": {
-                            "session_id": response.session_id,
-                            **(
-                                {"usage": resolved_token_usage}
-                                if resolved_token_usage is not None
-                                else {}
-                            ),
-                        }
-                    },
+                    metadata=_build_output_metadata(
+                        session_id=response.session_id,
+                        usage=resolved_token_usage,
+                    ),
                 )
                 # Attach the assistant message as the current status message.
                 task.status.message = assistant_message
@@ -1074,6 +1066,7 @@ class OpencodeAgentExecutor(AgentExecutor):
                         message_id=resolved_message_id,
                         role=chunk.role,
                         event_id=stream_state.build_event_id(sequence),
+                        sequence=sequence,
                     ),
                 )
                 logger.debug(
@@ -1099,18 +1092,20 @@ class OpencodeAgentExecutor(AgentExecutor):
                     context_id=context_id,
                     status=TaskStatus(state=state),
                     final=False,
-                    metadata={
-                        "opencode": {
-                            "session_id": session_id,
+                    metadata=_build_output_metadata(
+                        session_id=session_id,
+                        stream={
                             "message_id": stream_state.resolve_message_id(None),
                             "event_id": stream_state.build_event_id(sequence),
-                            "interrupt": {
-                                "request_id": request_id,
-                                "type": interrupt_type,
-                                "details": dict(details),
-                            },
-                        }
-                    },
+                            "source": "interrupt",
+                            "sequence": sequence,
+                        },
+                        interrupt={
+                            "request_id": request_id,
+                            "type": interrupt_type,
+                            "details": dict(details),
+                        },
+                    ),
                 )
             )
 
@@ -1462,18 +1457,51 @@ def _build_stream_artifact_metadata(
     message_id: str | None = None,
     role: str | None = None,
     event_id: str | None = None,
+    sequence: int | None = None,
 ) -> dict[str, Any]:
-    opencode_meta: dict[str, Any] = {
-        "block_type": block_type,
+    stream_meta: dict[str, Any] = {
+        "block_type": block_type.value,
         "source": source,
     }
     if message_id:
-        opencode_meta["message_id"] = message_id
+        stream_meta["message_id"] = message_id
     if role:
-        opencode_meta["role"] = role
+        stream_meta["role"] = role
     if event_id:
-        opencode_meta["event_id"] = event_id
-    return {"opencode": opencode_meta}
+        stream_meta["event_id"] = event_id
+    if sequence is not None:
+        stream_meta["sequence"] = sequence
+    return {"shared": {"stream": stream_meta}}
+
+
+def _build_output_metadata(
+    *,
+    session_id: str | None = None,
+    session_title: str | None = None,
+    usage: Mapping[str, Any] | None = None,
+    stream: Mapping[str, Any] | None = None,
+    interrupt: Mapping[str, Any] | None = None,
+    opencode_private: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    metadata: dict[str, Any] = {}
+    shared_meta: dict[str, Any] = {}
+
+    if session_id:
+        session_meta: dict[str, Any] = {"id": session_id}
+        if session_title is not None:
+            session_meta["title"] = session_title
+        shared_meta["session"] = session_meta
+    if usage is not None:
+        shared_meta["usage"] = dict(usage)
+    if stream is not None:
+        shared_meta["stream"] = dict(stream)
+    if interrupt is not None:
+        shared_meta["interrupt"] = dict(interrupt)
+    if shared_meta:
+        metadata["shared"] = shared_meta
+    if opencode_private:
+        metadata["opencode"] = dict(opencode_private)
+    return metadata or None
 
 
 def _coerce_number(value: Any) -> int | float | None:
@@ -1810,28 +1838,41 @@ def _build_history(context: RequestContext) -> list[Message]:
     return history
 
 
-def _iter_opencode_metadata_maps(context: RequestContext):
+def _iter_metadata_maps(context: RequestContext, namespace: str):
     try:
         meta = context.metadata
     except Exception:
         meta = None
 
     if isinstance(meta, Mapping):
-        opencode_meta = meta.get("opencode")
-        if isinstance(opencode_meta, Mapping):
-            yield opencode_meta
+        namespaced_meta = meta.get(namespace)
+        if isinstance(namespaced_meta, Mapping):
+            yield namespaced_meta
 
     if context.message is not None:
         msg_meta = getattr(context.message, "metadata", None) or {}
         if isinstance(msg_meta, Mapping):
-            opencode_meta = msg_meta.get("opencode")
-            if isinstance(opencode_meta, Mapping):
-                yield opencode_meta
+            namespaced_meta = msg_meta.get(namespace)
+            if isinstance(namespaced_meta, Mapping):
+                yield namespaced_meta
 
 
-def _extract_opencode_string_metadata(context: RequestContext, field: str) -> str | None:
-    for opencode_meta in _iter_opencode_metadata_maps(context):
-        candidate = opencode_meta.get(field)
+def _extract_namespaced_string_metadata(
+    context: RequestContext,
+    *,
+    namespace: str,
+    path: tuple[str, ...],
+) -> str | None:
+    for namespaced_meta in _iter_metadata_maps(context, namespace):
+        current: Any = namespaced_meta
+        for part in path[:-1]:
+            if not isinstance(current, Mapping):
+                current = None
+                break
+            current = current.get(part)
+        if not isinstance(current, Mapping):
+            continue
+        candidate = current.get(path[-1])
         if isinstance(candidate, str):
             value = candidate.strip()
             if value:
@@ -1839,11 +1880,19 @@ def _extract_opencode_string_metadata(context: RequestContext, field: str) -> st
     return None
 
 
-def _extract_opencode_session_id(context: RequestContext) -> str | None:
-    # Contract: clients pass binding metadata under metadata.opencode.session_id.
-    return _extract_opencode_string_metadata(context, "session_id")
+def _extract_shared_session_id(context: RequestContext) -> str | None:
+    # Contract: clients pass shared binding metadata under metadata.shared.session.id.
+    return _extract_namespaced_string_metadata(
+        context,
+        namespace="shared",
+        path=("session", "id"),
+    )
 
 
 def _extract_opencode_directory(context: RequestContext) -> str | None:
     # Contract: clients pass directory override under metadata.opencode.directory.
-    return _extract_opencode_string_metadata(context, "directory")
+    return _extract_namespaced_string_metadata(
+        context,
+        namespace="opencode",
+        path=("directory",),
+    )

--- a/src/opencode_a2a_serve/app.py
+++ b/src/opencode_a2a_serve/app.py
@@ -48,7 +48,9 @@ from .extension_contracts import (
     SESSION_CONTROL_METHODS,
     SESSION_QUERY_METHODS,
     build_interrupt_callback_extension_params,
+    build_session_binding_extension_params,
     build_session_query_extension_params,
+    build_streaming_extension_params,
 )
 from .jsonrpc_ext import (
     SESSION_CONTEXT_PREFIX,
@@ -66,9 +68,10 @@ _REQUEST_BODY_BYTES: ContextVar[bytes | None] = ContextVar(
 if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
 
-SESSION_BINDING_EXTENSION_URI = "urn:opencode-a2a:opencode-session-binding/v1"
-SESSION_QUERY_EXTENSION_URI = "urn:opencode-a2a:opencode-session-query/v1"
-INTERRUPT_CALLBACK_EXTENSION_URI = "urn:opencode-a2a:opencode-interrupt-callback/v1"
+SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
+STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
+SESSION_QUERY_EXTENSION_URI = "urn:opencode-a2a:session-query/v1"
+INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
 
 
 class OpencodeRequestHandler(DefaultRequestHandler):
@@ -270,8 +273,8 @@ def _build_agent_card_description(
         "Supports HTTP+JSON and JSON-RPC transports, standard A2A messaging "
         "(message/send, message/stream), task APIs (tasks/get, tasks/cancel, "
         "tasks/resubscribe; REST mapping: GET /v1/tasks/{id}:subscribe), "
-        "OpenCode session-query extensions, and interrupt callback extensions "
-        "(permission/question reply)."
+        "shared session-binding and streaming contracts, OpenCode session-query "
+        "extensions, and shared interrupt callback extensions."
     )
     parts: list[str] = [base, summary]
     parts.append(
@@ -307,9 +310,9 @@ def _build_jsonrpc_extension_openapi_description() -> str:
     return (
         "A2A JSON-RPC entrypoint. Supports core A2A methods "
         "(message/send, message/stream, tasks/get, tasks/cancel, tasks/resubscribe) "
-        "and OpenCode extension methods.\n\n"
-        f"Session query/control extension methods: {session_methods}.\n"
-        f"Interrupt callback extension methods: {interrupt_methods}.\n\n"
+        "plus OpenCode session-query methods and shared interrupt callback methods.\n\n"
+        f"OpenCode session query/control methods: {session_methods}.\n"
+        f"Shared interrupt callback methods: {interrupt_methods}.\n\n"
         "Notification semantics: extension requests without JSON-RPC id return HTTP 204."
     )
 
@@ -464,8 +467,8 @@ def _build_rest_message_openapi_examples() -> dict[str, Any]:
                     "content": [{"text": "Continue previous work and summarize next steps."}],
                 },
                 "metadata": {
-                    "opencode": {
-                        "session_id": "s-1",
+                    "shared": {
+                        "session": {"id": "s-1"},
                     }
                 },
             },
@@ -478,6 +481,11 @@ def _patch_jsonrpc_openapi_contract(
     *,
     deployment_context: dict[str, str | bool],
 ) -> None:
+    session_binding = build_session_binding_extension_params(
+        deployment_context=deployment_context,
+        directory_override_enabled=bool(deployment_context["allow_directory_override"]),
+    )
+    streaming = build_streaming_extension_params()
     session_query = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
@@ -500,7 +508,9 @@ def _patch_jsonrpc_openapi_contract(
                 if isinstance(post, dict):
                     post["summary"] = "Handle A2A JSON-RPC Requests"
                     post["description"] = _build_jsonrpc_extension_openapi_description()
-                    post["x-opencode-extension-contracts"] = {
+                    post["x-a2a-extension-contracts"] = {
+                        "session_binding": session_binding,
+                        "streaming": streaming,
                         "session_query": session_query,
                         "interrupt_callback": interrupt_callback,
                     }
@@ -592,6 +602,11 @@ def build_agent_card(settings: Settings) -> AgentCard:
         )
         security.append({"oauth2": list(settings.a2a_oauth_scopes.keys())})
 
+    session_binding_extension_params = build_session_binding_extension_params(
+        deployment_context=deployment_context,
+        directory_override_enabled=settings.a2a_allow_directory_override,
+    )
+    streaming_extension_params = build_streaming_extension_params()
     session_query_extension_params = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
@@ -617,33 +632,22 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     uri=SESSION_BINDING_EXTENSION_URI,
                     required=False,
                     description=(
-                        "Contract to bind A2A messages to an existing OpenCode session "
-                        "when continuing a previous chat. Clients should pass "
-                        "metadata.opencode.session_id. The metadata.opencode.directory field is "
-                        "also "
-                        "supported under server-side directory boundary validation."
+                        "Shared contract to bind A2A messages to an existing upstream "
+                        "session when continuing a previous chat. Clients should pass "
+                        "metadata.shared.session.id. The metadata.opencode.directory field "
+                        "remains available as an OpenCode-private override under "
+                        "server-side directory boundary validation."
                     ),
-                    params={
-                        "metadata_namespace": "opencode",
-                        "metadata_key": "opencode.session_id",
-                        "behavior": "prefer_metadata_binding_else_create_session",
-                        "supported_metadata": ["opencode.session_id", "opencode.directory"],
-                        "directory_override_enabled": settings.a2a_allow_directory_override,
-                        "shared_workspace_across_consumers": True,
-                        "tenant_isolation": "none",
-                        "deployment_context": deployment_context,
-                        "notes": [
-                            (
-                                "If metadata.opencode.session_id is provided, the server will "
-                                "send the message to that OpenCode session_id."
-                            ),
-                            (
-                                "Otherwise, the server will create a new OpenCode session and "
-                                "cache the (identity, contextId)->session_id mapping in memory "
-                                "with TTL."
-                            ),
-                        ],
-                    },
+                    params=session_binding_extension_params,
+                ),
+                AgentExtension(
+                    uri=STREAMING_EXTENSION_URI,
+                    required=False,
+                    description=(
+                        "Shared streaming metadata contract for canonical block hints, "
+                        "timeline identity, usage, and interactive interrupt metadata."
+                    ),
+                    params=streaming_extension_params,
                 ),
                 AgentExtension(
                     uri=SESSION_QUERY_EXTENSION_URI,
@@ -658,8 +662,8 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     uri=INTERRUPT_CALLBACK_EXTENSION_URI,
                     required=False,
                     description=(
-                        "Handle interactive interrupt callbacks generated by OpenCode "
-                        "(permission/question asked events) through JSON-RPC methods."
+                        "Handle interactive interrupt callbacks generated during "
+                        "streaming through shared JSON-RPC methods."
                     ),
                     params=interrupt_callback_extension_params,
                 ),
@@ -694,13 +698,13 @@ def build_agent_card(settings: Settings) -> AgentCard:
             ),
             AgentSkill(
                 id="opencode.interrupt.callback",
-                name="OpenCode Interrupt Callback",
+                name="Shared Interrupt Callback",
                 description=(
                     "Reply permission/question interrupts emitted during streaming via "
-                    "JSON-RPC methods opencode.permission.reply, "
-                    "opencode.question.reply, and opencode.question.reject."
+                    "JSON-RPC methods a2a.interrupt.permission.reply, "
+                    "a2a.interrupt.question.reply, and a2a.interrupt.question.reject."
                 ),
-                tags=["opencode", "interrupt", "permission", "question"],
+                tags=["interrupt", "permission", "question", "shared"],
                 examples=[
                     "Reply once/always/reject to a permission request by request_id.",
                     "Submit answers for a question request by request_id.",
@@ -808,13 +812,16 @@ def create_app(settings: Settings) -> FastAPI:
             return None
         return payload if isinstance(payload, dict) else None
 
-    def _detect_opencode_extension_method(payload: dict | None) -> str | None:
+    def _detect_sensitive_extension_method(payload: dict | None) -> str | None:
         if payload is None:
             return None
         method = payload.get("method")
         if not isinstance(method, str):
             return None
-        if method.startswith("opencode."):
+        sensitive_methods = set(SESSION_QUERY_METHODS.values()) | set(
+            INTERRUPT_CALLBACK_METHODS.values()
+        )
+        if method in sensitive_methods:
             return method
         return None
 
@@ -926,7 +933,7 @@ def create_app(settings: Settings) -> FastAPI:
                 body, token = await _get_request_body(request)
                 # Detect session-query JSON-RPC methods regardless of deployment prefixes/root_path.
                 payload = _parse_json_body(body)
-                sensitive_method = _detect_opencode_extension_method(payload)
+                sensitive_method = _detect_sensitive_extension_method(payload)
 
                 if sensitive_method:
                     logger.debug(

--- a/src/opencode_a2a_serve/extension_contracts.py
+++ b/src/opencode_a2a_serve/extension_contracts.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+SHARED_METADATA_NAMESPACE = "shared"
+SHARED_SESSION_BINDING_FIELD = "metadata.shared.session.id"
+SHARED_SESSION_METADATA_FIELD = "metadata.shared.session"
+SHARED_STREAM_METADATA_FIELD = "metadata.shared.stream"
+SHARED_INTERRUPT_METADATA_FIELD = "metadata.shared.interrupt"
+SHARED_USAGE_METADATA_FIELD = "metadata.shared.usage"
+OPENCODE_DIRECTORY_METADATA_FIELD = "metadata.opencode.directory"
+
 
 @dataclass(frozen=True)
 class SessionQueryMethodContract:
@@ -98,7 +106,7 @@ SESSION_QUERY_METHOD_CONTRACTS: dict[str, SessionQueryMethodContract] = {
             "request.format",
             "request.system",
             "request.variant",
-            "metadata.opencode.directory",
+            OPENCODE_DIRECTORY_METADATA_FIELD,
         ),
         result_fields=("ok", "session_id"),
         notification_response_status=204,
@@ -112,7 +120,7 @@ SESSION_QUERY_METHOD_CONTRACTS: dict[str, SessionQueryMethodContract] = {
             "request.model",
             "request.variant",
             "request.parts",
-            "metadata.opencode.directory",
+            OPENCODE_DIRECTORY_METADATA_FIELD,
         ),
         result_fields=("item",),
         notification_response_status=204,
@@ -122,7 +130,7 @@ SESSION_QUERY_METHOD_CONTRACTS: dict[str, SessionQueryMethodContract] = {
         required_params=("session_id", "request.agent", "request.command"),
         optional_params=(
             "request.model",
-            "metadata.opencode.directory",
+            OPENCODE_DIRECTORY_METADATA_FIELD,
         ),
         result_fields=("item",),
         notification_response_status=204,
@@ -162,19 +170,19 @@ SESSION_QUERY_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
 
 INTERRUPT_CALLBACK_METHOD_CONTRACTS: dict[str, InterruptMethodContract] = {
     "reply_permission": InterruptMethodContract(
-        method="opencode.permission.reply",
+        method="a2a.interrupt.permission.reply",
         required_params=("request_id", "reply"),
         optional_params=("message", "metadata"),
         notification_response_status=204,
     ),
     "reply_question": InterruptMethodContract(
-        method="opencode.question.reply",
+        method="a2a.interrupt.question.reply",
         required_params=("request_id", "answers"),
         optional_params=("metadata",),
         notification_response_status=204,
     ),
     "reject_question": InterruptMethodContract(
-        method="opencode.question.reject",
+        method="a2a.interrupt.question.reject",
         required_params=("request_id",),
         optional_params=("metadata",),
         notification_response_status=204,
@@ -223,6 +231,66 @@ def _build_method_contract_params(
     if unsupported:
         params["unsupported"] = list(unsupported)
     return params
+
+
+def build_session_binding_extension_params(
+    *,
+    deployment_context: dict[str, str | bool],
+    directory_override_enabled: bool,
+) -> dict[str, Any]:
+    return {
+        "metadata_field": SHARED_SESSION_BINDING_FIELD,
+        "behavior": "prefer_metadata_binding_else_create_session",
+        "supported_metadata": [
+            "shared.session.id",
+            "opencode.directory",
+        ],
+        "provider_private_metadata": ["opencode.directory"],
+        "directory_override_enabled": directory_override_enabled,
+        "shared_workspace_across_consumers": True,
+        "tenant_isolation": "none",
+        "deployment_context": deployment_context,
+        "notes": [
+            (
+                "If metadata.shared.session.id is provided, the server will send the "
+                "message to that upstream session."
+            ),
+            (
+                "Otherwise, the server will create a new upstream session and cache "
+                "the (identity, contextId)->session_id mapping in memory with TTL."
+            ),
+        ],
+    }
+
+
+def build_streaming_extension_params() -> dict[str, Any]:
+    return {
+        "artifact_metadata_field": SHARED_STREAM_METADATA_FIELD,
+        "status_metadata_field": SHARED_STREAM_METADATA_FIELD,
+        "interrupt_metadata_field": SHARED_INTERRUPT_METADATA_FIELD,
+        "session_metadata_field": SHARED_SESSION_METADATA_FIELD,
+        "usage_metadata_field": SHARED_USAGE_METADATA_FIELD,
+        "block_types": ["text", "reasoning", "tool_call"],
+        "stream_fields": {
+            "block_type": f"{SHARED_STREAM_METADATA_FIELD}.block_type",
+            "source": f"{SHARED_STREAM_METADATA_FIELD}.source",
+            "message_id": f"{SHARED_STREAM_METADATA_FIELD}.message_id",
+            "event_id": f"{SHARED_STREAM_METADATA_FIELD}.event_id",
+            "sequence": f"{SHARED_STREAM_METADATA_FIELD}.sequence",
+            "role": f"{SHARED_STREAM_METADATA_FIELD}.role",
+        },
+        "interrupt_fields": {
+            "request_id": f"{SHARED_INTERRUPT_METADATA_FIELD}.request_id",
+            "type": f"{SHARED_INTERRUPT_METADATA_FIELD}.type",
+            "details": f"{SHARED_INTERRUPT_METADATA_FIELD}.details",
+        },
+        "usage_fields": {
+            "input_tokens": f"{SHARED_USAGE_METADATA_FIELD}.input_tokens",
+            "output_tokens": f"{SHARED_USAGE_METADATA_FIELD}.output_tokens",
+            "total_tokens": f"{SHARED_USAGE_METADATA_FIELD}.total_tokens",
+            "cost": f"{SHARED_USAGE_METADATA_FIELD}.cost",
+        },
+    }
 
 
 def build_session_query_extension_params(
@@ -292,7 +360,7 @@ def build_session_query_extension_params(
         "context_semantics": {
             "a2a_context_id_field": "contextId",
             "a2a_context_id_prefix": context_id_prefix,
-            "upstream_session_id_field": "metadata.opencode.session_id",
+            "upstream_session_id_field": SHARED_SESSION_BINDING_FIELD,
         },
     }
 
@@ -328,10 +396,11 @@ def build_interrupt_callback_extension_params(
         "question_reply_contract": {
             "answers": "array of answer arrays (same order as asked questions)"
         },
-        "metadata_namespace": "opencode",
+        "request_id_field": f"{SHARED_INTERRUPT_METADATA_FIELD}.request_id",
         "supported_metadata": ["opencode.directory"],
+        "provider_private_metadata": ["opencode.directory"],
         "context_fields": {
-            "directory": "metadata.opencode.directory",
+            "directory": OPENCODE_DIRECTORY_METADATA_FIELD,
         },
         "success_result_fields": list(INTERRUPT_SUCCESS_RESULT_FIELDS),
         "errors": {

--- a/src/opencode_a2a_serve/jsonrpc_ext.py
+++ b/src/opencode_a2a_serve/jsonrpc_ext.py
@@ -393,7 +393,7 @@ def _as_a2a_session_task(session: Any) -> dict[str, Any] | None:
         context_id=context_id,
         # Model OpenCode sessions as completed A2A Tasks for stable downstream rendering.
         status=TaskStatus(state=TaskState.completed),
-        metadata={"opencode": {"session_id": session_id, "title": title}},
+        metadata={"shared": {"session": {"id": session_id, "title": title}}},
     )
     return task.model_dump(by_alias=True, exclude_none=True)
 
@@ -430,7 +430,7 @@ def _as_a2a_message(session_id: str, item: Any) -> dict[str, Any] | None:
         role=role,
         parts=[Part(root=TextPart(text=text))],
         context_id=context_id,
-        metadata={"opencode": {"session_id": session_id}},
+        metadata={"shared": {"session": {"id": session_id}}},
     )
     return msg.model_dump(by_alias=True, exclude_none=True)
 
@@ -545,7 +545,7 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
 
         opencode_metadata: dict[str, Any] | None = None
         if isinstance(metadata, dict):
-            unknown_metadata_fields = sorted(set(metadata) - {"opencode"})
+            unknown_metadata_fields = sorted(set(metadata) - {"opencode", "shared"})
             if unknown_metadata_fields:
                 prefixed_fields = [f"metadata.{field}" for field in unknown_metadata_fields]
                 return None, self._generate_error_response(
@@ -570,6 +570,17 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                 )
             if isinstance(raw_opencode_metadata, dict):
                 opencode_metadata = raw_opencode_metadata
+            raw_shared_metadata = metadata.get("shared")
+            if raw_shared_metadata is not None and not isinstance(raw_shared_metadata, dict):
+                return None, self._generate_error_response(
+                    request_id,
+                    A2AError(
+                        root=InvalidParamsError(
+                            message="metadata.shared must be an object",
+                            data={"type": "INVALID_FIELD", "field": "metadata.shared"},
+                        )
+                    ),
+                )
 
         directory = None
         if opencode_metadata is not None:

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -2,6 +2,7 @@ from opencode_a2a_serve.app import (
     INTERRUPT_CALLBACK_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
+    STREAMING_EXTENSION_URI,
     build_agent_card,
 )
 from opencode_a2a_serve.jsonrpc_ext import SESSION_CONTEXT_PREFIX
@@ -44,15 +45,21 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert context["variant"] == "safe"
     assert context["allow_directory_override"] is False
     assert context["shared_workspace_across_consumers"] is True
-    assert binding.params["metadata_namespace"] == "opencode"
-    assert binding.params["metadata_key"] == "opencode.session_id"
+    assert binding.params["metadata_field"] == "metadata.shared.session.id"
     assert binding.params["supported_metadata"] == [
-        "opencode.session_id",
+        "shared.session.id",
         "opencode.directory",
     ]
+    assert binding.params["provider_private_metadata"] == ["opencode.directory"]
     assert binding.params["directory_override_enabled"] is False
     assert binding.params["shared_workspace_across_consumers"] is True
     assert binding.params["tenant_isolation"] == "none"
+
+    streaming = ext_by_uri[STREAMING_EXTENSION_URI]
+    assert streaming.params["artifact_metadata_field"] == "metadata.shared.stream"
+    assert streaming.params["interrupt_metadata_field"] == "metadata.shared.interrupt"
+    assert streaming.params["usage_metadata_field"] == "metadata.shared.usage"
+    assert streaming.params["stream_fields"]["sequence"] == "metadata.shared.stream.sequence"
 
     session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
     assert session_query.params["deployment_context"]["project"] == "alpha"
@@ -107,7 +114,7 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     )
     assert (
         session_query.params["context_semantics"]["upstream_session_id_field"]
-        == "metadata.opencode.session_id"
+        == "metadata.shared.session.id"
     )
     assert session_query.params["errors"]["business_codes"] == {
         "SESSION_NOT_FOUND": -32001,
@@ -129,8 +136,9 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert interrupt.params["deployment_context"]["project"] == "alpha"
     assert interrupt.params["shared_workspace_across_consumers"] is True
     assert interrupt.params["tenant_isolation"] == "none"
-    assert interrupt.params["metadata_namespace"] == "opencode"
+    assert interrupt.params["request_id_field"] == "metadata.shared.interrupt.request_id"
     assert interrupt.params["supported_metadata"] == ["opencode.directory"]
+    assert interrupt.params["provider_private_metadata"] == ["opencode.directory"]
     assert interrupt.params["context_fields"]["directory"] == "metadata.opencode.directory"
     assert interrupt.params["errors"]["business_codes"] == {
         "INTERRUPT_REQUEST_NOT_FOUND": -32004,
@@ -153,9 +161,9 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
         "actual",
     ]
     for method_name in (
-        "opencode.permission.reply",
-        "opencode.question.reply",
-        "opencode.question.reject",
+        "a2a.interrupt.permission.reply",
+        "a2a.interrupt.question.reply",
+        "a2a.interrupt.question.reject",
     ):
         assert (
             interrupt.params["method_contracts"][method_name]["notification_response_status"] == 204

--- a/tests/test_extension_contract_consistency.py
+++ b/tests/test_extension_contract_consistency.py
@@ -3,7 +3,9 @@ import pytest
 
 from opencode_a2a_serve.app import (
     INTERRUPT_CALLBACK_EXTENSION_URI,
+    SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
+    STREAMING_EXTENSION_URI,
     build_agent_card,
     create_app,
 )
@@ -11,7 +13,9 @@ from opencode_a2a_serve.extension_contracts import (
     INTERRUPT_CALLBACK_METHODS,
     SESSION_QUERY_METHODS,
     build_interrupt_callback_extension_params,
+    build_session_binding_extension_params,
     build_session_query_extension_params,
+    build_streaming_extension_params,
 )
 from opencode_a2a_serve.jsonrpc_ext import SESSION_CONTEXT_PREFIX
 from tests.helpers import DummySessionQueryOpencodeClient as DummyOpencodeClient
@@ -22,10 +26,17 @@ def test_extension_ssot_matches_agent_card_contracts() -> None:
     card = build_agent_card(make_settings(a2a_bearer_token="test-token"))
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
 
+    session_binding = ext_by_uri[SESSION_BINDING_EXTENSION_URI]
+    streaming = ext_by_uri[STREAMING_EXTENSION_URI]
     session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
     interrupt_callback = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
     deployment_context = session_query.params["deployment_context"]
 
+    expected_session_binding = build_session_binding_extension_params(
+        deployment_context=deployment_context,
+        directory_override_enabled=True,
+    )
+    expected_streaming = build_streaming_extension_params()
     expected_session_query = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
@@ -34,6 +45,12 @@ def test_extension_ssot_matches_agent_card_contracts() -> None:
         deployment_context=deployment_context,
     )
 
+    assert session_binding.params == expected_session_binding, (
+        "Session binding extension drifted from extension_contracts SSOT."
+    )
+    assert streaming.params == expected_streaming, (
+        "Streaming extension drifted from extension_contracts SSOT."
+    )
     assert session_query.params == expected_session_query, (
         "Session query extension drifted from extension_contracts SSOT."
     )
@@ -47,14 +64,21 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     openapi = app.openapi()
     post = openapi["paths"]["/"]["post"]
 
-    contract = post.get("x-opencode-extension-contracts")
+    contract = post.get("x-a2a-extension-contracts")
     assert isinstance(contract, dict), (
-        "POST / OpenAPI is missing x-opencode-extension-contracts metadata."
+        "POST / OpenAPI is missing x-a2a-extension-contracts metadata."
     )
 
+    session_binding = contract["session_binding"]
+    streaming = contract["streaming"]
     session_query = contract["session_query"]
     interrupt_callback = contract["interrupt_callback"]
     deployment_context = session_query["deployment_context"]
+    expected_session_binding = build_session_binding_extension_params(
+        deployment_context=deployment_context,
+        directory_override_enabled=True,
+    )
+    expected_streaming = build_streaming_extension_params()
     expected_session_query = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
@@ -63,6 +87,12 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
         deployment_context=deployment_context,
     )
 
+    assert session_binding == expected_session_binding, (
+        "OpenAPI session binding contract drifted from extension_contracts SSOT."
+    )
+    assert streaming == expected_streaming, (
+        "OpenAPI streaming contract drifted from extension_contracts SSOT."
+    )
     assert session_query == expected_session_query, (
         "OpenAPI session query contract drifted from extension_contracts SSOT."
     )
@@ -126,13 +156,17 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
             },
             None,
         ),
-        ("opencode.permission.reply", {"request_id": "req-perm", "reply": "once"}, "permission"),
         (
-            "opencode.question.reply",
+            "a2a.interrupt.permission.reply",
+            {"request_id": "req-perm", "reply": "once"},
+            "permission",
+        ),
+        (
+            "a2a.interrupt.question.reply",
             {"request_id": "req-question-reply", "answers": [["ok"]]},
             "question",
         ),
-        ("opencode.question.reject", {"request_id": "req-question-reject"}, "question"),
+        ("a2a.interrupt.question.reject", {"request_id": "req-question-reject"}, "question"),
     ],
 )
 async def test_extension_notification_contracts_return_204(

--- a/tests/test_opencode_agent_session_binding.py
+++ b/tests/test_opencode_agent_session_binding.py
@@ -9,7 +9,7 @@ from tests.helpers import DummyChatOpencodeClient, DummyEventQueue, make_request
 
 
 @pytest.mark.asyncio
-async def test_agent_prefers_metadata_opencode_session_id() -> None:
+async def test_agent_prefers_metadata_shared_session_id() -> None:
     client = DummyChatOpencodeClient()
     executor = OpencodeAgentExecutor(client, streaming_enabled=False)
     q = DummyEventQueue()
@@ -18,7 +18,7 @@ async def test_agent_prefers_metadata_opencode_session_id() -> None:
         task_id="t-1",
         context_id="c-1",
         text="hello",
-        metadata={"opencode": {"session_id": "ses-bound"}},
+        metadata={"shared": {"session": {"id": "ses-bound"}}},
     )
     await executor.execute(ctx, q)
 
@@ -41,7 +41,7 @@ async def test_agent_caches_bound_session_id_for_followup_requests() -> None:
         task_id="t-1",
         context_id="c-1",
         text="hello",
-        metadata={"opencode": {"session_id": "ses-bound"}},
+        metadata={"shared": {"session": {"id": "ses-bound"}}},
     )
     await executor.execute(ctx1, q)
 
@@ -117,7 +117,7 @@ async def test_agent_uses_stable_fallback_message_id_when_upstream_missing_messa
     )
 
     task = next(event for event in q.events if isinstance(event, Task))
-    assert "message_id" not in task.metadata["opencode"]
+    assert "message_id" not in task.metadata["shared"]["session"]
     assert task.status.message.message_id == "t-fallback:c-fallback:assistant"
 
 
@@ -161,7 +161,7 @@ async def test_agent_includes_usage_in_non_stream_task_metadata() -> None:
     )
 
     task = next(event for event in q.events if isinstance(event, Task))
-    usage = task.metadata["opencode"]["usage"]
+    usage = task.metadata["shared"]["usage"]
     assert usage["input_tokens"] == 7
     assert usage["output_tokens"] == 3
     assert usage["total_tokens"] == 10

--- a/tests/test_opencode_session_extension.py
+++ b/tests/test_opencode_session_extension.py
@@ -14,6 +14,10 @@ _BASE_SETTINGS = {
 }
 
 
+def _session_meta(payload: dict) -> dict:
+    return payload["metadata"]["shared"]["session"]
+
+
 @pytest.mark.asyncio
 async def test_session_query_extension_requires_bearer_token(monkeypatch):
     import opencode_a2a_serve.app as app_module
@@ -86,10 +90,10 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
         assert session["contextId"] == "ctx:opencode-session:s-1"
-        assert session["contextId"] != session["metadata"]["opencode"]["session_id"]
-        assert session["metadata"]["opencode"]["session_id"] == "s-1"
-        assert session["metadata"]["opencode"]["title"] == "Session s-1"
-        assert "raw" not in session["metadata"]["opencode"]
+        assert session["contextId"] != _session_meta(session)["id"]
+        assert _session_meta(session)["id"] == "s-1"
+        assert _session_meta(session)["title"] == "Session s-1"
+        assert "raw" not in session["metadata"]["shared"]
         assert dummy.last_sessions_params is not None
         assert dummy.last_sessions_params.get("limit") == 10
 
@@ -111,7 +115,7 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
         message = payload["result"]["items"][0]
         assert message["contextId"] == "ctx:opencode-session:s-1"
         assert message["parts"][0]["text"] == "SECRET_HISTORY"
-        assert message["metadata"]["opencode"]["session_id"] == "s-1"
+        assert _session_meta(message)["id"] == "s-1"
         assert dummy.last_messages_params is not None
         assert dummy.last_messages_params.get("limit") == 5
 
@@ -174,7 +178,7 @@ async def test_session_query_extension_session_title_is_extracted_or_placeholder
         payload = resp.json()
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
-        assert session["metadata"]["opencode"]["title"] == "My Session"
+        assert _session_meta(session)["title"] == "My Session"
 
 
 @pytest.mark.asyncio
@@ -202,7 +206,7 @@ async def test_session_query_extension_keeps_session_with_empty_title(monkeypatc
         payload = resp.json()
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
-        assert session["metadata"]["opencode"]["title"] == ""
+        assert _session_meta(session)["title"] == ""
 
 
 @pytest.mark.asyncio
@@ -275,7 +279,7 @@ async def test_session_query_extension_accepts_top_level_list_payload(monkeypatc
         payload = resp.json()
         assert payload["result"]["items"][0]["id"] == "s-1"
         assert payload["result"]["items"][0]["contextId"] == "ctx:opencode-session:s-1"
-        assert payload["result"]["items"][0]["metadata"]["opencode"]["session_id"] == "s-1"
+        assert _session_meta(payload["result"]["items"][0])["id"] == "s-1"
 
         resp = await client.post(
             "/",
@@ -289,7 +293,7 @@ async def test_session_query_extension_accepts_top_level_list_payload(monkeypatc
         )
         payload = resp.json()
         assert payload["result"]["items"][0]["contextId"] == "ctx:opencode-session:s-1"
-        assert payload["result"]["items"][0]["metadata"]["opencode"]["session_id"] == "s-1"
+        assert _session_meta(payload["result"]["items"][0])["id"] == "s-1"
         assert payload["result"]["items"][0]["parts"][0]["text"] == "SECRET_HISTORY"
 
 
@@ -1033,7 +1037,7 @@ async def test_session_command_extension_success(monkeypatch):
         payload = resp.json()
         assert payload.get("error") is None
         assert payload["result"]["item"]["messageId"] == "msg-command-1"
-        assert payload["result"]["item"]["metadata"]["opencode"]["session_id"] == "s-1"
+        assert _session_meta(payload["result"]["item"])["id"] == "s-1"
         assert payload["result"]["item"]["parts"][0]["text"] == "Command completed."
         assert len(dummy.command_calls) == 1
         assert dummy.command_calls[0]["session_id"] == "s-1"
@@ -1206,7 +1210,7 @@ async def test_session_shell_extension_success_when_enabled(monkeypatch):
         payload = resp.json()
         assert payload.get("error") is None
         assert payload["result"]["item"]["messageId"] == "msg-shell-1"
-        assert payload["result"]["item"]["metadata"]["opencode"]["session_id"] == "s-1"
+        assert _session_meta(payload["result"]["item"])["id"] == "s-1"
         assert payload["result"]["item"]["parts"][0]["text"] == "Shell command executed."
         assert len(dummy.shell_calls) == 1
         assert dummy.shell_calls[0]["directory"] == "/workspace"
@@ -1451,7 +1455,7 @@ async def test_interrupt_callback_extension_permission_reply(monkeypatch):
             json={
                 "jsonrpc": "2.0",
                 "id": 11,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {
                     "request_id": "perm-1",
                     "reply": "once",
@@ -1496,7 +1500,7 @@ async def test_interrupt_callback_extension_rejects_legacy_permission_fields(mon
             json={
                 "jsonrpc": "2.0",
                 "id": 111,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"requestID": "perm-legacy", "decision": "allow"},
             },
         )
@@ -1525,7 +1529,7 @@ async def test_interrupt_callback_extension_rejects_legacy_metadata_directory(mo
             json={
                 "jsonrpc": "2.0",
                 "id": 112,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {
                     "request_id": "perm-legacy",
                     "reply": "once",
@@ -1598,7 +1602,7 @@ async def test_interrupt_callback_extension_question_reply_and_reject(monkeypatc
             json={
                 "jsonrpc": "2.0",
                 "id": 12,
-                "method": "opencode.question.reply",
+                "method": "a2a.interrupt.question.reply",
                 "params": {
                     "request_id": "q-1",
                     "answers": [["A"], ["B"]],
@@ -1623,7 +1627,7 @@ async def test_interrupt_callback_extension_question_reply_and_reject(monkeypatc
             json={
                 "jsonrpc": "2.0",
                 "id": 13,
-                "method": "opencode.question.reject",
+                "method": "a2a.interrupt.question.reject",
                 "params": {
                     "request_id": "q-2",
                     "metadata": {
@@ -1679,7 +1683,7 @@ async def test_interrupt_callback_extension_maps_404_to_interrupt_not_found(monk
             json={
                 "jsonrpc": "2.0",
                 "id": 14,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"request_id": "perm-404", "reply": "reject"},
             },
         )
@@ -1711,7 +1715,7 @@ async def test_interrupt_callback_extension_rejects_expired_request(monkeypatch)
             json={
                 "jsonrpc": "2.0",
                 "id": 15,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"request_id": "perm-expired", "reply": "once"},
             },
         )
@@ -1758,7 +1762,7 @@ async def test_interrupt_callback_extension_rejects_unknown_request_id(monkeypat
             json={
                 "jsonrpc": "2.0",
                 "id": 16,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"request_id": "perm-unknown", "reply": "once"},
             },
         )
@@ -1797,7 +1801,7 @@ async def test_interrupt_callback_extension_rejects_interrupt_type_mismatch(monk
             json={
                 "jsonrpc": "2.0",
                 "id": 17,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"request_id": "q-only", "reply": "once"},
             },
         )
@@ -1836,7 +1840,7 @@ async def test_interrupt_callback_extension_rejects_identity_mismatch(monkeypatc
             json={
                 "jsonrpc": "2.0",
                 "id": 18,
-                "method": "opencode.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"request_id": "perm-owned", "reply": "once"},
             },
         )

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -89,7 +89,7 @@ async def test_session_hijack_prevention(mock_client):
         context_id="context-B",
         identity="user-2",
         user_input="hello",
-        metadata={"opencode": {"session_id": "session-1"}},
+        metadata={"shared": {"session": {"id": "session-1"}}},
     )
 
     # This should fail and emit an error
@@ -250,7 +250,7 @@ async def test_preferred_session_claim_is_released_on_upstream_failure():
         context_id="context-A",
         identity="user-1",
         user_input="hello",
-        metadata={"opencode": {"session_id": "session-X"}},
+        metadata={"shared": {"session": {"id": "session-X"}}},
     )
 
     await executor.execute(context, event_queue)
@@ -283,7 +283,7 @@ async def test_preferred_session_claim_is_released_on_upstream_cancellation():
         context_id="context-A",
         identity="user-1",
         user_input="hello",
-        metadata={"opencode": {"session_id": "session-X"}},
+        metadata={"shared": {"session": {"id": "session-X"}}},
     )
 
     with pytest.raises(asyncio.CancelledError):

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -219,6 +219,18 @@ def _part_text(event: TaskArtifactUpdateEvent) -> str:
     return getattr(part, "text", None) or getattr(part.root, "text", "")
 
 
+def _artifact_stream_meta(event: TaskArtifactUpdateEvent) -> dict:
+    return event.artifact.metadata["shared"]["stream"]
+
+
+def _status_shared_meta(event: TaskStatusUpdateEvent) -> dict:
+    return (event.metadata or {})["shared"]
+
+
+def _interrupt_meta(event: TaskStatusUpdateEvent) -> dict:
+    return _status_shared_meta(event)["interrupt"]
+
+
 @pytest.mark.asyncio
 async def test_streaming_filters_user_echo_and_emits_single_artifact_block_types() -> None:
     user_text = "who are you"
@@ -248,11 +260,11 @@ async def test_streaming_filters_user_echo_and_emits_single_artifact_block_types
     assert updates
     texts = [_part_text(event) for event in updates]
     assert user_text not in texts
-    block_types = [event.artifact.metadata["opencode"]["block_type"] for event in updates]
+    block_types = [_artifact_stream_meta(event)["block_type"] for event in updates]
     assert _unique(block_types) == ["reasoning", "tool_call", "text"]
     artifact_ids = [event.artifact.artifact_id for event in updates]
     assert len(set(artifact_ids)) == 1
-    event_ids = [event.artifact.metadata["opencode"]["event_id"] for event in updates]
+    event_ids = [_artifact_stream_meta(event)["event_id"] for event in updates]
     assert event_ids == [f"task-1:ctx-1:task-1:stream:{seq}" for seq in range(1, len(updates) + 1)]
 
 
@@ -280,11 +292,11 @@ async def test_streaming_does_not_send_duplicate_final_snapshot_when_chunks_exis
     final_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["opencode"]["block_type"] == "text"
+        if _artifact_stream_meta(event)["block_type"] == "text"
     ]
     assert len(final_updates) == 1
     assert _part_text(final_updates[0]) == "stable final answer"
-    assert final_updates[0].artifact.metadata["opencode"]["source"] != "final_snapshot"
+    assert _artifact_stream_meta(final_updates[0])["source"] != "final_snapshot"
 
 
 @pytest.mark.asyncio
@@ -306,12 +318,12 @@ async def test_streaming_emits_final_snapshot_only_when_stream_has_no_final_answ
     final_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["opencode"]["block_type"] == "text"
+        if _artifact_stream_meta(event)["block_type"] == "text"
     ]
     assert len(final_updates) == 1
     final_event = final_updates[0]
     assert _part_text(final_event) == "final answer from send_message"
-    assert final_event.artifact.metadata["opencode"]["source"] == "final_snapshot"
+    assert _artifact_stream_meta(final_event)["source"] == "final_snapshot"
     assert final_event.append is True
     assert final_event.last_chunk is True
 
@@ -326,7 +338,7 @@ async def test_execute_serializes_send_message_per_session() -> None:
     executor = OpencodeAgentExecutor(client, streaming_enabled=False)
     queue_1 = DummyEventQueue()
     queue_2 = DummyEventQueue()
-    metadata = {"opencode": {"session_id": "ses-shared"}}
+    metadata = {"shared": {"session": {"id": "ses-shared"}}}
 
     await asyncio.gather(
         executor.execute(
@@ -373,15 +385,19 @@ async def test_streaming_emits_events_without_message_id_using_stable_fallback()
     assert len(updates) == 1
     update = updates[0]
     assert _part_text(update) == "final answer from send_message"
-    assert update.artifact.metadata["opencode"]["source"] == "delta"
-    assert update.artifact.metadata["opencode"]["block_type"] == "text"
-    assert update.artifact.metadata["opencode"]["message_id"] == "task-6:ctx-6:assistant"
-    assert update.artifact.metadata["opencode"]["event_id"] == "task-6:ctx-6:task-6:stream:1"
+    assert _artifact_stream_meta(update)["source"] == "delta"
+    assert _artifact_stream_meta(update)["block_type"] == "text"
+    assert _artifact_stream_meta(update)["message_id"] == "task-6:ctx-6:assistant"
+    assert _artifact_stream_meta(update)["event_id"] == "task-6:ctx-6:task-6:stream:1"
+    assert _artifact_stream_meta(update)["sequence"] == 1
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
-    assert final_status.metadata["opencode"]["message_id"] == "task-6:ctx-6:assistant"
-    assert final_status.metadata["opencode"]["event_id"] == "task-6:ctx-6:task-6:stream:status"
+    assert _status_shared_meta(final_status)["stream"]["message_id"] == "task-6:ctx-6:assistant"
+    assert (
+        _status_shared_meta(final_status)["stream"]["event_id"]
+        == "task-6:ctx-6:task-6:stream:status"
+    )
 
 
 @pytest.mark.asyncio
@@ -414,22 +430,27 @@ async def test_streaming_emits_snapshot_when_message_id_missing_and_stream_is_pa
     assert _part_text(first) == "partial "
     assert first.append is False
     assert first.last_chunk is None
-    assert first.artifact.metadata["opencode"]["source"] == "delta"
-    assert first.artifact.metadata["opencode"]["message_id"] == "task-6b:ctx-6b:assistant"
-    assert first.artifact.metadata["opencode"]["event_id"] == "task-6b:ctx-6b:task-6b:stream:1"
+    assert _artifact_stream_meta(first)["source"] == "delta"
+    assert _artifact_stream_meta(first)["message_id"] == "task-6b:ctx-6b:assistant"
+    assert _artifact_stream_meta(first)["event_id"] == "task-6b:ctx-6b:task-6b:stream:1"
+    assert _artifact_stream_meta(first)["sequence"] == 1
 
     assert _part_text(second) == "partial final answer"
     assert second.append is True
     assert second.last_chunk is True
-    assert second.artifact.metadata["opencode"]["source"] == "final_snapshot"
-    assert second.artifact.metadata["opencode"]["message_id"] == "task-6b:ctx-6b:assistant"
-    assert second.artifact.metadata["opencode"]["event_id"] == "task-6b:ctx-6b:task-6b:stream:2"
+    assert _artifact_stream_meta(second)["source"] == "final_snapshot"
+    assert _artifact_stream_meta(second)["message_id"] == "task-6b:ctx-6b:assistant"
+    assert _artifact_stream_meta(second)["event_id"] == "task-6b:ctx-6b:task-6b:stream:2"
+    assert _artifact_stream_meta(second)["sequence"] == 2
 
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
-    assert final_status.metadata["opencode"]["message_id"] == "task-6b:ctx-6b:assistant"
-    assert final_status.metadata["opencode"]["event_id"] == "task-6b:ctx-6b:task-6b:stream:status"
+    assert _status_shared_meta(final_status)["stream"]["message_id"] == "task-6b:ctx-6b:assistant"
+    assert (
+        _status_shared_meta(final_status)["stream"]["event_id"]
+        == "task-6b:ctx-6b:task-6b:stream:status"
+    )
 
 
 @pytest.mark.asyncio
@@ -470,7 +491,7 @@ async def test_streaming_includes_usage_in_final_status_metadata() -> None:
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
-    usage = final_status.metadata["opencode"]["usage"]
+    usage = _status_shared_meta(final_status)["usage"]
     assert usage["input_tokens"] == 12
     assert usage["output_tokens"] == 4
     assert usage["total_tokens"] == 16
@@ -548,11 +569,11 @@ async def test_streaming_emits_interrupt_status_for_permission_asked_event() -> 
         for event in queue.events
         if isinstance(event, TaskStatusUpdateEvent)
         and event.final is False
-        and (event.metadata or {}).get("opencode", {}).get("interrupt", {}).get("type")
+        and (event.metadata or {}).get("shared", {}).get("interrupt", {}).get("type")
         == "permission"
     ]
     assert len(interrupt_statuses) == 1
-    interrupt = interrupt_statuses[0].metadata["opencode"]["interrupt"]
+    interrupt = _interrupt_meta(interrupt_statuses[0])
     assert interrupt["request_id"] == "perm-req-1"
     assert interrupt["details"]["permission"] == "read"
     assert "/data/project/.env.secret" in interrupt["details"]["patterns"]
@@ -584,11 +605,10 @@ async def test_streaming_emits_interrupt_status_for_question_asked_event() -> No
         for event in queue.events
         if isinstance(event, TaskStatusUpdateEvent)
         and event.final is False
-        and (event.metadata or {}).get("opencode", {}).get("interrupt", {}).get("type")
-        == "question"
+        and (event.metadata or {}).get("shared", {}).get("interrupt", {}).get("type") == "question"
     ]
     assert len(interrupt_statuses) == 1
-    interrupt = interrupt_statuses[0].metadata["opencode"]["interrupt"]
+    interrupt = _interrupt_meta(interrupt_statuses[0])
     assert interrupt["request_id"] == "q-req-1"
     assert isinstance(interrupt["details"]["questions"], list)
     assert "tool" not in interrupt["details"]
@@ -636,7 +656,7 @@ async def test_streaming_treats_embedded_markers_as_plain_text_without_typed_par
     def _final_state(block_type: str) -> str:
         parts = []
         for ev in updates:
-            if ev.artifact.metadata["opencode"]["block_type"] == block_type:
+            if _artifact_stream_meta(ev)["block_type"] == block_type:
                 if not ev.append:
                     parts = [_part_text(ev)]
                 else:
@@ -701,9 +721,7 @@ async def test_streaming_emits_structured_tool_part_updates() -> None:
     )
 
     updates = _artifact_updates(queue)
-    tool_updates = [
-        ev for ev in updates if ev.artifact.metadata["opencode"]["block_type"] == "tool_call"
-    ]
+    tool_updates = [ev for ev in updates if _artifact_stream_meta(ev)["block_type"] == "tool_call"]
     assert len(tool_updates) == 3
     merged = "".join(_part_text(ev) for ev in tool_updates)
     assert '"status":"pending"' in merged
@@ -731,7 +749,7 @@ async def test_streaming_flushes_partial_marker_on_eof_as_current_block_type() -
     updates = _artifact_updates(queue)
     assert updates
     assert "".join(_part_text(ev) for ev in updates) == "hello <thin"
-    assert all(ev.artifact.metadata["opencode"]["block_type"] == "text" for ev in updates)
+    assert all(_artifact_stream_meta(ev)["block_type"] == "text" for ev in updates)
 
 
 @pytest.mark.asyncio
@@ -826,7 +844,7 @@ async def test_streaming_suppresses_reasoning_snapshot_reset_after_delta() -> No
     reasoning_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["opencode"]["block_type"] == "reasoning"
+        if _artifact_stream_meta(event)["block_type"] == "reasoning"
     ]
     assert len(reasoning_updates) == 1
     assert _part_text(reasoning_updates[0]) == "reasoning line\n\n"
@@ -861,7 +879,7 @@ async def test_streaming_supports_message_part_delta_events() -> None:
     reasoning_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["opencode"]["block_type"] == "reasoning"
+        if _artifact_stream_meta(event)["block_type"] == "reasoning"
     ]
     assert reasoning_updates
     merged = "".join(_part_text(ev) for ev in reasoning_updates)
@@ -899,7 +917,7 @@ async def test_streaming_buffers_delta_until_part_updated_arrives() -> None:
     reasoning_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["opencode"]["block_type"] == "reasoning"
+        if _artifact_stream_meta(event)["block_type"] == "reasoning"
     ]
     assert reasoning_updates
     merged = "".join(_part_text(ev) for ev in reasoning_updates)
@@ -940,6 +958,6 @@ async def test_streaming_keeps_multiple_message_ids_in_same_request_window() -> 
     )
 
     updates = _artifact_updates(queue)
-    message_ids = [ev.artifact.metadata["opencode"].get("message_id") for ev in updates]
+    message_ids = [_artifact_stream_meta(ev).get("message_id") for ev in updates]
     assert "msg-a" in message_ids
     assert "msg-b" in message_ids


### PR DESCRIPTION
## 关联事项

- Closes #152
- Relates to https://github.com/liujuanjuan1984/a2a-client-hub/issues/443

## 相关提交

- `bd5d3b5` `feat: align OpenCode adapter with shared A2A contracts (#152)`

## 变更说明

### 1. 共享契约 SSOT

- 在 `extension_contracts.py` 中补充 shared canonical contract 的单一事实来源。
- 将共享会话绑定主入口定义为 `metadata.shared.session.id`。
- 将共享流式语义定义为 `metadata.shared.stream.*`、`metadata.shared.interrupt.*`、`metadata.shared.usage`。
- 将 interrupt callback 方法名收口为共享形式：
  - `a2a.interrupt.permission.reply`
  - `a2a.interrupt.question.reply`
  - `a2a.interrupt.question.reject`
- 保留 OpenCode 私有能力边界：`metadata.opencode.directory`、`opencode.sessions.*`。

### 2. 运行时行为

- `agent.py`
  - 会话绑定读取改为 `metadata.shared.session.id`。
  - 主聊天输出的共享语义改为通过 `metadata.shared.*` 暴露。
  - 流式事件补充 canonical `sequence` 字段。
- `jsonrpc_ext.py`
  - session list / message history / control result 中的共享 session 信息改为 `metadata.shared.session.*`。
  - metadata 校验放宽为允许 `shared` 顶层命名空间，同时继续只接受 `opencode.directory` 作为 OpenCode 私有目录参数。

### 3. Agent Card / OpenAPI

- Agent Card 中的 session-binding / streaming / interactive-interrupt 共享能力改为中立 extension URI。
- OpenAPI 扩展元数据键从 provider-specific 形式收口为 `x-a2a-extension-contracts`。
- 示例请求同步改为 shared canonical contract。

### 4. 文档与测试

- README 与 `docs/guide.md` 同步更新为 shared canonical contract。
- 更新 session binding / streaming / interrupt / session query / Agent Card / OpenAPI 相关测试断言。
- 本次改动不保留旧私有共享语义兼容窗口，和 #152 的非目标一致。

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
