### PR TITLE
feat: emit explicit interrupt resolved status updates

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -72,9 +72,13 @@ Key variables to understand protocol behavior:
   such as `step-finish`; non-usage parts with similar fields are ignored.
   Interrupt events (`permission.asked` / `question.asked`) are mapped to
   `TaskStatusUpdateEvent(final=false, state=input-required)` with details at
-  `metadata.shared.interrupt` (including `request_id`, interrupt `type`, and
-  normalized minimal callback payload). Resolved interrupt events only clear
-  internal pending state; they do not emit a separate outward status event.
+  `metadata.shared.interrupt` (including `request_id`, interrupt `type`,
+  `phase=asked`, and normalized minimal callback payload). Resolved interrupt
+  events (`permission.replied` / `question.replied` / `question.rejected`) are
+  emitted as `TaskStatusUpdateEvent(final=false, state=working)` with
+  `metadata.shared.interrupt.phase=resolved` and a normalized
+  `metadata.shared.interrupt.resolution`. Duplicate or unknown resolved events
+  are suppressed unless the matching request is still pending.
   Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at
   `Task.metadata.shared.usage` with the same field schema.

--- a/src/opencode_a2a_serve/agent.py
+++ b/src/opencode_a2a_serve/agent.py
@@ -157,8 +157,14 @@ class _StreamOutputState:
         self.pending_interrupt_request_ids.add(normalized)
         return True
 
-    def clear_interrupt_pending(self, request_id: str) -> None:
-        self.pending_interrupt_request_ids.discard(request_id.strip())
+    def clear_interrupt_pending(self, request_id: str) -> bool:
+        normalized = request_id.strip()
+        if not normalized:
+            return False
+        if normalized not in self.pending_interrupt_request_ids:
+            return False
+        self.pending_interrupt_request_ids.discard(normalized)
+        return True
 
 
 @dataclass(frozen=True)
@@ -1097,8 +1103,19 @@ class OpencodeAgentExecutor(AgentExecutor):
             state: TaskState,
             request_id: str,
             interrupt_type: str,
-            details: Mapping[str, Any],
+            phase: str,
+            details: Mapping[str, Any] | None = None,
+            resolution: str | None = None,
         ) -> None:
+            interrupt_metadata: dict[str, Any] = {
+                "request_id": request_id,
+                "type": interrupt_type,
+                "phase": phase,
+            }
+            if details is not None:
+                interrupt_metadata["details"] = dict(details)
+            if resolution is not None:
+                interrupt_metadata["resolution"] = resolution
             sequence = stream_state.next_sequence()
             await event_queue.enqueue_event(
                 TaskStatusUpdateEvent(
@@ -1115,9 +1132,7 @@ class OpencodeAgentExecutor(AgentExecutor):
                             "sequence": sequence,
                         },
                         interrupt={
-                            "request_id": request_id,
-                            "type": interrupt_type,
-                            "details": dict(details),
+                            **interrupt_metadata,
                         },
                     ),
                 )
@@ -1326,17 +1341,28 @@ class OpencodeAgentExecutor(AgentExecutor):
                                         state=TaskState.input_required,
                                         request_id=request_id,
                                         interrupt_type=asked["interrupt_type"],
+                                        phase="asked",
                                         details=asked["details"],
                                     )
                             resolved = _extract_interrupt_resolved_event(event)
                             if resolved is not None:
                                 resolved_request_id = resolved["request_id"]
-                                stream_state.clear_interrupt_pending(resolved_request_id)
+                                cleared_pending = stream_state.clear_interrupt_pending(
+                                    resolved_request_id
+                                )
                                 discard_request = getattr(
                                     self._client, "discard_interrupt_request", None
                                 )
                                 if callable(discard_request):
                                     discard_request(resolved_request_id)
+                                if cleared_pending:
+                                    await _emit_interrupt_status(
+                                        state=TaskState.working,
+                                        request_id=resolved_request_id,
+                                        interrupt_type=resolved["interrupt_type"],
+                                        phase="resolved",
+                                        resolution=resolved["resolution"],
+                                    )
                         if event_type not in {"message.part.updated", "message.part.delta"}:
                             continue
                         part = props.get("part")
@@ -1842,7 +1868,14 @@ def _extract_interrupt_resolved_event(event: Mapping[str, Any]) -> dict[str, str
     request_id = _extract_interrupt_resolved_request_id(props)
     if not request_id:
         return None
-    return {"request_id": request_id, "event_type": event_type}
+    interrupt_type = "permission" if event_type.startswith("permission.") else "question"
+    resolution = "rejected" if event_type == "question.rejected" else "replied"
+    return {
+        "request_id": request_id,
+        "event_type": event_type,
+        "interrupt_type": interrupt_type,
+        "resolution": resolution,
+    }
 
 
 def _extract_stream_message_id(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -727,6 +727,7 @@ async def test_streaming_emits_interrupt_status_for_permission_asked_event() -> 
     assert len(interrupt_statuses) == 1
     interrupt = _interrupt_meta(interrupt_statuses[0])
     assert interrupt["request_id"] == "perm-req-1"
+    assert interrupt["phase"] == "asked"
     assert interrupt["details"]["permission"] == "read"
     assert "/data/project/.env.secret" in interrupt["details"]["patterns"]
     assert "metadata" not in interrupt["details"]
@@ -762,6 +763,7 @@ async def test_streaming_emits_interrupt_status_for_question_asked_event() -> No
     assert len(interrupt_statuses) == 1
     interrupt = _interrupt_meta(interrupt_statuses[0])
     assert interrupt["request_id"] == "q-req-1"
+    assert interrupt["phase"] == "asked"
     assert interrupt["details"]["questions"] == [
         {
             "header": "Confirm",
@@ -885,12 +887,69 @@ async def test_streaming_resolved_interrupt_only_clears_internal_pending_state()
         and event.final is False
         and (event.metadata or {}).get("shared", {}).get("interrupt") is not None
     ]
-    assert len(interrupt_statuses) == 1
-    assert _interrupt_meta(interrupt_statuses[0])["request_id"] == "perm-req-resolve"
+    assert len(interrupt_statuses) == 2
+    asked_interrupt = _interrupt_meta(interrupt_statuses[0])
+    resolved_interrupt = _interrupt_meta(interrupt_statuses[1])
+    assert asked_interrupt["request_id"] == "perm-req-resolve"
+    assert asked_interrupt["phase"] == "asked"
+    assert interrupt_statuses[0].status.state == TaskState.input_required
+    assert resolved_interrupt["request_id"] == "perm-req-resolve"
+    assert resolved_interrupt["type"] == "permission"
+    assert resolved_interrupt["phase"] == "resolved"
+    assert resolved_interrupt["resolution"] == "replied"
+    assert "details" not in resolved_interrupt
+    assert interrupt_statuses[1].status.state == TaskState.working
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
     assert "interrupt" not in (final_status.metadata or {}).get("shared", {})
+
+
+@pytest.mark.asyncio
+async def test_streaming_duplicate_interrupt_resolved_event_is_not_emitted_twice() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            _question_asked_event(session_id="ses-1", request_id="q-req-resolve"),
+            _interrupt_resolved_event(
+                session_id="ses-1",
+                request_id="q-req-resolve",
+                event_type="question.rejected",
+            ),
+            _interrupt_resolved_event(
+                session_id="ses-1",
+                request_id="q-req-resolve",
+                event_type="question.rejected",
+            ),
+            _event(session_id="ses-1", role="assistant", part_type="text", delta="answer"),
+        ],
+        response_text="answer",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    await executor.execute(
+        make_request_context(
+            task_id="task-interrupt-resolved-dedupe",
+            context_id="ctx-interrupt-resolved-dedupe",
+            text="hello",
+        ),
+        queue,
+    )
+
+    interrupt_statuses = [
+        event
+        for event in queue.events
+        if isinstance(event, TaskStatusUpdateEvent)
+        and event.final is False
+        and (event.metadata or {}).get("shared", {}).get("interrupt") is not None
+    ]
+    assert len(interrupt_statuses) == 2
+    assert _interrupt_meta(interrupt_statuses[0])["phase"] == "asked"
+    resolved_interrupt = _interrupt_meta(interrupt_statuses[1])
+    assert resolved_interrupt["phase"] == "resolved"
+    assert resolved_interrupt["type"] == "question"
+    assert resolved_interrupt["resolution"] == "rejected"
 
 
 def _unique(items: list[str]) -> list[str]:


### PR DESCRIPTION
## 背景
- 当前服务端在收到 `permission.replied` / `question.replied` / `question.rejected` 时，只清理内部 pending interrupt 状态，不会向下游显式外发 resolved 信号。
- 这会让消费方难以稳定实现“中断已解除 / 已恢复执行 / 已被拒绝”的用户可见状态。
- 本 PR 对应 issue #159，目标是在不破坏现有 interrupt asked 契约的前提下，为 resolved 阶段增加明确、可关联、可去重的对外状态事件。

## 变更说明
### 模块一：interrupt 运行时协议
- 保持 `permission.asked` / `question.asked` 继续输出 `TaskStatusUpdateEvent(final=false, state=input-required)`。
- 为 asked 事件补充稳定字段 `metadata.shared.interrupt.phase=asked`，让 interrupt 生命周期有显式起点。
- 为 resolved 事件新增输出：
  - `permission.replied`
  - `question.replied`
  - `question.rejected`
- resolved 统一映射为 `TaskStatusUpdateEvent(final=false, state=working)`。
- resolved 事件在 `metadata.shared.interrupt` 中补充：
  - `request_id`
  - `type`
  - `phase=resolved`
  - `resolution=replied|rejected`

### 模块二：幂等与去重语义
- 仅当对应 `request_id` 当前仍处于 pending 状态时，才外发 resolved 事件。
- 对重复 resolved、未知 request 或已清理 request 的 resolved 事件进行抑制，避免下游状态机重复推进。
- 保持 resolved 事件与 asked 事件通过同一个 `request_id` 关联，便于消费方做一一配对。

### 模块三：测试与文档
- 更新流式契约测试，校验 asked 事件显式携带 `phase=asked`。
- 新增 resolved 事件测试，校验：
  - asked + resolved 成对输出
  - resolved 事件的 `phase` / `resolution` 字段
  - resolved 使用 `state=working`
  - 重复 resolved 不会重复外发
- 更新 `docs/guide.md`，明确 interrupt asked/resolved 的输出契约与去重规则。

### 模块四：下游接入评估（a2a-client-hub）
- 结合 `/home/juanjuan/a2a-client-hub` 现有实现评估：
  - 在不修改下游代码的情况下，Hub 收到本次新增的 resolved 状态后，已经可以自动清空悬挂的 `pendingInterrupt` UI。
  - 如果 Hub 想显式向用户展示“中断已解除 / 已恢复执行 / 已被拒绝”，仍需要下游继续消费 `phase` / `resolution` 字段，并为其增加 toast、banner 或 timeline 状态。
- 也就是说，本 PR 先把协议面能力补齐；下游 richer UX 仍需单独接入实现。

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
- 结果：`163 passed`，coverage `84.48%`

## 关联
- Closes #159
- Relates to #158
- Relates to https://github.com/liujuanjuan1984/a2a-client-hub/issues/450
