### PR TITLE
chore: share health-check script prerequisites

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,11 +23,12 @@ Executable scripts live in this directory. This file is the entry index for scri
 
 ## Other Scripts
 
-- [`doctor.sh`](./doctor.sh): local environment consistency checks
-- [`dependency_health.sh`](./dependency_health.sh): dependency health checks
+- [`doctor.sh`](./doctor.sh): local development regression entrypoint (`sync`/`pip check` + lint + tests)
+- [`dependency_health.sh`](./dependency_health.sh): dependency review entrypoint (`sync`/`pip check` + outdated + audit)
 - [`lint.sh`](./lint.sh): lint helper
 
 ## Notes
 
 - `deploy/` contains helper scripts orchestrated by `deploy.sh` and `deploy_release.sh`.
+- `doctor.sh` and `dependency_health.sh` intentionally remain separate entrypoints and share common prerequisites through [`health_common.sh`](./health_common.sh).
 - Keep script behavior details in `scripts/*_readme.md` to avoid drift.

--- a/scripts/dependency_health.sh
+++ b/scripts/dependency_health.sh
@@ -1,19 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
+# shellcheck source=./health_common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"
 
-if ! command -v uv >/dev/null 2>&1; then
-  echo "uv not found in PATH" >&2
-  exit 1
-fi
-
-echo "[dependency-health] sync locked environment"
-uv sync --all-extras --frozen
-
-echo "[dependency-health] verify dependency compatibility"
-uv pip check
+run_shared_repo_health_prerequisites "dependency-health"
 
 echo "[dependency-health] list outdated packages"
 uv pip list --outdated

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,19 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
+# shellcheck source=./health_common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"
 
-if ! command -v uv >/dev/null 2>&1; then
-  echo "uv not found in PATH" >&2
-  exit 1
-fi
-
-echo "[doctor] sync locked environment"
-uv sync --all-extras --frozen
-
-echo "[doctor] verify dependency compatibility"
-uv pip check
+run_shared_repo_health_prerequisites "doctor"
 
 echo "[doctor] run lint"
 uv run pre-commit run --all-files

--- a/scripts/health_common.sh
+++ b/scripts/health_common.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Shared prerequisites for local repo health-check scripts.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+run_shared_repo_health_prerequisites() {
+  local label="${1:-health}"
+
+  cd "$ROOT_DIR"
+
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "uv not found in PATH" >&2
+    exit 1
+  fi
+
+  echo "[${label}] sync locked environment"
+  uv sync --all-extras --frozen
+
+  echo "[${label}] verify dependency compatibility"
+  uv pip check
+}

--- a/tests/test_script_health_contract.py
+++ b/tests/test_script_health_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
+DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
+HEALTH_COMMON_TEXT = Path("scripts/health_common.sh").read_text()
+SCRIPTS_INDEX_TEXT = Path("scripts/README.md").read_text()
+
+
+def test_shared_repo_health_prerequisites_live_in_common_helper() -> None:
+    assert "run_shared_repo_health_prerequisites()" in HEALTH_COMMON_TEXT
+    assert 'echo "[${label}] sync locked environment"' in HEALTH_COMMON_TEXT
+    assert 'echo "[${label}] verify dependency compatibility"' in HEALTH_COMMON_TEXT
+    assert "uv sync --all-extras --frozen" in HEALTH_COMMON_TEXT
+    assert "uv pip check" in HEALTH_COMMON_TEXT
+
+
+def test_doctor_keeps_local_regression_scope() -> None:
+    assert 'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"' in DOCTOR_TEXT
+    assert 'run_shared_repo_health_prerequisites "doctor"' in DOCTOR_TEXT
+    assert "uv run pre-commit run --all-files" in DOCTOR_TEXT
+    assert "uv run pytest" in DOCTOR_TEXT
+    assert "uv pip list --outdated" not in DOCTOR_TEXT
+    assert "uv run pip-audit" not in DOCTOR_TEXT
+
+
+def test_dependency_health_keeps_dependency_review_scope() -> None:
+    assert (
+        'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"'
+        in DEPENDENCY_HEALTH_TEXT
+    )
+    assert 'run_shared_repo_health_prerequisites "dependency-health"' in DEPENDENCY_HEALTH_TEXT
+    assert "uv pip list --outdated" in DEPENDENCY_HEALTH_TEXT
+    assert "uv run pip-audit" in DEPENDENCY_HEALTH_TEXT
+    assert "uv run pytest" not in DEPENDENCY_HEALTH_TEXT
+    assert "uv run pre-commit run --all-files" not in DEPENDENCY_HEALTH_TEXT
+
+
+def test_scripts_index_documents_split_health_entrypoints() -> None:
+    assert "local development regression entrypoint" in SCRIPTS_INDEX_TEXT
+    assert "dependency review entrypoint" in SCRIPTS_INDEX_TEXT
+    assert "health_common.sh" in SCRIPTS_INDEX_TEXT


### PR DESCRIPTION
## 变更概览

本 PR 收敛 `doctor.sh` 与 `dependency_health.sh` 的重复前置逻辑，保留两个清晰入口，但不再复制实现。

Closes #198

## 脚本模块

- 新增 `scripts/health_common.sh`，统一承接本地健康检查脚本的公共前置步骤：
  - 进入仓库根目录
  - 校验 `uv` 是否存在
  - 执行 `uv sync --all-extras --frozen`
  - 执行 `uv pip check`
- `scripts/doctor.sh` 改为调用共享 helper，继续只负责本地开发回归：lint + pytest
- `scripts/dependency_health.sh` 改为调用共享 helper，继续只负责依赖巡检：outdated + pip-audit

## 测试模块

- 新增 `tests/test_script_health_contract.py`
- 覆盖共享 helper 的存在与职责
- 覆盖 `doctor.sh` 与 `dependency_health.sh` 的职责边界，防止后续再次回到复制实现

## 文档模块

- 更新 `scripts/README.md`
- 明确两个入口脚本的用途差异
- 说明它们通过共享 helper 收敛公共前置逻辑

## 验证

- `bash -n scripts/health_common.sh scripts/doctor.sh scripts/dependency_health.sh`
- `uv run pre-commit run --all-files`
- `uv run pytest`
