### PR TITLE
feat: add shared model selection and provider discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Provide a practical adapter layer that lets individuals and small teams expose O
 - A2A JSON-RPC endpoint (`POST /`) for standard methods and OpenCode-oriented extensions.
 - Streaming with incremental task artifacts and terminal status events.
 - Session continuation via `metadata.shared.session.id`.
-- OpenCode session query/control extension methods (`opencode.sessions.*`) and shared interrupt callback methods.
+- Request-scoped model selection via `metadata.shared.model`.
+- OpenCode session query/control (`opencode.sessions.*`) and provider/model discovery (`opencode.providers.*`, `opencode.models.*`) extension methods.
+- Shared interrupt callback methods.
 
 ## Quick Start & Development
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -43,6 +43,8 @@ Key variables to understand protocol behavior:
 ## Service Behavior
 
 - The service forwards A2A `message:send` to OpenCode session/message calls.
+- Main chat requests may override the default upstream model via
+  `metadata.shared.model` with `{ providerID, modelID }`.
 - Task state defaults to `completed` for successful turns.
 - Streaming (`/v1/message:stream`) emits incremental
   `TaskArtifactUpdateEvent` and then
@@ -128,18 +130,62 @@ curl -sS http://127.0.0.1:8000/v1/message:send \
   }'
 ```
 
-## OpenCode Session Query (A2A Extension)
+## Shared Model Selection Contract
 
-This service exposes OpenCode session list/message-history queries and session control methods via A2A JSON-RPC extension methods (default endpoint: `POST /`). No extra custom REST endpoint is introduced.
+To override the default upstream model for one main-chat request, include:
+
+- `metadata.shared.model.providerID`
+- `metadata.shared.model.modelID`
+
+Server behavior:
+
+- If both fields are non-empty strings, the request is sent with that upstream
+  model override.
+- If the object is missing, partial, or invalid, the service falls back to the
+  configured default model (`OPENCODE_PROVIDER_ID` / `OPENCODE_MODEL_ID`).
+- This contract applies to the main chat path only (`message/send`,
+  `message:stream`). OpenCode session-control methods continue to use
+  `params.request.model`.
+
+Minimal example:
+
+```bash
+curl -sS http://127.0.0.1:8000/v1/message:send \
+  -H 'content-type: application/json' \
+  -H 'Authorization: Bearer <your-token>' \
+  -d '{
+    "message": {
+      "messageId": "msg-model-1",
+      "role": "ROLE_USER",
+      "content": [{"text": "Answer with the faster model."}]
+    },
+    "metadata": {
+      "shared": {
+        "model": {
+          "providerID": "google",
+          "modelID": "gemini-2.5-flash"
+        }
+      }
+    }
+  }'
+```
+
+## OpenCode Session Query & Provider Discovery (A2A Extensions)
+
+This service exposes OpenCode session list/message-history queries, session
+control methods, and provider/model discovery via A2A JSON-RPC extension
+methods (default endpoint: `POST /`). No extra custom REST endpoint is
+introduced.
 
 - Trigger: call extension methods through A2A JSON-RPC
 - Auth: same `Authorization: Bearer <token>`
 - Privacy guard: when `A2A_LOG_PAYLOADS=true`, request/response bodies are still
-  suppressed for `method=opencode.sessions.*`
+  suppressed for `method=opencode.sessions.*`, `opencode.providers.*`, and
+  `opencode.models.*`
 - Endpoint discovery: prefer `additional_interfaces[]` with
   `transport=jsonrpc` from Agent Card
-- Notification behavior: for `opencode.sessions.*`, requests without `id`
-  return HTTP `204 No Content`
+- Notification behavior: for `opencode.sessions.*`, `opencode.providers.*`, and
+  `opencode.models.*`, requests without `id` return HTTP `204 No Content`
 - Result format (query methods):
   - `result.items` is always an array of A2A standard objects
   - session list => `Task` with `status.state=completed`
@@ -194,6 +240,10 @@ curl -sS http://127.0.0.1:8000/ \
       "session_id": "<session_id>",
       "request": {
         "parts": [{"type": "text", "text": "Continue and summarize next steps."}],
+        "model": {
+          "providerID": "google",
+          "modelID": "gemini-2.5-flash"
+        },
         "noReply": true
       },
       "metadata": {
@@ -221,6 +271,8 @@ Validation notes:
 
 - `metadata.opencode.directory` follows the same normalization and boundary rules
   as message send (`realpath` + workspace boundary check).
+- `request.model` uses the same `{ providerID, modelID }` shape as
+  `metadata.shared.model`, but is scoped to OpenCode session-control methods.
 - Control methods enforce session owner guard based on request identity.
 
 ### Session Command (`opencode.sessions.command`)
@@ -237,7 +289,11 @@ curl -sS http://127.0.0.1:8000/ \
       "session_id": "<session_id>",
       "request": {
         "command": "/review",
-        "arguments": "focus on security findings"
+        "arguments": "focus on security findings",
+        "model": {
+          "providerID": "openai",
+          "modelID": "gpt-5"
+        }
       },
       "metadata": {
         "opencode": {
@@ -283,6 +339,51 @@ curl -sS http://127.0.0.1:8000/ \
     }
   }'
 ```
+
+### Provider List (`opencode.providers.list`)
+
+Returns normalized provider summaries from the upstream OpenCode provider
+catalog.
+
+```bash
+curl -sS http://127.0.0.1:8000/ \
+  -H 'content-type: application/json' \
+  -H 'Authorization: Bearer <your-token>' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 24,
+    "method": "opencode.providers.list",
+    "params": {}
+  }'
+```
+
+Response:
+
+- success => `{"items": [...], "default_by_provider": {...}, "connected": [...]}` (JSON-RPC result)
+
+### Model List (`opencode.models.list`)
+
+Returns normalized, flattened model summaries. Supports optional provider filter:
+
+- `params.provider_id`
+
+```bash
+curl -sS http://127.0.0.1:8000/ \
+  -H 'content-type: application/json' \
+  -H 'Authorization: Bearer <your-token>' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 25,
+    "method": "opencode.models.list",
+    "params": {
+      "provider_id": "openai"
+    }
+  }'
+```
+
+Response:
+
+- success => `{"items": [...], "default_by_provider": {...}, "connected": [...]}` (JSON-RPC result)
 
 Response:
 

--- a/src/opencode_a2a_serve/agent.py
+++ b/src/opencode_a2a_serve/agent.py
@@ -450,6 +450,7 @@ class OpencodeAgentExecutor(AgentExecutor):
         streaming_request = self._should_stream(context)
         user_text = context.get_user_input().strip()
         bound_session_id = _extract_shared_session_id(context)
+        model_override = _extract_shared_model(context)
 
         # Directory validation
         metadata = context.metadata
@@ -560,6 +561,7 @@ class OpencodeAgentExecutor(AgentExecutor):
                     session_id,
                     user_text,
                     directory=directory,
+                    model_override=model_override,
                     timeout_override=self._client.stream_timeout,
                 )
             else:
@@ -567,6 +569,7 @@ class OpencodeAgentExecutor(AgentExecutor):
                     session_id,
                     user_text,
                     directory=directory,
+                    model_override=model_override,
                 )
 
             if pending_preferred_claim:
@@ -1887,6 +1890,25 @@ def _extract_shared_session_id(context: RequestContext) -> str | None:
         namespace="shared",
         path=("session", "id"),
     )
+
+
+def _extract_shared_model(context: RequestContext) -> dict[str, str] | None:
+    provider_id = _extract_namespaced_string_metadata(
+        context,
+        namespace="shared",
+        path=("model", "providerID"),
+    )
+    model_id = _extract_namespaced_string_metadata(
+        context,
+        namespace="shared",
+        path=("model", "modelID"),
+    )
+    if provider_id is None or model_id is None:
+        return None
+    return {
+        "providerID": provider_id,
+        "modelID": model_id,
+    }
 
 
 def _extract_opencode_directory(context: RequestContext) -> str | None:

--- a/src/opencode_a2a_serve/app.py
+++ b/src/opencode_a2a_serve/app.py
@@ -45,9 +45,12 @@ from .agent import OpencodeAgentExecutor
 from .config import Settings
 from .extension_contracts import (
     INTERRUPT_CALLBACK_METHODS,
+    PROVIDER_DISCOVERY_METHODS,
     SESSION_CONTROL_METHODS,
     SESSION_QUERY_METHODS,
     build_interrupt_callback_extension_params,
+    build_model_selection_extension_params,
+    build_provider_discovery_extension_params,
     build_session_binding_extension_params,
     build_session_query_extension_params,
     build_streaming_extension_params,
@@ -69,8 +72,10 @@ if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
 
 SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
+MODEL_SELECTION_EXTENSION_URI = "urn:a2a:model-selection/v1"
 STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
 SESSION_QUERY_EXTENSION_URI = "urn:opencode-a2a:session-query/v1"
+PROVIDER_DISCOVERY_EXTENSION_URI = "urn:opencode-a2a:provider-discovery/v1"
 INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
 
 
@@ -272,9 +277,10 @@ def _build_agent_card_description(
     summary = (
         "Supports HTTP+JSON and JSON-RPC transports, standard A2A messaging "
         "(message/send, message/stream), task APIs (tasks/get, tasks/cancel, "
-        "tasks/resubscribe; REST mapping: GET /v1/tasks/{id}:subscribe), "
-        "shared session-binding and streaming contracts, OpenCode session-query "
-        "extensions, and shared interrupt callback extensions."
+        "tasks/resubscribe; REST mapping: GET /v1/tasks/{id}:subscribe), shared "
+        "session-binding/model-selection/streaming contracts, OpenCode "
+        "session-query/provider-discovery extensions, and shared interrupt "
+        "callback extensions."
     )
     parts: list[str] = [base, summary]
     parts.append(
@@ -306,12 +312,14 @@ def _build_chat_examples(project: str | None) -> list[str]:
 
 def _build_jsonrpc_extension_openapi_description() -> str:
     session_methods = ", ".join(sorted(SESSION_QUERY_METHODS.values()))
+    provider_methods = ", ".join(sorted(PROVIDER_DISCOVERY_METHODS.values()))
     interrupt_methods = ", ".join(sorted(INTERRUPT_CALLBACK_METHODS.values()))
     return (
         "A2A JSON-RPC entrypoint. Supports core A2A methods "
         "(message/send, message/stream, tasks/get, tasks/cancel, tasks/resubscribe) "
-        "plus OpenCode session-query methods and shared interrupt callback methods.\n\n"
+        "plus OpenCode session/provider extensions and shared interrupt callback methods.\n\n"
         f"OpenCode session query/control methods: {session_methods}.\n"
+        f"OpenCode provider/model discovery methods: {provider_methods}.\n"
         f"Shared interrupt callback methods: {interrupt_methods}.\n\n"
         "Notification semantics: extension requests without JSON-RPC id return HTTP 204."
     )
@@ -351,6 +359,29 @@ def _build_jsonrpc_extension_openapi_examples() -> dict[str, Any]:
                             }
                         ],
                     }
+                },
+            },
+        },
+        "message_send_model_override": {
+            "summary": "Send message with shared model override",
+            "value": {
+                "jsonrpc": "2.0",
+                "id": 103,
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "messageId": "msg-model-1",
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "Answer with the faster model."}],
+                    },
+                    "metadata": {
+                        "shared": {
+                            "model": {
+                                "providerID": "google",
+                                "modelID": "gemini-2.5-flash",
+                            }
+                        }
+                    },
                 },
             },
         },
@@ -416,6 +447,24 @@ def _build_jsonrpc_extension_openapi_examples() -> dict[str, Any]:
                 },
             },
         },
+        "providers_list": {
+            "summary": "List available OpenCode providers",
+            "value": {
+                "jsonrpc": "2.0",
+                "id": 24,
+                "method": PROVIDER_DISCOVERY_METHODS["list_providers"],
+                "params": {},
+            },
+        },
+        "models_list": {
+            "summary": "List available models for one provider",
+            "value": {
+                "jsonrpc": "2.0",
+                "id": 25,
+                "method": PROVIDER_DISCOVERY_METHODS["list_models"],
+                "params": {"provider_id": "openai"},
+            },
+        },
         "permission_reply": {
             "summary": "Reply to permission interrupt request",
             "value": {
@@ -473,6 +522,24 @@ def _build_rest_message_openapi_examples() -> dict[str, Any]:
                 },
             },
         },
+        "message_with_model_override": {
+            "summary": "Send message with shared model override",
+            "value": {
+                "message": {
+                    "messageId": "msg-rest-model-1",
+                    "role": "ROLE_USER",
+                    "content": [{"text": "Answer with the faster model."}],
+                },
+                "metadata": {
+                    "shared": {
+                        "model": {
+                            "providerID": "google",
+                            "modelID": "gemini-2.5-flash",
+                        }
+                    }
+                },
+            },
+        },
     }
 
 
@@ -485,10 +552,16 @@ def _patch_jsonrpc_openapi_contract(
         deployment_context=deployment_context,
         directory_override_enabled=bool(deployment_context["allow_directory_override"]),
     )
+    model_selection = build_model_selection_extension_params(
+        deployment_context=deployment_context,
+    )
     streaming = build_streaming_extension_params()
     session_query = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
+    )
+    provider_discovery = build_provider_discovery_extension_params(
+        deployment_context=deployment_context,
     )
     interrupt_callback = build_interrupt_callback_extension_params(
         deployment_context=deployment_context,
@@ -510,8 +583,10 @@ def _patch_jsonrpc_openapi_contract(
                     post["description"] = _build_jsonrpc_extension_openapi_description()
                     post["x-a2a-extension-contracts"] = {
                         "session_binding": session_binding,
+                        "model_selection": model_selection,
                         "streaming": streaming,
                         "session_query": session_query,
+                        "provider_discovery": provider_discovery,
                         "interrupt_callback": interrupt_callback,
                     }
 
@@ -606,10 +681,16 @@ def build_agent_card(settings: Settings) -> AgentCard:
         deployment_context=deployment_context,
         directory_override_enabled=settings.a2a_allow_directory_override,
     )
+    model_selection_extension_params = build_model_selection_extension_params(
+        deployment_context=deployment_context,
+    )
     streaming_extension_params = build_streaming_extension_params()
     session_query_extension_params = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
+    )
+    provider_discovery_extension_params = build_provider_discovery_extension_params(
+        deployment_context=deployment_context,
     )
     interrupt_callback_extension_params = build_interrupt_callback_extension_params(
         deployment_context=deployment_context,
@@ -641,6 +722,16 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     params=session_binding_extension_params,
                 ),
                 AgentExtension(
+                    uri=MODEL_SELECTION_EXTENSION_URI,
+                    required=False,
+                    description=(
+                        "Shared contract for request-scoped upstream model selection on the "
+                        "main chat path. Clients should pass metadata.shared.model with "
+                        "providerID/modelID."
+                    ),
+                    params=model_selection_extension_params,
+                ),
+                AgentExtension(
                     uri=STREAMING_EXTENSION_URI,
                     required=False,
                     description=(
@@ -659,6 +750,15 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     params=session_query_extension_params,
                 ),
                 AgentExtension(
+                    uri=PROVIDER_DISCOVERY_EXTENSION_URI,
+                    required=False,
+                    description=(
+                        "Expose OpenCode-specific provider/model discovery methods through "
+                        "JSON-RPC extensions."
+                    ),
+                    params=provider_discovery_extension_params,
+                ),
+                AgentExtension(
                     uri=INTERRUPT_CALLBACK_EXTENSION_URI,
                     required=False,
                     description=(
@@ -675,7 +775,7 @@ def build_agent_card(settings: Settings) -> AgentCard:
                 name="OpenCode Chat",
                 description=(
                     "Handle message/send and message/stream requests by routing user text to "
-                    "OpenCode sessions."
+                    "OpenCode sessions with shared session binding and shared model selection."
                 ),
                 tags=["assistant", "coding", "opencode"],
                 examples=_build_chat_examples(settings.a2a_project),
@@ -694,6 +794,19 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     "Send async prompt to a session (method opencode.sessions.prompt_async).",
                     "Send command to a session (method opencode.sessions.command).",
                     "Run shell in a session (method opencode.sessions.shell).",
+                ],
+            ),
+            AgentSkill(
+                id="opencode.providers.query",
+                name="OpenCode Provider Catalog",
+                description=(
+                    "Query available OpenCode providers/models via JSON-RPC extensions "
+                    "(opencode.providers.list / opencode.models.list)."
+                ),
+                tags=["opencode", "providers", "models"],
+                examples=[
+                    "List available providers (method opencode.providers.list).",
+                    "List available models for a provider (method opencode.models.list).",
                 ],
             ),
             AgentSkill(
@@ -786,6 +899,7 @@ def create_app(settings: Settings) -> FastAPI:
         methods={
             **SESSION_QUERY_METHODS,
             **SESSION_CONTROL_METHODS,
+            **PROVIDER_DISCOVERY_METHODS,
             **INTERRUPT_CALLBACK_METHODS,
         },
     ).build(title=settings.a2a_title, version=settings.a2a_version, lifespan=lifespan)
@@ -818,8 +932,10 @@ def create_app(settings: Settings) -> FastAPI:
         method = payload.get("method")
         if not isinstance(method, str):
             return None
-        sensitive_methods = set(SESSION_QUERY_METHODS.values()) | set(
-            INTERRUPT_CALLBACK_METHODS.values()
+        sensitive_methods = (
+            set(SESSION_QUERY_METHODS.values())
+            | set(PROVIDER_DISCOVERY_METHODS.values())
+            | set(INTERRUPT_CALLBACK_METHODS.values())
         )
         if method in sensitive_methods:
             return method

--- a/src/opencode_a2a_serve/extension_contracts.py
+++ b/src/opencode_a2a_serve/extension_contracts.py
@@ -6,6 +6,7 @@ from typing import Any
 SHARED_METADATA_NAMESPACE = "shared"
 SHARED_SESSION_BINDING_FIELD = "metadata.shared.session.id"
 SHARED_SESSION_METADATA_FIELD = "metadata.shared.session"
+SHARED_MODEL_SELECTION_FIELD = "metadata.shared.model"
 SHARED_STREAM_METADATA_FIELD = "metadata.shared.stream"
 SHARED_INTERRUPT_METADATA_FIELD = "metadata.shared.interrupt"
 SHARED_USAGE_METADATA_FIELD = "metadata.shared.usage"
@@ -30,6 +31,17 @@ class InterruptMethodContract:
     method: str
     required_params: tuple[str, ...] = ()
     optional_params: tuple[str, ...] = ()
+    notification_response_status: int | None = None
+
+
+@dataclass(frozen=True)
+class ProviderDiscoveryMethodContract:
+    method: str
+    required_params: tuple[str, ...] = ()
+    optional_params: tuple[str, ...] = ()
+    result_fields: tuple[str, ...] = ()
+    items_type: str | None = None
+    items_field: str | None = None
     notification_response_status: int | None = None
 
 
@@ -193,6 +205,28 @@ INTERRUPT_CALLBACK_METHODS: dict[str, str] = {
     key: contract.method for key, contract in INTERRUPT_CALLBACK_METHOD_CONTRACTS.items()
 }
 
+PROVIDER_DISCOVERY_METHOD_CONTRACTS: dict[str, ProviderDiscoveryMethodContract] = {
+    "list_providers": ProviderDiscoveryMethodContract(
+        method="opencode.providers.list",
+        result_fields=("items", "default_by_provider", "connected"),
+        items_type="ProviderSummary[]",
+        items_field="items",
+        notification_response_status=204,
+    ),
+    "list_models": ProviderDiscoveryMethodContract(
+        method="opencode.models.list",
+        optional_params=("provider_id",),
+        result_fields=("items", "default_by_provider", "connected"),
+        items_type="ModelSummary[]",
+        items_field="items",
+        notification_response_status=204,
+    ),
+}
+
+PROVIDER_DISCOVERY_METHODS: dict[str, str] = {
+    key: contract.method for key, contract in PROVIDER_DISCOVERY_METHOD_CONTRACTS.items()
+}
+
 INTERRUPT_SUCCESS_RESULT_FIELDS: tuple[str, ...] = ("ok", "request_id")
 INTERRUPT_ERROR_BUSINESS_CODES: dict[str, int] = {
     "INTERRUPT_REQUEST_NOT_FOUND": -32004,
@@ -214,6 +248,22 @@ INTERRUPT_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
     "request_id",
     "expected",
     "actual",
+)
+PROVIDER_DISCOVERY_ERROR_BUSINESS_CODES: dict[str, int] = {
+    "UPSTREAM_UNREACHABLE": -32002,
+    "UPSTREAM_HTTP_ERROR": -32003,
+    "UPSTREAM_PAYLOAD_ERROR": -32005,
+}
+PROVIDER_DISCOVERY_ERROR_DATA_FIELDS: tuple[str, ...] = (
+    "type",
+    "method",
+    "upstream_status",
+    "detail",
+)
+PROVIDER_DISCOVERY_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
+    "type",
+    "field",
+    "fields",
 )
 
 
@@ -261,6 +311,48 @@ def build_session_binding_extension_params(
             ),
         ],
     }
+
+
+def build_model_selection_extension_params(
+    *,
+    deployment_context: dict[str, str | bool],
+) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "metadata_field": SHARED_MODEL_SELECTION_FIELD,
+        "behavior": "prefer_metadata_model_else_server_default",
+        "applies_to_methods": ["message/send", "message/stream"],
+        "supported_metadata": [
+            "shared.model.providerID",
+            "shared.model.modelID",
+        ],
+        "provider_private_metadata": [],
+        "shared_workspace_across_consumers": True,
+        "tenant_isolation": "none",
+        "deployment_context": deployment_context,
+        "fields": {
+            "providerID": f"{SHARED_MODEL_SELECTION_FIELD}.providerID",
+            "modelID": f"{SHARED_MODEL_SELECTION_FIELD}.modelID",
+        },
+        "notes": [
+            (
+                "If both metadata.shared.model.providerID and metadata.shared.model.modelID "
+                "are non-empty strings, the server will override the default upstream model "
+                "for this request only."
+            ),
+            (
+                "If shared model metadata is missing, partial, or invalid, the server falls "
+                "back to the configured default model."
+            ),
+        ],
+    }
+    provider_id = deployment_context.get("provider_id")
+    model_id = deployment_context.get("model_id")
+    if isinstance(provider_id, str) and isinstance(model_id, str):
+        params["default_model"] = {
+            "providerID": provider_id,
+            "modelID": model_id,
+        }
+    return params
 
 
 def build_streaming_extension_params() -> dict[str, Any]:
@@ -412,4 +504,88 @@ def build_interrupt_callback_extension_params(
         "shared_workspace_across_consumers": True,
         "tenant_isolation": "none",
         "deployment_context": deployment_context,
+    }
+
+
+def build_provider_discovery_extension_params(
+    *,
+    deployment_context: dict[str, str | bool],
+) -> dict[str, Any]:
+    method_contracts: dict[str, Any] = {}
+    result_envelope_by_method: dict[str, Any] = {}
+
+    for method_contract in PROVIDER_DISCOVERY_METHOD_CONTRACTS.values():
+        params_contract = _build_method_contract_params(
+            required=method_contract.required_params,
+            optional=method_contract.optional_params,
+            unsupported=(),
+        )
+        result_contract: dict[str, Any] = {"fields": list(method_contract.result_fields)}
+        if method_contract.items_type:
+            result_contract["items_type"] = method_contract.items_type
+
+        contract_doc: dict[str, Any] = {
+            "params": params_contract,
+            "result": result_contract,
+        }
+        if method_contract.notification_response_status is not None:
+            contract_doc["notification_response_status"] = (
+                method_contract.notification_response_status
+            )
+        method_contracts[method_contract.method] = contract_doc
+
+        envelope_doc: dict[str, Any] = {"fields": list(method_contract.result_fields)}
+        if method_contract.items_field:
+            envelope_doc["items_field"] = method_contract.items_field
+        result_envelope_by_method[method_contract.method] = envelope_doc
+
+    return {
+        "methods": dict(PROVIDER_DISCOVERY_METHODS),
+        "method_contracts": method_contracts,
+        "result_envelope": {
+            "by_method": result_envelope_by_method,
+        },
+        "supported_metadata": ["opencode.directory"],
+        "provider_private_metadata": ["opencode.directory"],
+        "context_fields": {
+            "directory": OPENCODE_DIRECTORY_METADATA_FIELD,
+        },
+        "provider_item_fields": {
+            "provider_id": "items[].provider_id",
+            "name": "items[].name",
+            "source": "items[].source",
+            "connected": "items[].connected",
+            "default_model_id": "items[].default_model_id",
+            "model_count": "items[].model_count",
+        },
+        "model_item_fields": {
+            "provider_id": "items[].provider_id",
+            "model_id": "items[].model_id",
+            "name": "items[].name",
+            "status": "items[].status",
+            "context_window": "items[].context_window",
+            "supports_reasoning": "items[].supports_reasoning",
+            "supports_tool_call": "items[].supports_tool_call",
+            "supports_attachments": "items[].supports_attachments",
+            "default": "items[].default",
+            "connected": "items[].connected",
+        },
+        "errors": {
+            "business_codes": dict(PROVIDER_DISCOVERY_ERROR_BUSINESS_CODES),
+            "error_data_fields": list(PROVIDER_DISCOVERY_ERROR_DATA_FIELDS),
+            "invalid_params_data_fields": list(PROVIDER_DISCOVERY_INVALID_PARAMS_DATA_FIELDS),
+        },
+        "shared_workspace_across_consumers": True,
+        "tenant_isolation": "none",
+        "deployment_context": deployment_context,
+        "notes": [
+            (
+                "Provider/model discovery is OpenCode-specific and exposed through "
+                "provider-private JSON-RPC methods."
+            ),
+            (
+                "The server normalizes upstream provider catalogs into summary records so "
+                "downstream callers do not need to parse raw OpenCode payloads."
+            ),
+        ],
     }

--- a/src/opencode_a2a_serve/jsonrpc_ext.py
+++ b/src/opencode_a2a_serve/jsonrpc_ext.py
@@ -29,6 +29,7 @@ from .extension_contracts import (
     COMMAND_REQUEST_ALLOWED_FIELDS,
     INTERRUPT_ERROR_BUSINESS_CODES,
     PROMPT_ASYNC_REQUEST_ALLOWED_FIELDS,
+    PROVIDER_DISCOVERY_ERROR_BUSINESS_CODES,
     SESSION_QUERY_ERROR_BUSINESS_CODES,
     SESSION_QUERY_PAGINATION_UNSUPPORTED,
     SHELL_REQUEST_ALLOWED_FIELDS,
@@ -45,6 +46,11 @@ ERR_UPSTREAM_UNREACHABLE = SESSION_QUERY_ERROR_BUSINESS_CODES["UPSTREAM_UNREACHA
 ERR_UPSTREAM_HTTP_ERROR = SESSION_QUERY_ERROR_BUSINESS_CODES["UPSTREAM_HTTP_ERROR"]
 ERR_INTERRUPT_NOT_FOUND = INTERRUPT_ERROR_BUSINESS_CODES["INTERRUPT_REQUEST_NOT_FOUND"]
 ERR_UPSTREAM_PAYLOAD_ERROR = SESSION_QUERY_ERROR_BUSINESS_CODES["UPSTREAM_PAYLOAD_ERROR"]
+ERR_DISCOVERY_UPSTREAM_UNREACHABLE = PROVIDER_DISCOVERY_ERROR_BUSINESS_CODES["UPSTREAM_UNREACHABLE"]
+ERR_DISCOVERY_UPSTREAM_HTTP_ERROR = PROVIDER_DISCOVERY_ERROR_BUSINESS_CODES["UPSTREAM_HTTP_ERROR"]
+ERR_DISCOVERY_UPSTREAM_PAYLOAD_ERROR = PROVIDER_DISCOVERY_ERROR_BUSINESS_CODES[
+    "UPSTREAM_PAYLOAD_ERROR"
+]
 SESSION_CONTEXT_PREFIX = "ctx:opencode-session:"
 
 
@@ -323,13 +329,17 @@ def _validate_command_request_payload(value: dict[str, Any]) -> None:
                 message="request.messageID must be a string starting with 'msg'",
             )
 
-    for key in ("agent", "model", "variant"):
+    for key in ("agent", "variant"):
         data = value.get(key)
         if data is not None and not isinstance(data, str):
             _raise_prompt_async_validation_error(
                 field=f"request.{key}",
                 message=f"request.{key} must be a string",
             )
+
+    model = value.get("model")
+    if model is not None:
+        _validate_model_ref(model, field="request.model")
 
     parts = value.get("parts")
     if parts is not None:
@@ -442,6 +452,143 @@ def _extract_raw_items(raw_result: Any, *, kind: str) -> list[Any]:
     raise ValueError(f"OpenCode {kind} payload must be an array; got {type(raw_result).__name__}")
 
 
+def _extract_provider_catalog(
+    raw_result: Any,
+) -> tuple[list[dict[str, Any]], dict[str, str], list[str]]:
+    if not isinstance(raw_result, dict):
+        raise ValueError(
+            f"OpenCode provider catalog payload must be an object; got {type(raw_result).__name__}"
+        )
+
+    raw_providers = raw_result.get("all")
+    if not isinstance(raw_providers, list):
+        raise ValueError("OpenCode provider catalog payload field 'all' must be an array")
+
+    raw_defaults = raw_result.get("default")
+    if not isinstance(raw_defaults, dict):
+        raise ValueError("OpenCode provider catalog payload field 'default' must be an object")
+
+    raw_connected = raw_result.get("connected")
+    if not isinstance(raw_connected, list):
+        raise ValueError("OpenCode provider catalog payload field 'connected' must be an array")
+
+    providers: list[dict[str, Any]] = []
+    for item in raw_providers:
+        if not isinstance(item, dict):
+            raise ValueError("OpenCode provider catalog items must be objects")
+        providers.append(item)
+
+    default_by_provider: dict[str, str] = {}
+    for key, value in raw_defaults.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError("OpenCode provider catalog default entries must be string:string")
+        provider_id = key.strip()
+        model_id = value.strip()
+        if provider_id and model_id:
+            default_by_provider[provider_id] = model_id
+
+    connected: list[str] = []
+    for item in raw_connected:
+        if not isinstance(item, str):
+            raise ValueError("OpenCode provider catalog connected entries must be strings")
+        provider_id = item.strip()
+        if provider_id:
+            connected.append(provider_id)
+
+    return providers, default_by_provider, connected
+
+
+def _normalize_provider_summaries(
+    raw_providers: list[dict[str, Any]],
+    *,
+    default_by_provider: dict[str, str],
+    connected: list[str],
+) -> list[dict[str, Any]]:
+    connected_set = set(connected)
+    items: list[dict[str, Any]] = []
+    for provider in raw_providers:
+        raw_id = provider.get("id")
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            continue
+        provider_id = raw_id.strip()
+        raw_models = provider.get("models")
+        model_count = len(raw_models) if isinstance(raw_models, dict) else 0
+        item: dict[str, Any] = {
+            "provider_id": provider_id,
+            "name": provider.get("name") if isinstance(provider.get("name"), str) else provider_id,
+            "connected": provider_id in connected_set,
+            "model_count": model_count,
+        }
+        source = provider.get("source")
+        if isinstance(source, str) and source.strip():
+            item["source"] = source.strip()
+        default_model_id = default_by_provider.get(provider_id)
+        if default_model_id:
+            item["default_model_id"] = default_model_id
+        items.append(item)
+    return items
+
+
+def _normalize_model_summaries(
+    raw_providers: list[dict[str, Any]],
+    *,
+    default_by_provider: dict[str, str],
+    connected: list[str],
+    provider_id: str | None = None,
+) -> list[dict[str, Any]]:
+    connected_set = set(connected)
+    items: list[dict[str, Any]] = []
+    for provider in raw_providers:
+        raw_id = provider.get("id")
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            continue
+        current_provider_id = raw_id.strip()
+        if provider_id is not None and current_provider_id != provider_id:
+            continue
+        raw_models = provider.get("models")
+        if not isinstance(raw_models, dict):
+            continue
+        default_model_id = default_by_provider.get(current_provider_id)
+        for raw_model_id, raw_model in raw_models.items():
+            if not isinstance(raw_model_id, str) or not raw_model_id.strip():
+                continue
+            if not isinstance(raw_model, dict):
+                continue
+            model_id = raw_model_id.strip()
+            item: dict[str, Any] = {
+                "provider_id": current_provider_id,
+                "model_id": model_id,
+                "name": raw_model.get("name")
+                if isinstance(raw_model.get("name"), str)
+                else model_id,
+                "default": model_id == default_model_id,
+                "connected": current_provider_id in connected_set,
+            }
+            status = raw_model.get("status")
+            if isinstance(status, str) and status.strip():
+                item["status"] = status.strip()
+            limit = raw_model.get("limit")
+            if isinstance(limit, dict):
+                context_window = limit.get("context")
+                max_output_tokens = limit.get("output")
+                if isinstance(context_window, int):
+                    item["context_window"] = context_window
+                if isinstance(max_output_tokens, int):
+                    item["max_output_tokens"] = max_output_tokens
+            capabilities = raw_model.get("capabilities")
+            if isinstance(capabilities, dict):
+                for source_key, target_key in (
+                    ("reasoning", "supports_reasoning"),
+                    ("toolcall", "supports_tool_call"),
+                    ("attachment", "supports_attachments"),
+                ):
+                    value = capabilities.get(source_key)
+                    if isinstance(value, bool):
+                        item[target_key] = value
+            items.append(item)
+    return items
+
+
 class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
     """Extend A2A JSON-RPC endpoint with OpenCode session methods.
 
@@ -468,6 +615,8 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         self._method_prompt_async = methods["prompt_async"]
         self._method_command = methods["command"]
         self._method_shell = methods["shell"]
+        self._method_list_providers = methods["list_providers"]
+        self._method_list_models = methods["list_models"]
         self._method_reply_permission = methods["reply_permission"]
         self._method_reply_question = methods["reply_question"]
         self._method_reject_question = methods["reject_question"]
@@ -623,6 +772,10 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
             self._method_list_sessions,
             self._method_get_session_messages,
         }
+        provider_discovery_methods = {
+            self._method_list_providers,
+            self._method_list_models,
+        }
         session_control_methods = {
             self._method_prompt_async,
             self._method_command,
@@ -635,7 +788,10 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         }
         if (
             base_request.method
-            not in session_query_methods | session_control_methods | interrupt_callback_methods
+            not in session_query_methods
+            | provider_discovery_methods
+            | session_control_methods
+            | interrupt_callback_methods
         ):
             return await super()._handle_requests(request)
 
@@ -648,6 +804,8 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
 
         if base_request.method in session_query_methods:
             return await self._handle_session_query_request(base_request, params)
+        if base_request.method in provider_discovery_methods:
+            return await self._handle_provider_discovery_request(base_request, params)
         if base_request.method in session_control_methods:
             return await self._handle_session_control_request(
                 base_request,
@@ -816,6 +974,136 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
             base_request.id,
             result,
         )
+
+    async def _handle_provider_discovery_request(
+        self,
+        base_request: JSONRPCRequest,
+        params: dict[str, Any],
+    ) -> Response:
+        allowed_fields = {"metadata"}
+        if base_request.method == self._method_list_models:
+            allowed_fields.add("provider_id")
+        unknown_fields = sorted(set(params) - allowed_fields)
+        if unknown_fields:
+            prefixed_fields = [f"params.{field}" for field in unknown_fields]
+            return self._generate_error_response(
+                base_request.id,
+                A2AError(
+                    root=InvalidParamsError(
+                        message=f"Unsupported params fields: {', '.join(prefixed_fields)}",
+                        data={"type": "INVALID_FIELD", "fields": prefixed_fields},
+                    )
+                ),
+            )
+
+        provider_id: str | None = None
+        if base_request.method == self._method_list_models:
+            raw_provider_id = params.get("provider_id")
+            if raw_provider_id is not None:
+                if not isinstance(raw_provider_id, str) or not raw_provider_id.strip():
+                    return self._generate_error_response(
+                        base_request.id,
+                        A2AError(
+                            root=InvalidParamsError(
+                                message="provider_id must be a non-empty string",
+                                data={"type": "INVALID_FIELD", "field": "provider_id"},
+                            )
+                        ),
+                    )
+                provider_id = raw_provider_id.strip()
+
+        directory, metadata_error = self._extract_directory_from_metadata(
+            request_id=base_request.id,
+            params=params,
+        )
+        if metadata_error is not None:
+            return metadata_error
+
+        try:
+            directory = self._directory_resolver(directory)
+        except ValueError as exc:
+            return self._generate_error_response(
+                base_request.id,
+                A2AError(
+                    root=InvalidParamsError(
+                        message=str(exc),
+                        data={"type": "INVALID_FIELD", "field": "metadata.opencode.directory"},
+                    )
+                ),
+            )
+
+        try:
+            raw_result = await self._opencode_client.list_provider_catalog(directory=directory)
+        except httpx.HTTPStatusError as exc:
+            upstream_status = exc.response.status_code
+            return self._generate_error_response(
+                base_request.id,
+                JSONRPCError(
+                    code=ERR_DISCOVERY_UPSTREAM_HTTP_ERROR,
+                    message="Upstream OpenCode error",
+                    data={
+                        "type": "UPSTREAM_HTTP_ERROR",
+                        "method": base_request.method,
+                        "upstream_status": upstream_status,
+                    },
+                ),
+            )
+        except httpx.HTTPError:
+            return self._generate_error_response(
+                base_request.id,
+                JSONRPCError(
+                    code=ERR_DISCOVERY_UPSTREAM_UNREACHABLE,
+                    message="Upstream OpenCode unreachable",
+                    data={"type": "UPSTREAM_UNREACHABLE", "method": base_request.method},
+                ),
+            )
+        except Exception as exc:
+            logger.exception("OpenCode provider discovery JSON-RPC method failed")
+            return self._generate_error_response(
+                base_request.id,
+                A2AError(root=InternalError(message=str(exc))),
+            )
+
+        try:
+            raw_providers, default_by_provider, connected = _extract_provider_catalog(raw_result)
+            if base_request.method == self._method_list_providers:
+                items = _normalize_provider_summaries(
+                    raw_providers,
+                    default_by_provider=default_by_provider,
+                    connected=connected,
+                )
+            else:
+                items = _normalize_model_summaries(
+                    raw_providers,
+                    default_by_provider=default_by_provider,
+                    connected=connected,
+                    provider_id=provider_id,
+                )
+        except ValueError as exc:
+            logger.warning("Upstream OpenCode provider payload mismatch: %s", exc)
+            return self._generate_error_response(
+                base_request.id,
+                JSONRPCError(
+                    code=ERR_DISCOVERY_UPSTREAM_PAYLOAD_ERROR,
+                    message="Upstream OpenCode payload mismatch",
+                    data={
+                        "type": "UPSTREAM_PAYLOAD_ERROR",
+                        "method": base_request.method,
+                        "detail": str(exc),
+                    },
+                ),
+            )
+
+        result = {
+            "items": items,
+            "default_by_provider": default_by_provider,
+            "connected": connected,
+        }
+
+        if base_request.id is None:
+            return Response(status_code=204)
+
+        return self._jsonrpc_success_response(base_request.id, result)
 
     async def _handle_session_control_request(
         self,

--- a/src/opencode_a2a_serve/opencode_client.py
+++ b/src/opencode_a2a_serve/opencode_client.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -176,6 +176,23 @@ class OpencodeClient:
             params[key] = value if isinstance(value, str) else str(value)
         return params
 
+    @staticmethod
+    def _normalize_model_ref(value: Mapping[str, Any] | None) -> dict[str, str] | None:
+        if value is None:
+            return None
+        provider = value.get("providerID")
+        model = value.get("modelID")
+        if not isinstance(provider, str) or not isinstance(model, str):
+            return None
+        provider_id = provider.strip()
+        model_id = model.strip()
+        if not provider_id or not model_id:
+            return None
+        return {
+            "providerID": provider_id,
+            "modelID": model_id,
+        }
+
     async def stream_events(
         self, stop_event: asyncio.Event | None = None, *, directory: str | None = None
     ) -> AsyncIterator[dict[str, Any]]:
@@ -303,12 +320,20 @@ class OpencodeClient:
         response.raise_for_status()
         return response.json()
 
+    async def list_provider_catalog(self, *, directory: str | None = None) -> Any:
+        response = await self._client.get(
+            "/provider", params=self._query_params(directory=directory)
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def send_message(
         self,
         session_id: str,
         text: str,
         *,
         directory: str | None = None,
+        model_override: Mapping[str, Any] | None = None,
         timeout_override: float | None | object = _UNSET,
     ) -> OpencodeMessage:
         payload: dict[str, Any] = {
@@ -319,11 +344,16 @@ class OpencodeClient:
                 }
             ]
         }
-        if self._provider_id and self._model_id:
-            payload["model"] = {
-                "providerID": self._provider_id,
-                "modelID": self._model_id,
-            }
+        resolved_model = self._normalize_model_ref(model_override)
+        if resolved_model is None:
+            resolved_model = self._normalize_model_ref(
+                {
+                    "providerID": self._provider_id,
+                    "modelID": self._model_id,
+                }
+            )
+        if resolved_model is not None:
+            payload["model"] = resolved_model
         if self._agent:
             payload["agent"] = self._agent
         if self._system:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -96,6 +96,7 @@ class DummyChatOpencodeClient:
     def __init__(self, settings: Settings | None = None) -> None:
         self.created_sessions = 0
         self.sent_session_ids: list[str] = []
+        self.sent_model_overrides: list[dict[str, str] | None] = []
         self.stream_timeout = None
         self.directory = None
         self.settings = settings or make_settings(
@@ -122,10 +123,12 @@ class DummyChatOpencodeClient:
         text: str,
         *,
         directory: str | None = None,
+        model_override: dict[str, str] | None = None,
         timeout_override=None,  # noqa: ANN001
     ) -> OpencodeMessage:
         del directory, timeout_override
         self.sent_session_ids.append(session_id)
+        self.sent_model_overrides.append(model_override)
         return OpencodeMessage(
             text=f"echo:{text}",
             session_id=session_id,
@@ -175,6 +178,49 @@ class DummySessionQueryOpencodeClient:
         self.prompt_async_calls: list[dict[str, Any]] = []
         self.command_calls: list[dict[str, Any]] = []
         self.shell_calls: list[dict[str, Any]] = []
+        self.provider_catalog_payload: dict[str, Any] = {
+            "all": [
+                {
+                    "id": "openai",
+                    "name": "OpenAI",
+                    "source": "api",
+                    "models": {
+                        "gpt-5": {
+                            "name": "GPT-5",
+                            "status": "active",
+                            "limit": {"context": 200000, "output": 8192},
+                            "capabilities": {
+                                "reasoning": True,
+                                "toolcall": True,
+                                "attachment": False,
+                            },
+                        }
+                    },
+                },
+                {
+                    "id": "google",
+                    "name": "Google",
+                    "source": "config",
+                    "models": {
+                        "gemini-2.5-flash": {
+                            "name": "Gemini 2.5 Flash",
+                            "status": "beta",
+                            "limit": {"context": 1000000, "output": 8192},
+                            "capabilities": {
+                                "reasoning": True,
+                                "toolcall": True,
+                                "attachment": True,
+                            },
+                        }
+                    },
+                },
+            ],
+            "default": {
+                "openai": "gpt-5",
+                "google": "gemini-2.5-flash",
+            },
+            "connected": ["openai"],
+        }
         self._interrupt_requests: dict[str, dict[str, str | None]] = {}
 
     async def close(self) -> None:
@@ -242,6 +288,10 @@ class DummySessionQueryOpencodeClient:
             "role": "assistant",
             "parts": [{"type": "text", "text": "Shell command executed."}],
         }
+
+    async def list_provider_catalog(self, *, directory: str | None = None):
+        del directory
+        return self.provider_catalog_payload
 
     def remember_interrupt_request(
         self,

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -1,5 +1,7 @@
 from opencode_a2a_serve.app import (
     INTERRUPT_CALLBACK_EXTENSION_URI,
+    MODEL_SELECTION_EXTENSION_URI,
+    PROVIDER_DISCOVERY_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
     STREAMING_EXTENSION_URI,
@@ -54,6 +56,16 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert binding.params["directory_override_enabled"] is False
     assert binding.params["shared_workspace_across_consumers"] is True
     assert binding.params["tenant_isolation"] == "none"
+
+    model_selection = ext_by_uri[MODEL_SELECTION_EXTENSION_URI]
+    assert model_selection.params["metadata_field"] == "metadata.shared.model"
+    assert model_selection.params["fields"]["providerID"] == "metadata.shared.model.providerID"
+    assert model_selection.params["fields"]["modelID"] == "metadata.shared.model.modelID"
+    assert model_selection.params["default_model"] == {
+        "providerID": "google",
+        "modelID": "gemini-2.5-flash",
+    }
+    assert model_selection.params["applies_to_methods"] == ["message/send", "message/stream"]
 
     streaming = ext_by_uri[STREAMING_EXTENSION_URI]
     assert streaming.params["artifact_metadata_field"] == "metadata.shared.stream"
@@ -131,6 +143,21 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
         "supported",
         "unsupported",
     ]
+
+    provider_discovery = ext_by_uri[PROVIDER_DISCOVERY_EXTENSION_URI]
+    assert provider_discovery.params["deployment_context"]["project"] == "alpha"
+    assert provider_discovery.params["methods"] == {
+        "list_providers": "opencode.providers.list",
+        "list_models": "opencode.models.list",
+    }
+    assert provider_discovery.params["method_contracts"]["opencode.models.list"]["params"] == {
+        "optional": ["provider_id"]
+    }
+    assert provider_discovery.params["errors"]["business_codes"] == {
+        "UPSTREAM_UNREACHABLE": -32002,
+        "UPSTREAM_HTTP_ERROR": -32003,
+        "UPSTREAM_PAYLOAD_ERROR": -32005,
+    }
 
     interrupt = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
     assert interrupt.params["deployment_context"]["project"] == "alpha"

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -23,6 +23,7 @@ async def test_cancel_interrupts_running_execute_and_keeps_queue_open(caplog):
         _text,
         *,
         directory=None,  # noqa: ARG001
+        model_override=None,  # noqa: ARG001
         timeout_override=None,  # noqa: ARG001
     ):
         send_started.set()
@@ -115,6 +116,7 @@ async def test_cancel_keeps_canceled_status_when_abort_session_fails() -> None:
         _text,
         *,
         directory=None,  # noqa: ARG001
+        model_override=None,  # noqa: ARG001
         timeout_override=None,  # noqa: ARG001
     ):
         send_started.set()
@@ -182,6 +184,7 @@ async def test_cancel_remains_responsive_when_abort_session_hangs(caplog) -> Non
         _text,
         *,
         directory=None,  # noqa: ARG001
+        model_override=None,  # noqa: ARG001
         timeout_override=None,  # noqa: ARG001
     ):
         send_started.set()

--- a/tests/test_extension_contract_consistency.py
+++ b/tests/test_extension_contract_consistency.py
@@ -3,6 +3,8 @@ import pytest
 
 from opencode_a2a_serve.app import (
     INTERRUPT_CALLBACK_EXTENSION_URI,
+    MODEL_SELECTION_EXTENSION_URI,
+    PROVIDER_DISCOVERY_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
     STREAMING_EXTENSION_URI,
@@ -11,8 +13,11 @@ from opencode_a2a_serve.app import (
 )
 from opencode_a2a_serve.extension_contracts import (
     INTERRUPT_CALLBACK_METHODS,
+    PROVIDER_DISCOVERY_METHODS,
     SESSION_QUERY_METHODS,
     build_interrupt_callback_extension_params,
+    build_model_selection_extension_params,
+    build_provider_discovery_extension_params,
     build_session_binding_extension_params,
     build_session_query_extension_params,
     build_streaming_extension_params,
@@ -27,8 +32,10 @@ def test_extension_ssot_matches_agent_card_contracts() -> None:
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
 
     session_binding = ext_by_uri[SESSION_BINDING_EXTENSION_URI]
+    model_selection = ext_by_uri[MODEL_SELECTION_EXTENSION_URI]
     streaming = ext_by_uri[STREAMING_EXTENSION_URI]
     session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
+    provider_discovery = ext_by_uri[PROVIDER_DISCOVERY_EXTENSION_URI]
     interrupt_callback = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
     deployment_context = session_query.params["deployment_context"]
 
@@ -36,10 +43,16 @@ def test_extension_ssot_matches_agent_card_contracts() -> None:
         deployment_context=deployment_context,
         directory_override_enabled=True,
     )
+    expected_model_selection = build_model_selection_extension_params(
+        deployment_context=deployment_context,
+    )
     expected_streaming = build_streaming_extension_params()
     expected_session_query = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
+    )
+    expected_provider_discovery = build_provider_discovery_extension_params(
+        deployment_context=deployment_context,
     )
     expected_interrupt_callback = build_interrupt_callback_extension_params(
         deployment_context=deployment_context,
@@ -48,11 +61,17 @@ def test_extension_ssot_matches_agent_card_contracts() -> None:
     assert session_binding.params == expected_session_binding, (
         "Session binding extension drifted from extension_contracts SSOT."
     )
+    assert model_selection.params == expected_model_selection, (
+        "Model selection extension drifted from extension_contracts SSOT."
+    )
     assert streaming.params == expected_streaming, (
         "Streaming extension drifted from extension_contracts SSOT."
     )
     assert session_query.params == expected_session_query, (
         "Session query extension drifted from extension_contracts SSOT."
+    )
+    assert provider_discovery.params == expected_provider_discovery, (
+        "Provider discovery extension drifted from extension_contracts SSOT."
     )
     assert interrupt_callback.params == expected_interrupt_callback, (
         "Interrupt callback extension drifted from extension_contracts SSOT."
@@ -70,18 +89,26 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     )
 
     session_binding = contract["session_binding"]
+    model_selection = contract["model_selection"]
     streaming = contract["streaming"]
     session_query = contract["session_query"]
+    provider_discovery = contract["provider_discovery"]
     interrupt_callback = contract["interrupt_callback"]
     deployment_context = session_query["deployment_context"]
     expected_session_binding = build_session_binding_extension_params(
         deployment_context=deployment_context,
         directory_override_enabled=True,
     )
+    expected_model_selection = build_model_selection_extension_params(
+        deployment_context=deployment_context,
+    )
     expected_streaming = build_streaming_extension_params()
     expected_session_query = build_session_query_extension_params(
         deployment_context=deployment_context,
         context_id_prefix=SESSION_CONTEXT_PREFIX,
+    )
+    expected_provider_discovery = build_provider_discovery_extension_params(
+        deployment_context=deployment_context,
     )
     expected_interrupt_callback = build_interrupt_callback_extension_params(
         deployment_context=deployment_context,
@@ -90,11 +117,17 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     assert session_binding == expected_session_binding, (
         "OpenAPI session binding contract drifted from extension_contracts SSOT."
     )
+    assert model_selection == expected_model_selection, (
+        "OpenAPI model selection contract drifted from extension_contracts SSOT."
+    )
     assert streaming == expected_streaming, (
         "OpenAPI streaming contract drifted from extension_contracts SSOT."
     )
     assert session_query == expected_session_query, (
         "OpenAPI session query contract drifted from extension_contracts SSOT."
+    )
+    assert provider_discovery == expected_provider_discovery, (
+        "OpenAPI provider discovery contract drifted from extension_contracts SSOT."
     )
     assert interrupt_callback == expected_interrupt_callback, (
         "OpenAPI interrupt callback contract drifted from extension_contracts SSOT."
@@ -117,8 +150,10 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     example_methods = {
         value.get("value", {}).get("method") for value in example_values if isinstance(value, dict)
     }
-    expected_methods = set(SESSION_QUERY_METHODS.values()) | set(
-        INTERRUPT_CALLBACK_METHODS.values()
+    expected_methods = (
+        set(SESSION_QUERY_METHODS.values())
+        | set(PROVIDER_DISCOVERY_METHODS.values())
+        | set(INTERRUPT_CALLBACK_METHODS.values())
     )
     missing_methods = sorted(method for method in expected_methods if method not in example_methods)
     assert not missing_methods, (
@@ -156,6 +191,8 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
             },
             None,
         ),
+        ("opencode.providers.list", {}, None),
+        ("opencode.models.list", {"provider_id": "openai"}, None),
         (
             "a2a.interrupt.permission.reply",
             {"request_id": "req-perm", "reply": "once"},

--- a/tests/test_opencode_agent_session_binding.py
+++ b/tests/test_opencode_agent_session_binding.py
@@ -27,6 +27,40 @@ async def test_agent_prefers_metadata_shared_session_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_passes_shared_model_override_to_upstream() -> None:
+    client = DummyChatOpencodeClient()
+    executor = OpencodeAgentExecutor(client, streaming_enabled=False)
+    q = DummyEventQueue()
+
+    ctx = make_request_context(
+        task_id="t-model",
+        context_id="c-model",
+        text="hello",
+        metadata={"shared": {"model": {"providerID": "google", "modelID": "gemini-2.5-flash"}}},
+    )
+    await executor.execute(ctx, q)
+
+    assert client.sent_model_overrides == [{"providerID": "google", "modelID": "gemini-2.5-flash"}]
+
+
+@pytest.mark.asyncio
+async def test_agent_ignores_partial_shared_model_override() -> None:
+    client = DummyChatOpencodeClient()
+    executor = OpencodeAgentExecutor(client, streaming_enabled=False)
+    q = DummyEventQueue()
+
+    ctx = make_request_context(
+        task_id="t-model-invalid",
+        context_id="c-model-invalid",
+        text="hello",
+        metadata={"shared": {"model": {"providerID": "google"}}},
+    )
+    await executor.execute(ctx, q)
+
+    assert client.sent_model_overrides == [None]
+
+
+@pytest.mark.asyncio
 async def test_agent_caches_bound_session_id_for_followup_requests() -> None:
     client = DummyChatOpencodeClient()
     executor = OpencodeAgentExecutor(
@@ -96,9 +130,10 @@ async def test_agent_uses_stable_fallback_message_id_when_upstream_missing_messa
             text: str,
             *,
             directory: str | None = None,
+            model_override: dict[str, str] | None = None,
             timeout_override=None,  # noqa: ANN001
         ) -> OpencodeMessage:
-            del text, directory, timeout_override
+            del text, directory, model_override, timeout_override
             self.sent_session_ids.append(session_id)
             return OpencodeMessage(
                 text="echo:hello",
@@ -130,9 +165,10 @@ async def test_agent_includes_usage_in_non_stream_task_metadata() -> None:
             text: str,
             *,
             directory: str | None = None,
+            model_override: dict[str, str] | None = None,
             timeout_override=None,  # noqa: ANN001
         ) -> OpencodeMessage:
-            del text, directory, timeout_override
+            del text, directory, model_override, timeout_override
             self.sent_session_ids.append(session_id)
             return OpencodeMessage(
                 text="echo:hello",

--- a/tests/test_opencode_client_params.py
+++ b/tests/test_opencode_client_params.py
@@ -176,6 +176,109 @@ async def test_session_shell_posts_shell_endpoint(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_message_prefers_request_model_override(monkeypatch):
+    client = OpencodeClient(
+        make_settings(
+            a2a_bearer_token="t-1",
+            opencode_provider_id="openai",
+            opencode_model_id="gpt-5",
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+        )
+    )
+
+    seen = {}
+
+    async def fake_post(path: str, *, params=None, json=None, **_kwargs):
+        seen["path"] = path
+        seen["params"] = params
+        seen["json"] = json
+        return _DummyResponse({"info": {"id": "m-1"}, "parts": [{"type": "text", "text": "ok"}]})
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+
+    await client.send_message(
+        "ses-1",
+        "hello",
+        model_override={"providerID": "google", "modelID": "gemini-2.5-flash"},
+    )
+
+    assert seen["path"] == "/session/ses-1/message"
+    assert seen["json"]["model"] == {
+        "providerID": "google",
+        "modelID": "gemini-2.5-flash",
+    }
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_send_message_falls_back_to_default_model_on_partial_override(monkeypatch):
+    client = OpencodeClient(
+        make_settings(
+            a2a_bearer_token="t-1",
+            opencode_provider_id="openai",
+            opencode_model_id="gpt-5",
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+        )
+    )
+
+    seen = {}
+
+    async def fake_post(path: str, *, params=None, json=None, **_kwargs):
+        seen["json"] = json
+        return _DummyResponse({"info": {"id": "m-1"}, "parts": [{"type": "text", "text": "ok"}]})
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+
+    await client.send_message(
+        "ses-1",
+        "hello",
+        model_override={"providerID": "google"},
+    )
+
+    assert seen["json"]["model"] == {
+        "providerID": "openai",
+        "modelID": "gpt-5",
+    }
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_provider_catalog_calls_provider_endpoint(monkeypatch):
+    client = OpencodeClient(
+        make_settings(
+            a2a_bearer_token="t-1",
+            opencode_directory="/safe",
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+        )
+    )
+
+    seen = {}
+
+    async def fake_get(path: str, *, params=None, **_kwargs):
+        seen["path"] = path
+        seen["params"] = params
+        return _DummyResponse({"all": [], "default": {}, "connected": []})
+
+    monkeypatch.setattr(client._client, "get", fake_get)
+
+    data = await client.list_provider_catalog()
+
+    assert seen["path"] == "/provider"
+    assert seen["params"]["directory"] == "/safe"
+    assert data == {"all": [], "default": {}, "connected": []}
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_permission_reply_raises_on_404_without_legacy_fallback(monkeypatch):
     client = OpencodeClient(
         make_settings(

--- a/tests/test_opencode_session_extension.py
+++ b/tests/test_opencode_session_extension.py
@@ -121,6 +121,127 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_provider_discovery_extension_returns_normalized_catalog(monkeypatch):
+    import opencode_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(
+            a2a_bearer_token="t-1",
+            a2a_log_payloads=False,
+            opencode_directory="/workspace",
+            **_BASE_SETTINGS,
+        )
+    )
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(
+            a2a_bearer_token="t-1",
+            a2a_log_payloads=False,
+            opencode_directory="/workspace",
+            **_BASE_SETTINGS,
+        )
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        providers_resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "opencode.providers.list",
+                "params": {},
+            },
+        )
+        assert providers_resp.status_code == 200
+        providers_payload = providers_resp.json()["result"]
+        assert providers_payload["default_by_provider"]["openai"] == "gpt-5"
+        assert providers_payload["connected"] == ["openai"]
+        assert providers_payload["items"][0]["provider_id"] == "openai"
+        assert providers_payload["items"][0]["default_model_id"] == "gpt-5"
+
+        models_resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "opencode.models.list",
+                "params": {"provider_id": "google"},
+            },
+        )
+        assert models_resp.status_code == 200
+        models_payload = models_resp.json()["result"]
+        assert len(models_payload["items"]) == 1
+        assert models_payload["items"][0]["provider_id"] == "google"
+        assert models_payload["items"][0]["model_id"] == "gemini-2.5-flash"
+        assert models_payload["items"][0]["supports_attachments"] is True
+
+
+@pytest.mark.asyncio
+async def test_provider_discovery_extension_rejects_invalid_provider_id(monkeypatch):
+    import opencode_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 13,
+                "method": "opencode.models.list",
+                "params": {"provider_id": 123},
+            },
+        )
+        payload = resp.json()
+        assert payload["error"]["code"] == -32602
+        assert payload["error"]["data"]["field"] == "provider_id"
+
+
+@pytest.mark.asyncio
+async def test_provider_discovery_extension_maps_payload_mismatch(monkeypatch):
+    import opencode_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    dummy.provider_catalog_payload = {"all": "bad", "default": {}, "connected": []}
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 14,
+                "method": "opencode.providers.list",
+                "params": {},
+            },
+        )
+        payload = resp.json()
+        assert payload["error"]["code"] == -32005
+        assert payload["error"]["data"]["type"] == "UPSTREAM_PAYLOAD_ERROR"
+
+
+@pytest.mark.asyncio
 async def test_session_query_extension_rejects_non_array_upstream_payload(monkeypatch):
     import opencode_a2a_serve.app as app_module
 
@@ -1042,6 +1163,49 @@ async def test_session_command_extension_success(monkeypatch):
         assert len(dummy.command_calls) == 1
         assert dummy.command_calls[0]["session_id"] == "s-1"
         assert dummy.command_calls[0]["directory"] == "/workspace"
+
+
+@pytest.mark.asyncio
+async def test_session_command_extension_accepts_request_model(monkeypatch):
+    import opencode_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 3201,
+                "method": "opencode.sessions.command",
+                "params": {
+                    "session_id": "s-1",
+                    "request": {
+                        "command": "/review",
+                        "arguments": "security",
+                        "model": {
+                            "providerID": "openai",
+                            "modelID": "gpt-5",
+                        },
+                    },
+                },
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json().get("error") is None
+        assert dummy.command_calls[0]["request"]["model"] == {
+            "providerID": "openai",
+            "modelID": "gpt-5",
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -128,9 +128,10 @@ async def test_concurrent_session_create_isolated_by_identity():
         _text,
         *,
         directory=None,
+        model_override=None,
         timeout_override=None,
     ):
-        del directory, timeout_override
+        del directory, model_override, timeout_override
         response = MagicMock()
         response.text = "OpenCode response"
         response.session_id = session_id
@@ -235,6 +236,7 @@ async def test_preferred_session_claim_is_released_on_upstream_failure():
         _text,
         *,
         directory=None,  # noqa: ARG001
+        model_override=None,  # noqa: ARG001
         timeout_override=None,  # noqa: ARG001
     ):
         raise RuntimeError(f"upstream failed for {session_id}")
@@ -268,6 +270,7 @@ async def test_preferred_session_claim_is_released_on_upstream_cancellation():
         _text,
         *,
         directory=None,  # noqa: ARG001
+        model_override=None,  # noqa: ARG001
         timeout_override=None,  # noqa: ARG001
     ):
         raise asyncio.CancelledError()

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -48,9 +48,10 @@ class DummyStreamingClient:
         text: str,
         *,
         directory: str | None = None,
+        model_override: dict[str, str] | None = None,
         timeout_override=None,  # noqa: ANN001
     ) -> OpencodeMessage:
-        del text, directory, timeout_override
+        del text, directory, model_override, timeout_override
         self._in_flight_send += 1
         self.max_in_flight_send = max(self.max_in_flight_send, self._in_flight_send)
         await asyncio.sleep(self._send_delay)


### PR DESCRIPTION
- Closes #76
- Relates to https://github.com/liujuanjuan1984/a2a-client-hub/issues/443
- Relates to https://github.com/liujuanjuan1984/a2a-client-hub/issues/447


## 相关提交
- `5edb3d4 feat: add shared model selection and provider discovery #76`

## 变更概览
本 PR 按 `#443` 的 shared/private contract 原则，实现 `#76` 的两部分目标：
- 为主聊天链路补齐请求级模型切换
- 为 OpenCode 补齐 provider/model discovery 扩展

同时修正现有 session-control 路径的模型契约一致性，避免主聊天与 `opencode.sessions.*` 出现双轨语义。

## 模块变更

### 1. Shared model selection
- 新增 shared contract：`metadata.shared.model`
- 主聊天链路 `message/send` / `message:stream` 现在可通过 `{ providerID, modelID }` 覆盖单次请求模型
- `agent` 负责提取 shared model metadata，`opencode_client` 负责映射到 OpenCode 上游 `model` payload
- 当 shared model metadata 缺失、部分缺失或不合法时，回退到服务端默认模型

### 2. OpenCode provider/model discovery
- 新增 JSON-RPC 方法：
  - `opencode.providers.list`
  - `opencode.models.list`
- 读取 OpenCode 上游 provider catalog，并输出最小标准化结果：
  - provider summary / model summary
  - `default_by_provider`
  - `connected`
- discovery 方法复用现有 `metadata.opencode.directory` 目录边界校验

### 3. 契约 SSOT / Agent Card / OpenAPI
- 在 `extension_contracts.py` 中新增：
  - shared model-selection contract
  - provider-discovery contract
- Agent Card 与 OpenAPI `x-a2a-extension-contracts` 同步声明：
  - `urn:a2a:model-selection/v1`
  - `urn:opencode-a2a:provider-discovery/v1`
- JSON-RPC / REST examples 同步补充 model override 与 discovery 调用示例

### 4. Session-control 契约对齐
- 修正 `opencode.sessions.command` 的 `request.model` 校验逻辑
- 让 `prompt_async` / `command` / `shell` 统一采用 `{ providerID, modelID }`
- 避免主聊天 shared contract 与 session-control request contract 之间发生 shape 漂移

### 5. 文档与测试
- 更新 `README.md` 与 `docs/guide.md`
- 新增/更新测试覆盖：
  - shared model override
  - provider/model discovery
  - extension SSOT consistency
  - Agent Card / OpenAPI contract
  - client payload fallback / override

## 契约边界

### shared
- `metadata.shared.session.id`
- `metadata.shared.model`
- `metadata.shared.stream.*`
- `metadata.shared.interrupt.*`
- `metadata.shared.usage`

### OpenCode private
- `metadata.opencode.directory`
- `opencode.sessions.*`
- `opencode.providers.*`
- `opencode.models.*`

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
