### PR TITLE
refactor: clarify stream payload contracts for tool calls, usage, and interrupts

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -68,10 +68,13 @@ Key variables to understand protocol behavior:
   continue to use `TextPart`. Final status event metadata may include
   normalized token usage at `metadata.shared.usage` with fields like
   `input_tokens`, `output_tokens`, `total_tokens`, and optional `cost`.
+  Usage is extracted from documented info payloads and supported usage parts
+  such as `step-finish`; non-usage parts with similar fields are ignored.
   Interrupt events (`permission.asked` / `question.asked`) are mapped to
   `TaskStatusUpdateEvent(final=false, state=input-required)` with details at
   `metadata.shared.interrupt` (including `request_id`, interrupt `type`, and
-  minimal callback payload).
+  normalized minimal callback payload). Resolved interrupt events only clear
+  internal pending state; they do not emit a separate outward status event.
   Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at
   `Task.metadata.shared.usage` with the same field schema.

--- a/src/opencode_a2a_serve/agent.py
+++ b/src/opencode_a2a_serve/agent.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 _INTERRUPT_ASKED_EVENT_TYPES = {"permission.asked", "question.asked"}
 _INTERRUPT_RESOLVED_EVENT_TYPES = {"permission.replied", "question.replied", "question.rejected"}
+_USAGE_PART_TYPES = {"step-finish"}
 
 
 class BlockType(str, Enum):
@@ -1632,7 +1633,10 @@ def _extract_token_usage(payload: Any) -> dict[str, Any] | None:
         if isinstance(props_info, Mapping):
             candidates.append(props_info)
         part = props.get("part")
-        if isinstance(part, Mapping):
+        if (
+            isinstance(part, Mapping)
+            and _extract_stream_part_type(part, props) in _USAGE_PART_TYPES
+        ):
             candidates.append(part)
 
     for candidate in candidates:
@@ -1739,6 +1743,53 @@ def _extract_string_list(value: Any) -> list[str]:
     return result
 
 
+def _extract_optional_string(source: Mapping[str, Any], key: str) -> str | None:
+    value = source.get(key)
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _normalize_interrupt_question_options(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    options: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        normalized_option: dict[str, str] = {}
+        for key in ("label", "value", "description"):
+            normalized = _extract_optional_string(item, key)
+            if normalized is not None:
+                normalized_option[key] = normalized
+        if normalized_option:
+            options.append(normalized_option)
+    return options
+
+
+def _normalize_interrupt_questions(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    questions: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        normalized_question: dict[str, Any] = {}
+        for key in ("header", "question"):
+            normalized = _extract_optional_string(item, key)
+            if normalized is not None:
+                normalized_question[key] = normalized
+        options = _normalize_interrupt_question_options(item.get("options"))
+        if options:
+            normalized_question["options"] = options
+        if normalized_question:
+            questions.append(normalized_question)
+    return questions
+
+
 def _extract_interrupt_asked_request_id(props: Mapping[str, Any]) -> str | None:
     return _extract_first_nonempty_string(
         props,
@@ -1765,7 +1816,7 @@ def _extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] |
         return None
     if event_type == "permission.asked":
         details: dict[str, Any] = {
-            "permission": props.get("permission"),
+            "permission": _extract_optional_string(props, "permission"),
             "patterns": _extract_string_list(props.get("patterns")),
         }
         return {
@@ -1773,8 +1824,7 @@ def _extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] |
             "interrupt_type": "permission",
             "details": details,
         }
-    questions = props.get("questions")
-    details = {"questions": questions if isinstance(questions, list) else []}
+    details = {"questions": _normalize_interrupt_questions(props.get("questions"))}
     return {
         "request_id": request_id,
         "interrupt_type": "question",

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -6,6 +6,7 @@ from a2a.types import Task, TaskArtifactUpdateEvent, TaskState, TaskStatusUpdate
 from opencode_a2a_serve.agent import (
     BlockType,
     OpencodeAgentExecutor,
+    _extract_token_usage,
     _extract_tool_part_payload,
     _StreamOutputState,
 )
@@ -216,6 +217,16 @@ def _question_asked_event(*, session_id: str, request_id: str) -> dict:
     }
 
 
+def _interrupt_resolved_event(*, session_id: str, request_id: str, event_type: str) -> dict:
+    return {
+        "type": event_type,
+        "properties": {
+            "requestID": request_id,
+            "sessionID": session_id,
+        },
+    }
+
+
 def _artifact_updates(queue: DummyEventQueue) -> list[TaskArtifactUpdateEvent]:
     return [event for event in queue.events if isinstance(event, TaskArtifactUpdateEvent)]
 
@@ -293,6 +304,23 @@ def test_extract_tool_part_payload_normalizes_structured_state() -> None:
         "output": {"stdout": "/workspace"},
     }
     assert _extract_tool_part_payload({"callID": " ", "tool": None, "state": {}}) is None
+
+
+def test_extract_token_usage_ignores_non_step_finish_part_payload() -> None:
+    assert (
+        _extract_token_usage(
+            {
+                "properties": {
+                    "part": {
+                        "type": "tool",
+                        "tokens": {"input": 9, "output": 3, "total": 12},
+                        "cost": 0.4,
+                    }
+                }
+            }
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio
@@ -565,6 +593,66 @@ async def test_streaming_includes_usage_in_final_status_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_ignores_non_step_finish_usage_like_part_payloads() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            _event(
+                session_id="ses-1",
+                role="assistant",
+                part_type="tool",
+                delta="",
+                part_id="prt-tool-usage-lookalike",
+                part_overrides={
+                    "callID": "call-usage-lookalike",
+                    "tool": "bash",
+                    "tokens": {"input": 99, "output": 1, "total": 100},
+                    "cost": 1.2,
+                    "state": {"status": "running"},
+                },
+            ),
+        ],
+        response_text="answer",
+        response_raw={
+            "info": {
+                "tokens": {
+                    "input": 11,
+                    "output": 5,
+                    "reasoning": 0,
+                    "cache": {"read": 0, "write": 0},
+                },
+                "cost": 0.0009,
+            }
+        },
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    await executor.execute(
+        make_request_context(
+            task_id="task-usage-guard",
+            context_id="ctx-usage-guard",
+            text="hello",
+        ),
+        queue,
+    )
+
+    final_status = [
+        event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
+    ][-1]
+    usage = _status_shared_meta(final_status)["usage"]
+    assert usage["input_tokens"] == 11
+    assert usage["output_tokens"] == 5
+    assert usage["cost"] == 0.0009
+    tool_updates = [
+        event
+        for event in _artifact_updates(queue)
+        if _artifact_stream_meta(event)["block_type"] == "tool_call"
+    ]
+    assert len(tool_updates) == 1
+
+
+@pytest.mark.asyncio
 async def test_streaming_final_status_state_is_completed() -> None:
     client = DummyStreamingClient(
         stream_events_payload=[],
@@ -674,9 +762,135 @@ async def test_streaming_emits_interrupt_status_for_question_asked_event() -> No
     assert len(interrupt_statuses) == 1
     interrupt = _interrupt_meta(interrupt_statuses[0])
     assert interrupt["request_id"] == "q-req-1"
-    assert isinstance(interrupt["details"]["questions"], list)
+    assert interrupt["details"]["questions"] == [
+        {
+            "header": "Confirm",
+            "question": "Proceed?",
+            "options": [{"label": "Yes", "value": "yes"}],
+        }
+    ]
     assert "tool" not in interrupt["details"]
     assert interrupt_statuses[0].status.state == TaskState.input_required
+
+
+@pytest.mark.asyncio
+async def test_streaming_normalizes_question_interrupt_details() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            {
+                "type": "question.asked",
+                "properties": {
+                    "id": "q-req-rich",
+                    "sessionID": "ses-1",
+                    "questions": [
+                        {
+                            "header": " Confirm ",
+                            "question": " Proceed? ",
+                            "ignored": "drop-me",
+                            "options": [
+                                {
+                                    "label": " Yes ",
+                                    "value": " yes ",
+                                    "description": " continue ",
+                                    "extra": "drop-me",
+                                },
+                                {
+                                    "label": " ",
+                                    "value": "no",
+                                },
+                                "invalid",
+                            ],
+                        },
+                        {
+                            "ignored": "only-invalid",
+                            "options": [{"extra": "drop-me"}],
+                        },
+                    ],
+                },
+            },
+            _event(session_id="ses-1", role="assistant", part_type="text", delta="answer"),
+        ],
+        response_text="answer",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    await executor.execute(
+        make_request_context(
+            task_id="task-question-normalized",
+            context_id="ctx-question-normalized",
+            text="hello",
+        ),
+        queue,
+    )
+
+    interrupt_status = next(
+        event
+        for event in queue.events
+        if isinstance(event, TaskStatusUpdateEvent)
+        and event.final is False
+        and (event.metadata or {}).get("shared", {}).get("interrupt", {}).get("type") == "question"
+    )
+    interrupt = _interrupt_meta(interrupt_status)
+    assert interrupt["details"]["questions"] == [
+        {
+            "header": "Confirm",
+            "question": "Proceed?",
+            "options": [
+                {
+                    "label": "Yes",
+                    "value": "yes",
+                    "description": "continue",
+                },
+                {
+                    "value": "no",
+                },
+            ],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streaming_resolved_interrupt_only_clears_internal_pending_state() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            _permission_asked_event(session_id="ses-1", request_id="perm-req-resolve"),
+            _interrupt_resolved_event(
+                session_id="ses-1",
+                request_id="perm-req-resolve",
+                event_type="permission.replied",
+            ),
+            _event(session_id="ses-1", role="assistant", part_type="text", delta="answer"),
+        ],
+        response_text="answer",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    await executor.execute(
+        make_request_context(
+            task_id="task-interrupt-resolved",
+            context_id="ctx-interrupt-resolved",
+            text="hello",
+        ),
+        queue,
+    )
+
+    interrupt_statuses = [
+        event
+        for event in queue.events
+        if isinstance(event, TaskStatusUpdateEvent)
+        and event.final is False
+        and (event.metadata or {}).get("shared", {}).get("interrupt") is not None
+    ]
+    assert len(interrupt_statuses) == 1
+    assert _interrupt_meta(interrupt_statuses[0])["request_id"] == "perm-req-resolve"
+    final_status = [
+        event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
+    ][-1]
+    assert "interrupt" not in (final_status.metadata or {}).get("shared", {})
 
 
 def _unique(items: list[str]) -> list[str]:


### PR DESCRIPTION
## 背景
- 当前 PR 起点是 `tool_call` 流块从 `TextPart` 切换为 `DataPart`，解决结构化工具状态被文本载体承载导致的语义混淆。
- 在实现 `#155` 的过程中，又识别出两个相邻契约问题：
  - `step-finish` usage 提取边界偏宽，未来存在误吸收非 usage 事件的风险。
  - interrupt 控制流契约需要更明确的最小字段归一化，以及对 resolved 事件外显策略的明示。

## 变更说明
### 模块一：流式 `tool_call` 契约
- 将 `tool_call` 流块改为 `DataPart(data={...})` 承载结构化工具状态。
- 保留 `artifact.metadata.shared.stream.block_type = "tool_call"` 作为块语义权威字段。
- 保持 `text` / `reasoning` 继续使用 `TextPart`。
- 保持单 artifact、append-only 的流式语义不变。
- 将 `tool_call` 去重逻辑调整为基于规范化结构化 payload，而不是 JSON 文本拼接。

### 模块二：usage 提取边界
- 收紧流式 usage 提取来源：`properties.part` 只有在 `part.type == "step-finish"` 时才会被识别为 usage 来源。
- 保留现有优先级：合法流式 usage 仍可覆盖 `response.raw.info` 的 usage。
- 避免未来非 usage part 仅因携带 `tokens` / `cost` 字段而污染最终 `metadata.shared.usage`。

### 模块三：interrupt 控制流契约
- 保持 `permission.asked` / `question.asked` 继续映射为 `TaskStatusUpdateEvent(final=false, state=input-required)`。
- 对 `question.asked` 的 `details.questions` 增加显式归一化，只保留稳定、客户端真正需要的最小字段。
- 对 `permission.asked` 的 `permission` 字段增加字符串规范化。
- 明确 resolved 类 interrupt 事件当前只清理内部 pending 状态，不额外外发一个 resolved status event。

### 模块四：测试与文档
- 更新流式输出契约测试，校验 `tool_call` 输出为 `DataPart`。
- 新增 `tool_call` 非累积去重与结构化 payload 归一化测试。
- 新增 usage 边界测试，覆盖非 `step-finish` part 的误吸收场景。
- 新增 interrupt 归一化与 resolved 外显策略测试。
- 更新 guide，明确 `tool_call` / usage / interrupt 的最新协议约束。

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
- 结果：`162 passed`，coverage `84.43%`

## 关联
- Closes #155
- Closes #157
- Closes #158
- Relates to https://github.com/liujuanjuan1984/a2a-client-hub/issues/443
