### PR TITLE
docs: formalize DataPart input rejection policy

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -151,7 +151,7 @@ curl -sS http://127.0.0.1:8000/ \
 Current compatibility note:
 
 - `TextPart` and `FilePart` are supported.
-- `DataPart` is rejected with an explicit error until a stable mapping policy is defined.
+- `DataPart` input is not supported and is rejected with an explicit error.
 
 ## Extension Capability Overview
 

--- a/src/opencode_a2a_server/parts_mapper.py
+++ b/src/opencode_a2a_server/parts_mapper.py
@@ -85,7 +85,7 @@ def map_a2a_parts_to_opencode_parts(parts: Any) -> list[OpencodeInputPart]:
 
         if kind == "data":
             raise UnsupportedA2AInputError(
-                f"request.parts[{index}] DataPart is not supported yet; use TextPart or FilePart."
+                f"request.parts[{index}] DataPart input is not supported; use TextPart or FilePart."
             )
 
         raise UnsupportedA2AInputError(

--- a/tests/test_multipart_input.py
+++ b/tests/test_multipart_input.py
@@ -167,4 +167,4 @@ async def test_execute_rejects_data_parts() -> None:
     assert client.sent_calls == []
     task = queue.events[-1]
     assert task.status.state.name == "failed"
-    assert "DataPart is not supported yet" in task.status.message.parts[0].root.text
+    assert "DataPart input is not supported" in task.status.message.parts[0].root.text


### PR DESCRIPTION
## 变更概览

本 PR 收敛 `DataPart` 输入策略的措辞，使当前实现、测试与文档统一表达为正式决策，而不是临时态表述。

Relates to #195

## 代码模块

- 更新 `src/opencode_a2a_server/parts_mapper.py`
- 将 `DataPart is not supported yet` 调整为正式策略表述：`DataPart input is not supported`

## 测试模块

- 更新 `tests/test_multipart_input.py`
- 使错误断言与正式策略文案保持一致

## 文档模块

- 更新 `docs/guide.md`
- 明确当前输入契约只支持 `TextPart` / `FilePart`
- 明确 `DataPart` 输入当前不支持，并返回显式错误

## 背景

`#195` 已完成策略收敛并关闭：当前不支持输入 `DataPart`，且短期也不计划支持。
本 PR 仅负责把代码、测试和文档里的临时态措辞收敛为正式决策表述。

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
