### PR TITLE
security(init-system): pin uv bootstrap and remove remote NodeSource scripts (#149)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,9 +133,9 @@
         "filename": "scripts/init_system.sh",
         "hashed_secret": "96183ea4ff07d786ed3233777364ddbf14eb74cc",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 23
       }
     ]
   },
-  "generated_at": "2026-02-24T14:14:56Z"
+  "generated_at": "2026-03-13T14:03:33Z"
 }

--- a/scripts/init_system.sh
+++ b/scripts/init_system.sh
@@ -3,6 +3,10 @@
 # Initialize host prerequisites for OpenCode + A2A (idempotent).
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./init_system_uv_release_manifest.sh
+source "${SCRIPT_DIR}/init_system_uv_release_manifest.sh"
+
 OPENCODE_CORE_DIR="/opt/.opencode"
 SHARED_WRAPPER_DIR="/opt/opencode-a2a"
 OPENCODE_A2A_DIR="${SHARED_WRAPPER_DIR}/opencode-a2a-server"
@@ -18,16 +22,6 @@ OPENCODE_INSTALLER_URL="https://opencode.ai/install"
 OPENCODE_INSTALLER_VERSION="1.2.5"
 OPENCODE_INSTALLER_SHA256="fc3c1b2123f49b6df545a7622e5127d21cd794b15134fc3b66e1ca49f7fb297e"
 OPENCODE_INSTALL_CMD="--version ${OPENCODE_INSTALLER_VERSION}"
-UV_VERSION="0.10.7"
-UV_RELEASE_BASE_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}"
-UV_TARBALL_X86_64_GNU="uv-x86_64-unknown-linux-gnu.tar.gz"
-UV_TARBALL_X86_64_GNU_SHA256="9ac6cee4e379a5abfca06e78a777b26b7ba1f81cb7935b97054d80d85ac00774" # pragma: allowlist secret
-UV_TARBALL_X86_64_MUSL="uv-x86_64-unknown-linux-musl.tar.gz"
-UV_TARBALL_X86_64_MUSL_SHA256="992529add6024e67135b1c80617abd2eca7be2cf0b99b3911f923de815bd8dc1" # pragma: allowlist secret
-UV_TARBALL_AARCH64_GNU="uv-aarch64-unknown-linux-gnu.tar.gz"
-UV_TARBALL_AARCH64_GNU_SHA256="20efc27d946860093650bcf26096a016b10fdaf03b13c33b75fbde02962beea9" # pragma: allowlist secret
-UV_TARBALL_AARCH64_MUSL="uv-aarch64-unknown-linux-musl.tar.gz"
-UV_TARBALL_AARCH64_MUSL_SHA256="115291f9943531a3b63db3a2eabda8b74b8da4831551679382cb309c9debd9f7" # pragma: allowlist secret
 
 # Feature toggles.
 INSTALL_PACKAGES="true"

--- a/scripts/init_system_readme.md
+++ b/scripts/init_system_readme.md
@@ -28,22 +28,22 @@ The script does not accept runtime arguments. Adjust defaults by editing constan
 - Paths: `OPENCODE_CORE_DIR`, `SHARED_WRAPPER_DIR`, `UV_PYTHON_DIR`, `DATA_ROOT`
 - Repo and branch: `OPENCODE_A2A_REPO`, `OPENCODE_A2A_BRANCH`
 - Toggles: `INSTALL_PACKAGES`, `INSTALL_UV`, `INSTALL_GH`, `INSTALL_NODE`
-- Versions: `NODE_MAJOR`, `UV_VERSION`, `UV_PYTHON_VERSIONS`
+- Versions: `NODE_MAJOR`, `UV_PYTHON_VERSIONS`
 - Installer pinning: `OPENCODE_INSTALLER_URL`, `OPENCODE_INSTALLER_VERSION`, `OPENCODE_INSTALLER_SHA256`, `OPENCODE_INSTALL_CMD`
-- uv release pinning: `UV_RELEASE_BASE_URL`, `UV_TARBALL_*`, `UV_TARBALL_*_SHA256`
+- uv release pinning: [`init_system_uv_release_manifest.sh`](./init_system_uv_release_manifest.sh)
 
 ## Current Trust Model
 
 - `gh`: installed from distro package manager or package-manager-backed vendor repo configuration
 - Node.js: installed only from the distro package manager; the script no longer executes NodeSource setup scripts
-- `uv`: installed from a pinned upstream GitHub release tarball with an embedded SHA256 allowlist
+- `uv`: installed from a pinned upstream GitHub release tarball, with static asset/checksum data sourced from `init_system_uv_release_manifest.sh`
 - OpenCode: installer is still a remote script, but it is version-pinned and checksum-verified before execution
 - repo bootstrap: clone still trusts the configured git remote + branch head
 
 ## Recommended Secure Mode
 
 - keep installer pinning/checksum verification enabled
-- keep `uv` release pinning aligned with the exact release assets you intend to trust
+- keep `init_system_uv_release_manifest.sh` aligned with the exact `uv` release assets you intend to trust
 - prefer distro package mirrors or internal mirrors for Node.js instead of adding ad-hoc third-party setup scripts
 - keep `/opt/uv-python` in controlled group mode (`770` -> `750` hardening flow)
 - set `UV_PYTHON_DIR_GROUP` to a controlled group and add runtime users intentionally

--- a/scripts/init_system_uv_release_manifest.sh
+++ b/scripts/init_system_uv_release_manifest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Pinned uv release assets used by scripts/init_system.sh.
+
+UV_VERSION="0.10.7"
+UV_RELEASE_BASE_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}"
+
+UV_TARBALL_X86_64_GNU="uv-x86_64-unknown-linux-gnu.tar.gz"
+UV_TARBALL_X86_64_GNU_SHA256="9ac6cee4e379a5abfca06e78a777b26b7ba1f81cb7935b97054d80d85ac00774" # pragma: allowlist secret
+
+UV_TARBALL_X86_64_MUSL="uv-x86_64-unknown-linux-musl.tar.gz"
+UV_TARBALL_X86_64_MUSL_SHA256="992529add6024e67135b1c80617abd2eca7be2cf0b99b3911f923de815bd8dc1" # pragma: allowlist secret
+
+UV_TARBALL_AARCH64_GNU="uv-aarch64-unknown-linux-gnu.tar.gz"
+UV_TARBALL_AARCH64_GNU_SHA256="20efc27d946860093650bcf26096a016b10fdaf03b13c33b75fbde02962beea9" # pragma: allowlist secret
+
+UV_TARBALL_AARCH64_MUSL="uv-aarch64-unknown-linux-musl.tar.gz"
+UV_TARBALL_AARCH64_MUSL_SHA256="115291f9943531a3b63db3a2eabda8b74b8da4831551679382cb309c9debd9f7" # pragma: allowlist secret

--- a/tests/test_init_system_security.py
+++ b/tests/test_init_system_security.py
@@ -3,21 +3,23 @@ from pathlib import Path
 
 INIT_SYSTEM_PATH = Path("scripts/init_system.sh")
 INIT_SYSTEM_TEXT = INIT_SYSTEM_PATH.read_text()
+UV_MANIFEST_PATH = Path("scripts/init_system_uv_release_manifest.sh")
+UV_MANIFEST_TEXT = UV_MANIFEST_PATH.read_text()
 
 
-def _extract_var(var_name: str) -> str:
-    match = re.search(rf"^{var_name}=\"([^\"]*)\"", INIT_SYSTEM_TEXT, re.MULTILINE)
+def _extract_var(text: str, var_name: str) -> str:
+    match = re.search(rf"^{var_name}=\"([^\"]*)\"", text, re.MULTILINE)
     if not match:
-        msg = f"Missing constant {var_name} in scripts/init_system.sh"
+        msg = f"Missing constant {var_name}"
         raise AssertionError(msg)
     return match.group(1)
 
 
 def test_opencode_install_flow_is_pinned_and_verified() -> None:
-    url = _extract_var("OPENCODE_INSTALLER_URL")
-    version = _extract_var("OPENCODE_INSTALLER_VERSION")
-    checksum = _extract_var("OPENCODE_INSTALLER_SHA256")
-    install_cmd = _extract_var("OPENCODE_INSTALL_CMD")
+    url = _extract_var(INIT_SYSTEM_TEXT, "OPENCODE_INSTALLER_URL")
+    version = _extract_var(INIT_SYSTEM_TEXT, "OPENCODE_INSTALLER_VERSION")
+    checksum = _extract_var(INIT_SYSTEM_TEXT, "OPENCODE_INSTALLER_SHA256")
+    install_cmd = _extract_var(INIT_SYSTEM_TEXT, "OPENCODE_INSTALL_CMD")
 
     assert url == "https://opencode.ai/install"
     assert version
@@ -26,6 +28,7 @@ def test_opencode_install_flow_is_pinned_and_verified() -> None:
     assert "bash -" not in install_cmd
     assert "--version" in install_cmd
     assert "curl -fsSL https://opencode.ai/install | bash" not in INIT_SYSTEM_TEXT
+    assert 'source "${SCRIPT_DIR}/init_system_uv_release_manifest.sh"' in INIT_SYSTEM_TEXT
     assert 'download_file "$OPENCODE_INSTALLER_URL"' in INIT_SYSTEM_TEXT
     assert (
         'verify_file_checksum "$opencode_install_script" "$OPENCODE_INSTALLER_SHA256"'
@@ -34,8 +37,8 @@ def test_opencode_install_flow_is_pinned_and_verified() -> None:
 
 
 def test_uv_install_flow_is_pinned_to_release_tarballs() -> None:
-    version = _extract_var("UV_VERSION")
-    base_url = _extract_var("UV_RELEASE_BASE_URL")
+    version = _extract_var(UV_MANIFEST_TEXT, "UV_VERSION")
+    base_url = _extract_var(UV_MANIFEST_TEXT, "UV_RELEASE_BASE_URL")
 
     assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version)
     assert base_url == "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}"
@@ -48,7 +51,7 @@ def test_uv_install_flow_is_pinned_to_release_tarballs() -> None:
         "UV_TARBALL_AARCH64_GNU_SHA256",
         "UV_TARBALL_AARCH64_MUSL_SHA256",
     ):
-        assert re.fullmatch(r"[0-9a-f]{64}", _extract_var(checksum_var))
+        assert re.fullmatch(r"[0-9a-f]{64}", _extract_var(UV_MANIFEST_TEXT, checksum_var))
 
 
 def test_node_install_flow_avoids_remote_setup_scripts() -> None:
@@ -64,8 +67,8 @@ def _parse_octal_mode(mode: str) -> int:
 
 
 def test_uv_python_default_permissions_are_not_world_writable() -> None:
-    initial_mode = _extract_var("UV_PYTHON_DIR_MODE")
-    final_mode = _extract_var("UV_PYTHON_DIR_FINAL_MODE")
+    initial_mode = _extract_var(INIT_SYSTEM_TEXT, "UV_PYTHON_DIR_MODE")
+    final_mode = _extract_var(INIT_SYSTEM_TEXT, "UV_PYTHON_DIR_FINAL_MODE")
     mode_groups = _parse_octal_mode(initial_mode), _parse_octal_mode(final_mode)
     for mode in mode_groups:
         assert mode & 0o002 == 0


### PR DESCRIPTION
## 背景
本 PR 基于 `#149` 收窄后的范围，聚焦 `scripts/init_system.sh` 中仍然存在的两条“下载脚本后执行”链路：
- Node.js 的 NodeSource setup script
- `uv` 的远程 installer shell script

相关提交：
- `7173d6b security(init-system): harden node and uv bootstrap paths (#149)`
- `05931f6 refactor(init-system): move uv release pins into static manifest (#149)`

## 按模块说明
### 1. `scripts/init_system.sh`
- 移除 NodeSource setup script 的远程执行路径。
- Node.js 改为只信任发行版包管理器安装；若无法满足 `NODE_MAJOR`，则 fail-closed 并提示人工兜底。
- `uv` 安装逻辑改为读取仓库内静态清单，执行固定官方 release tarball + SHA256 校验 + 本地解包安装。
- 保留 OpenCode installer 的版本 pin + SHA256 校验逻辑。
- 不在本 PR 内扩展到 repo clone 的版本 pin 策略；该部分转由 `#178` 跟进。

### 2. `scripts/init_system_uv_release_manifest.sh`
- 新增 `uv` 静态清单文件。
- 将 `uv` 版本、release 基址、受信资产名与 SHA256 从主脚本中抽离。
- 保持当前供应链 pin 安全模型不变，只优化数据与脚本逻辑分层。

### 3. `scripts/init_system_readme.md`
- 补充当前 trust model。
- 补充失败回退与人工兜底流程。
- 明确 `uv` 静态清单文件和 Node.js 包管理器安装的推荐方式。

### 4. `tests/test_init_system_security.py`
- 增加 `uv` release pin / checksum 的安全契约测试。
- 增加“Node.js 不再执行远程 setup script”的约束测试。
- 同步调整 OpenCode installer 下载 helper 断言。
- 调整测试以覆盖新的静态清单文件结构。

## 回归
- `bash -n scripts/init_system.sh scripts/init_system_uv_release_manifest.sh`
- `uv run pre-commit run --all-files`
- `uv run pytest`

## 关联
- Closes #149
- Relates to #145
- Relates to #178
- Relates to #180
