### PR TITLE
docs: define parameterized self-deployment contract (#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,7 @@ Detailed consumption guidance:
 One `OpenCode + opencode-a2a-server` instance pair is treated as a
 single-tenant trust boundary.
 
-This repository's intended scaling model is parameterized self-deployment:
-consumers should launch their own isolated instance pairs through the provided
-deployment scripts instead of sharing one runtime across mutually untrusted
-tenants.
+This repository's intended scaling model is parameterized self-deployment: consumers should launch their own isolated instance pairs through the provided deployment scripts instead of sharing one runtime across mutually untrusted tenants.
 
 - OpenCode may manage multiple projects/directories, but one deployed instance
   is not a secure multi-tenant runtime.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,9 +13,7 @@ not fully isolate upstream model credentials from OpenCode runtime behavior.
   tenant-isolation boundary inside one deployed instance.
 - One `OpenCode + opencode-a2a-server` instance pair is treated as a
   single-tenant trust boundary by design.
-- Tenant isolation across consumers is expected to come from parameterized
-  self-deployment of separate instance pairs with distinct Linux users,
-  workspace roots, credentials, and runtime ports.
+- Tenant isolation across consumers is expected to come from parameterized self-deployment of separate instance pairs with distinct Linux users, workspace roots, credentials, and runtime ports.
 - Within one instance, consumers share the same underlying OpenCode
   workspace/environment by default.
 - LLM provider keys are consumed by the `opencode` process. Prompt injection or

--- a/scripts/deploy_light_readme.md
+++ b/scripts/deploy_light_readme.md
@@ -13,9 +13,6 @@ This script does **not** replace the systemd deployment flow:
 - It is best suited for single-user or small-team environments that already trust the current host user and workspace.
 
 For production-oriented multi-instance deployment, continue using [`deploy.sh`](./deploy_readme.md).
-For trusted local automation, this script is the lightweight parameterized
-self-deployment entry point when the caller already controls the current Linux
-user and workspace root.
 
 ## Usage
 

--- a/scripts/deploy_readme.md
+++ b/scripts/deploy_readme.md
@@ -28,13 +28,11 @@ For one-time host bootstrap, see [`init_system_readme.md`](./init_system_readme.
 
 ## Parameterized Self-Deployment Contract
 
-`deploy.sh` is the systemd-oriented entry point for parameterized
-self-deployment in trusted operator environments.
+`deploy.sh` is the systemd-oriented entry point for parameterized self-deployment in trusted operator environments.
 
 Its contract is intentionally simple:
 
-- accept non-interactive `key=value` inputs while keeping secrets in env vars
-  or root-only files
+- accept non-interactive `key=value` inputs while keeping secrets in env vars or root-only files
 - provision or update one isolated instance directory per `project`
 - install/start the corresponding systemd units for that instance
 - exit non-zero when validation, setup, or service startup fails


### PR DESCRIPTION
## 变更范围

### README.md
- 明确仓库的扩展方式是参数化自部署，而不是在单个实例内追求多租户共享。
- 补充单租户实例对的隔离建议，强调应通过独立用户、工作区、凭据和端口进行隔离。

### SECURITY.md
- 将“租户隔离依赖独立实例对”写入安全边界说明。
- 让安全模型与单租户自部署策略保持一致。

### scripts/deploy_readme.md
- 补充 `deploy.sh` 作为 systemd 自部署入口的契约说明。
- 仅描述当前脚本已经具备的输入、部署和失败语义，不扩写未实现能力。

### scripts/deploy_light_readme.md
- 补充 `deploy_light.sh` 在受信任本地自动化场景下的参数化自部署定位。
- 保持与 #181 已合并的 foreground launcher 语义一致，不回退旧行为。

## Issue 关系

- Closes #145

