### PR TITLE
chore: align interoperability contracts with runtime truth (#204, #207)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -114,35 +114,81 @@ Key variables to understand protocol behavior:
 - Agent Card declares OAuth2 only when both
   `A2A_OAUTH_AUTHORIZATION_URL` and `A2A_OAUTH_TOKEN_URL` are set.
 
-## Compatibility Profile & Wire Contract (A2A Extensions)
+## Wire Contract
 
-To help generic A2A clients and developers understand the interoperability baseline and runtime method boundaries of this deployment, the service exposes two metadata extensions:
+The service publishes a machine-readable wire contract through Agent Card and
+OpenAPI metadata to describe the current runtime method boundary.
 
-- **Compatibility Profile** (`urn:a2a:compatibility-profile/v1`)
-  - Defines the core baseline (JSON-RPC methods and HTTP endpoints).
-  - Specifies extension retention policy (e.g., `stable`).
-  - Highlights deployment-conditional method behavior.
-- **Wire Contract** (`urn:a2a:wire-contract/v1`)
-  - Declares the exact set of supported JSON-RPC methods and HTTP endpoints.
-  - Flags conditionally available methods (e.g., `opencode.sessions.shell` if disabled by config).
-  - Defines the unified error contract for unsupported methods.
+Use it to answer:
 
-### Discovery Guidance
+- which JSON-RPC methods are part of the current A2A core baseline
+- which JSON-RPC methods are custom extensions
+- which methods are deployment-conditional rather than currently active
+- what error shape is returned for unsupported JSON-RPC methods
 
-Clients should prioritize Agent Card discovery to determine which profile and wire-level capabilities are active. Both extensions are also injected into the OpenAPI definition under `x-a2a-extension-contracts` at the `POST /` path.
+Current behavior:
 
-### Unified Unsupported Method Error
+- Core JSON-RPC methods are declared under `core.jsonrpc_methods`.
+- Core HTTP endpoints are declared under `core.http_endpoints`.
+- Extension JSON-RPC methods are declared under `extensions.jsonrpc_methods`.
+- Deployment-conditional methods are declared under
+  `extensions.conditionally_available_methods`.
+- Shared metadata extension URIs such as session binding, model selection, and
+  streaming are listed under `extensions.extension_uris`.
+- `all_jsonrpc_methods` is the runtime truth for the current deployment.
 
-When a client calls a JSON-RPC method that is not supported by the current deployment, the service returns a unified `-32601` error with discovery hints:
+When `A2A_ENABLE_SESSION_SHELL=false`, `opencode.sessions.shell` is omitted from
+`all_jsonrpc_methods` and exposed only through
+`extensions.conditionally_available_methods`.
 
-- `code`: `-32601`
-- `message`: `Unsupported method: <method>`
-- `data.type`: `METHOD_NOT_SUPPORTED`
-- `data.method`: the requested method name
-- `data.supported_methods`: list of all currently supported JSON-RPC methods
-- `data.protocol_version`: the service's protocol version
+Unsupported method contract:
 
-This allows clients to dynamically adjust their behavior or provide better diagnostic messages when a method is missing from the runtime boundary.
+- JSON-RPC error code: `-32601`
+- Error message: `Unsupported method: <method>`
+- Error data fields:
+  - `type=METHOD_NOT_SUPPORTED`
+  - `method`
+  - `supported_methods`
+  - `protocol_version`
+
+Consumer guidance:
+
+- Discover custom JSON-RPC methods from Agent Card / OpenAPI before calling
+  them.
+- Treat `supported_methods` in `error.data` as the runtime truth for the
+  current deployment, especially when a deployment-conditional method is
+  disabled.
+
+## Compatibility Profile
+
+The service also publishes a machine-readable compatibility profile through
+Agent Card and OpenAPI metadata.
+
+Its purpose is to declare:
+
+- the stable A2A core interoperability baseline
+- which custom JSON-RPC methods are deployment extensions
+- which extension surfaces are required runtime metadata contracts
+- which methods are deployment-conditional rather than always available
+
+Current profile shape:
+
+- `profile_id=opencode-a2a-baseline-v1`
+- Core methods and endpoints are declared under `core`.
+- Extension retention policy is declared under `extension_retention`.
+- Per-method retention and availability are declared under `method_retention`.
+
+Retention guidance:
+
+- Treat core A2A methods as the generic client interoperability baseline.
+- Treat session binding and streaming metadata contracts as required for the
+  current deployment model.
+- Treat shared model selection metadata as a stable runtime metadata contract
+  for the main chat path.
+- Treat `opencode.*` and `a2a.interrupt.*` JSON-RPC methods as declared custom
+  extensions that remain stable within the current major line.
+- Treat `opencode.sessions.shell` as deployment-conditional and discover it
+  from the declared profile and current wire contract before calling it.
 
 ## Multipart Input Example
 

--- a/src/opencode_a2a_server/app.py
+++ b/src/opencode_a2a_server/app.py
@@ -44,10 +44,18 @@ from starlette.responses import StreamingResponse
 from .agent import OpencodeAgentExecutor
 from .config import Settings
 from .extension_contracts import (
+    COMPATIBILITY_PROFILE_EXTENSION_URI,
+    INTERRUPT_CALLBACK_EXTENSION_URI,
     INTERRUPT_CALLBACK_METHODS,
+    MODEL_SELECTION_EXTENSION_URI,
+    PROVIDER_DISCOVERY_EXTENSION_URI,
     PROVIDER_DISCOVERY_METHODS,
+    SESSION_BINDING_EXTENSION_URI,
     SESSION_CONTROL_METHODS,
+    SESSION_QUERY_EXTENSION_URI,
     SESSION_QUERY_METHODS,
+    STREAMING_EXTENSION_URI,
+    WIRE_CONTRACT_EXTENSION_URI,
     build_compatibility_profile_params,
     build_interrupt_callback_extension_params,
     build_model_selection_extension_params,
@@ -55,6 +63,7 @@ from .extension_contracts import (
     build_session_binding_extension_params,
     build_session_query_extension_params,
     build_streaming_extension_params,
+    build_supported_jsonrpc_methods,
     build_wire_contract_params,
 )
 from .jsonrpc_ext import (
@@ -72,15 +81,6 @@ _REQUEST_BODY_BYTES: ContextVar[bytes | None] = ContextVar(
 
 if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
-
-SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
-MODEL_SELECTION_EXTENSION_URI = "urn:a2a:model-selection/v1"
-STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
-SESSION_QUERY_EXTENSION_URI = "urn:opencode-a2a:session-query/v1"
-PROVIDER_DISCOVERY_EXTENSION_URI = "urn:opencode-a2a:provider-discovery/v1"
-INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
-COMPATIBILITY_PROFILE_EXTENSION_URI = "urn:a2a:compatibility-profile/v1"
-WIRE_CONTRACT_EXTENSION_URI = "urn:a2a:wire-contract/v1"
 
 
 class OpencodeRequestHandler(DefaultRequestHandler):
@@ -314,23 +314,30 @@ def _build_chat_examples(project: str | None) -> list[str]:
     return examples
 
 
-def _build_jsonrpc_extension_openapi_description() -> str:
-    session_methods = ", ".join(sorted(SESSION_QUERY_METHODS.values()))
+def _build_jsonrpc_extension_openapi_description(*, session_shell_enabled: bool) -> str:
+    session_methods = [
+        SESSION_QUERY_METHODS["list_sessions"],
+        SESSION_QUERY_METHODS["get_session_messages"],
+        SESSION_QUERY_METHODS["prompt_async"],
+        SESSION_QUERY_METHODS["command"],
+    ]
+    if session_shell_enabled:
+        session_methods.append(SESSION_QUERY_METHODS["shell"])
     provider_methods = ", ".join(sorted(PROVIDER_DISCOVERY_METHODS.values()))
     interrupt_methods = ", ".join(sorted(INTERRUPT_CALLBACK_METHODS.values()))
     return (
         "A2A JSON-RPC entrypoint. Supports core A2A methods "
         "(message/send, message/stream, tasks/get, tasks/cancel, tasks/resubscribe) "
         "plus OpenCode session/provider extensions and shared interrupt callback methods.\n\n"
-        f"OpenCode session query/control methods: {session_methods}.\n"
+        f"OpenCode session query/control methods: {', '.join(session_methods)}.\n"
         f"OpenCode provider/model discovery methods: {provider_methods}.\n"
         f"Shared interrupt callback methods: {interrupt_methods}.\n\n"
         "Notification semantics: extension requests without JSON-RPC id return HTTP 204."
     )
 
 
-def _build_jsonrpc_extension_openapi_examples() -> dict[str, Any]:
-    return {
+def _build_jsonrpc_extension_openapi_examples(*, session_shell_enabled: bool) -> dict[str, Any]:
+    examples = {
         "message_send": {
             "summary": "Send message via JSON-RPC core method",
             "value": {
@@ -436,21 +443,6 @@ def _build_jsonrpc_extension_openapi_examples() -> dict[str, Any]:
                 },
             },
         },
-        "session_shell": {
-            "summary": "Run shell command in an existing session",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 23,
-                "method": SESSION_QUERY_METHODS["shell"],
-                "params": {
-                    "session_id": "s-1",
-                    "request": {
-                        "agent": "code-reviewer",
-                        "command": "git status --short",
-                    },
-                },
-            },
-        },
         "providers_list": {
             "summary": "List available OpenCode providers",
             "value": {
@@ -497,6 +489,23 @@ def _build_jsonrpc_extension_openapi_examples() -> dict[str, Any]:
             },
         },
     }
+    if session_shell_enabled:
+        examples["session_shell"] = {
+            "summary": "Run shell command in an existing session",
+            "value": {
+                "jsonrpc": "2.0",
+                "id": 23,
+                "method": SESSION_QUERY_METHODS["shell"],
+                "params": {
+                    "session_id": "s-1",
+                    "request": {
+                        "agent": "code-reviewer",
+                        "command": "git status --short",
+                    },
+                },
+            },
+        }
+    return examples
 
 
 def _build_rest_message_openapi_examples() -> dict[str, Any]:
@@ -573,6 +582,7 @@ def _patch_jsonrpc_openapi_contract(
     )
     compatibility_profile = build_compatibility_profile_params(
         protocol_version=settings.a2a_protocol_version,
+        deployment_context=deployment_context,
     )
     wire_contract = build_wire_contract_params(
         protocol_version=settings.a2a_protocol_version,
@@ -592,7 +602,9 @@ def _patch_jsonrpc_openapi_contract(
                 post = root_path.get("post")
                 if isinstance(post, dict):
                     post["summary"] = "Handle A2A JSON-RPC Requests"
-                    post["description"] = _build_jsonrpc_extension_openapi_description()
+                    post["description"] = _build_jsonrpc_extension_openapi_description(
+                        session_shell_enabled=bool(deployment_context.get("session_shell_enabled")),
+                    )
                     post["x-a2a-extension-contracts"] = {
                         "session_binding": session_binding,
                         "model_selection": model_selection,
@@ -610,7 +622,11 @@ def _patch_jsonrpc_openapi_contract(
                         if isinstance(content, dict):
                             app_json = content.setdefault("application/json", {})
                             if isinstance(app_json, dict):
-                                app_json["examples"] = _build_jsonrpc_extension_openapi_examples()
+                                app_json["examples"] = _build_jsonrpc_extension_openapi_examples(
+                                    session_shell_enabled=bool(
+                                        deployment_context.get("session_shell_enabled")
+                                    ),
+                                )
 
             rest_post_contracts: dict[str, dict[str, Any]] = {
                 "/v1/message:send": {
@@ -711,6 +727,7 @@ def build_agent_card(settings: Settings) -> AgentCard:
     )
     compatibility_profile_params = build_compatibility_profile_params(
         protocol_version=settings.a2a_protocol_version,
+        deployment_context=deployment_context,
     )
     wire_contract_params = build_wire_contract_params(
         protocol_version=settings.a2a_protocol_version,
@@ -924,23 +941,30 @@ def create_app(settings: Settings) -> FastAPI:
     agent_card = build_agent_card(settings)
     context_builder = IdentityAwareCallContextBuilder()
 
+    jsonrpc_methods = {
+        **SESSION_QUERY_METHODS,
+        **SESSION_CONTROL_METHODS,
+        **PROVIDER_DISCOVERY_METHODS,
+        **INTERRUPT_CALLBACK_METHODS,
+    }
+    if not settings.a2a_enable_session_shell:
+        jsonrpc_methods.pop("shell", None)
+
     # Build JSON-RPC app (POST / by default) and attach REST endpoints (HTTP+JSON) to the same app.
     app = OpencodeSessionQueryJSONRPCApplication(
         agent_card=agent_card,
         http_handler=handler,
         context_builder=context_builder,
         opencode_client=client,
-        enable_session_shell=settings.a2a_enable_session_shell,
+        protocol_version=settings.a2a_protocol_version,
+        supported_methods=build_supported_jsonrpc_methods(
+            session_shell_enabled=settings.a2a_enable_session_shell,
+        ),
         directory_resolver=executor.resolve_directory_for_control,
         session_claim=executor.claim_session_for_control,
         session_claim_finalize=executor.finalize_session_for_control,
         session_claim_release=executor.release_session_for_control,
-        methods={
-            **SESSION_QUERY_METHODS,
-            **SESSION_CONTROL_METHODS,
-            **PROVIDER_DISCOVERY_METHODS,
-            **INTERRUPT_CALLBACK_METHODS,
-        },
+        methods=jsonrpc_methods,
     ).build(title=settings.a2a_title, version=settings.a2a_version, lifespan=lifespan)
     app.state.opencode_agent_executor = executor
     deployment_context = _build_deployment_context(settings)

--- a/src/opencode_a2a_server/extension_contracts.py
+++ b/src/opencode_a2a_server/extension_contracts.py
@@ -11,6 +11,15 @@ SHARED_INTERRUPT_METADATA_FIELD = "metadata.shared.interrupt"
 SHARED_USAGE_METADATA_FIELD = "metadata.shared.usage"
 OPENCODE_DIRECTORY_METADATA_FIELD = "metadata.opencode.directory"
 
+SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
+MODEL_SELECTION_EXTENSION_URI = "urn:a2a:model-selection/v1"
+STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
+SESSION_QUERY_EXTENSION_URI = "urn:opencode-a2a:session-query/v1"
+PROVIDER_DISCOVERY_EXTENSION_URI = "urn:opencode-a2a:provider-discovery/v1"
+INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
+COMPATIBILITY_PROFILE_EXTENSION_URI = "urn:a2a:compatibility-profile/v1"
+WIRE_CONTRACT_EXTENSION_URI = "urn:a2a:wire-contract/v1"
+
 
 @dataclass(frozen=True)
 class SessionQueryMethodContract:
@@ -156,11 +165,30 @@ SESSION_CONTROL_METHODS: dict[str, str] = {
     key: SESSION_QUERY_METHODS[key] for key in SESSION_CONTROL_METHOD_KEYS
 }
 
+CORE_JSONRPC_METHODS: tuple[str, ...] = (
+    "message/send",
+    "message/stream",
+    "tasks/get",
+    "tasks/cancel",
+    "tasks/resubscribe",
+)
+CORE_HTTP_ENDPOINTS: tuple[str, ...] = (
+    "POST /v1/message:send",
+    "POST /v1/message:stream",
+    "GET /v1/tasks/{id}",
+    "POST /v1/tasks/{id}:cancel",
+    "GET /v1/tasks/{id}:subscribe",
+)
+WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS: tuple[str, ...] = (
+    "type",
+    "method",
+    "supported_methods",
+    "protocol_version",
+)
+
 SESSION_QUERY_ERROR_BUSINESS_CODES: dict[str, int] = {
     "SESSION_NOT_FOUND": -32001,
     "SESSION_FORBIDDEN": -32006,
-    "METHOD_DISABLED": -32007,
-    "METHOD_NOT_SUPPORTED": -32601,
     "UPSTREAM_UNREACHABLE": -32002,
     "UPSTREAM_HTTP_ERROR": -32003,
     "UPSTREAM_PAYLOAD_ERROR": -32005,
@@ -171,8 +199,6 @@ SESSION_QUERY_ERROR_DATA_FIELDS: tuple[str, ...] = (
     "session_id",
     "upstream_status",
     "detail",
-    "supported_methods",
-    "protocol_version",
 )
 SESSION_QUERY_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
     "type",
@@ -267,6 +293,21 @@ PROVIDER_DISCOVERY_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
     "field",
     "fields",
 )
+
+
+def build_supported_jsonrpc_methods(*, session_shell_enabled: bool) -> list[str]:
+    methods = [
+        *CORE_JSONRPC_METHODS,
+        SESSION_QUERY_METHODS["list_sessions"],
+        SESSION_QUERY_METHODS["get_session_messages"],
+        SESSION_CONTROL_METHODS["prompt_async"],
+        SESSION_CONTROL_METHODS["command"],
+        *PROVIDER_DISCOVERY_METHODS.values(),
+        *INTERRUPT_CALLBACK_METHODS.values(),
+    ]
+    if session_shell_enabled:
+        methods.append(SESSION_CONTROL_METHODS["shell"])
+    return methods
 
 
 def _build_method_contract_params(
@@ -392,11 +433,20 @@ def build_session_query_extension_params(
     deployment_context: dict[str, str | bool],
     context_id_prefix: str,
 ) -> dict[str, Any]:
+    session_shell_enabled = bool(deployment_context.get("session_shell_enabled"))
+    methods = dict(SESSION_QUERY_METHODS)
+    control_methods = dict(SESSION_CONTROL_METHODS)
+    if not session_shell_enabled:
+        methods.pop("shell", None)
+        control_methods.pop("shell", None)
+
     method_contracts: dict[str, Any] = {}
     result_envelope_by_method: dict[str, Any] = {}
     pagination_applies_to: list[str] = []
 
     for method_contract in SESSION_QUERY_METHOD_CONTRACTS.values():
+        if method_contract.method == SESSION_QUERY_METHODS["shell"] and not session_shell_enabled:
+            continue
         params_contract = _build_method_contract_params(
             required=method_contract.required_params,
             optional=method_contract.optional_params,
@@ -425,8 +475,8 @@ def build_session_query_extension_params(
             pagination_applies_to.append(method_contract.method)
 
     return {
-        "methods": dict(SESSION_QUERY_METHODS),
-        "control_methods": dict(SESSION_CONTROL_METHODS),
+        "methods": methods,
+        "control_methods": control_methods,
         "control_method_flags": {
             SESSION_QUERY_METHODS["shell"]: {
                 "enabled_by_default": False,
@@ -596,27 +646,113 @@ def build_provider_discovery_extension_params(
 def build_compatibility_profile_params(
     *,
     protocol_version: str,
+    deployment_context: dict[str, str | bool],
 ) -> dict[str, Any]:
+    session_shell_enabled = bool(deployment_context.get("session_shell_enabled"))
+    method_retention: dict[str, dict[str, Any]] = {
+        method: {
+            "surface": "core",
+            "availability": "always",
+            "retention": "required",
+        }
+        for method in CORE_JSONRPC_METHODS
+    }
+    method_retention.update(
+        {
+            method: {
+                "surface": "extension",
+                "availability": "always",
+                "retention": "stable",
+                "extension_uri": SESSION_QUERY_EXTENSION_URI,
+            }
+            for method in (
+                SESSION_QUERY_METHODS["list_sessions"],
+                SESSION_QUERY_METHODS["get_session_messages"],
+                SESSION_CONTROL_METHODS["prompt_async"],
+                SESSION_CONTROL_METHODS["command"],
+            )
+        }
+    )
+    method_retention[SESSION_CONTROL_METHODS["shell"]] = {
+        "surface": "extension",
+        "availability": "enabled" if session_shell_enabled else "disabled",
+        "retention": "deployment-conditional",
+        "extension_uri": SESSION_QUERY_EXTENSION_URI,
+        "toggle": "A2A_ENABLE_SESSION_SHELL",
+    }
+    method_retention.update(
+        {
+            method: {
+                "surface": "extension",
+                "availability": "always",
+                "retention": "stable",
+                "extension_uri": PROVIDER_DISCOVERY_EXTENSION_URI,
+            }
+            for method in PROVIDER_DISCOVERY_METHODS.values()
+        }
+    )
+    method_retention.update(
+        {
+            method: {
+                "surface": "extension",
+                "availability": "always",
+                "retention": "stable",
+                "extension_uri": INTERRUPT_CALLBACK_EXTENSION_URI,
+            }
+            for method in INTERRUPT_CALLBACK_METHODS.values()
+        }
+    )
     return {
         "profile_id": "opencode-a2a-baseline-v1",
         "protocol_version": protocol_version,
-        "core_jsonrpc_methods": [
-            "message/send",
-            "message/stream",
-            "tasks/get",
-            "tasks/cancel",
-            "tasks/resubscribe",
+        "core": {
+            "jsonrpc_methods": list(CORE_JSONRPC_METHODS),
+            "http_endpoints": list(CORE_HTTP_ENDPOINTS),
+        },
+        "extension_retention": {
+            SESSION_BINDING_EXTENSION_URI: {
+                "surface": "core-runtime-metadata",
+                "availability": "always",
+                "retention": "required",
+            },
+            MODEL_SELECTION_EXTENSION_URI: {
+                "surface": "core-runtime-metadata",
+                "availability": "always",
+                "retention": "stable",
+            },
+            STREAMING_EXTENSION_URI: {
+                "surface": "core-runtime-metadata",
+                "availability": "always",
+                "retention": "required",
+            },
+            SESSION_QUERY_EXTENSION_URI: {
+                "surface": "jsonrpc-extension",
+                "availability": "always",
+                "retention": "stable",
+            },
+            PROVIDER_DISCOVERY_EXTENSION_URI: {
+                "surface": "jsonrpc-extension",
+                "availability": "always",
+                "retention": "stable",
+            },
+            INTERRUPT_CALLBACK_EXTENSION_URI: {
+                "surface": "jsonrpc-extension",
+                "availability": "always",
+                "retention": "stable",
+            },
+        },
+        "method_retention": method_retention,
+        "consumer_guidance": [
+            "Treat core A2A methods as the stable interoperability baseline for generic clients.",
+            (
+                "Treat opencode.* and a2a.interrupt.* JSON-RPC methods as declared custom "
+                "extensions that remain stable within the current major line."
+            ),
+            (
+                "Treat opencode.sessions.shell as deployment-conditional and discover it from "
+                "the declared profile and current wire contract before calling it."
+            ),
         ],
-        "core_http_endpoints": [
-            "POST /v1/message:send",
-            "POST /v1/message:stream",
-            "GET /v1/tasks/{id}",
-            "POST /v1/tasks/{id}:cancel",
-            "GET /v1/tasks/{id}:subscribe",
-        ],
-        "extension_retention": "stable",
-        "method_retention": "deployment-conditional",
-        "consumer_guidance": "discovery-first",
     }
 
 
@@ -625,39 +761,50 @@ def build_wire_contract_params(
     protocol_version: str,
     deployment_context: dict[str, str | bool],
 ) -> dict[str, Any]:
-    supported_methods = [
-        "message/send",
-        "message/stream",
-        "tasks/get",
-        "tasks/cancel",
-        "tasks/resubscribe",
-        *SESSION_QUERY_METHODS.values(),
+    session_shell_enabled = bool(deployment_context.get("session_shell_enabled"))
+    extension_jsonrpc_methods = [
+        SESSION_QUERY_METHODS["list_sessions"],
+        SESSION_QUERY_METHODS["get_session_messages"],
+        SESSION_CONTROL_METHODS["prompt_async"],
+        SESSION_CONTROL_METHODS["command"],
         *PROVIDER_DISCOVERY_METHODS.values(),
         *INTERRUPT_CALLBACK_METHODS.values(),
     ]
-    conditionally_available_methods = []
-    if not deployment_context.get("session_shell_enabled"):
-        conditionally_available_methods.append(SESSION_QUERY_METHODS["shell"])
+    conditionally_available_methods: dict[str, dict[str, str]] = {}
+    if session_shell_enabled:
+        extension_jsonrpc_methods.append(SESSION_CONTROL_METHODS["shell"])
+    else:
+        conditionally_available_methods[SESSION_CONTROL_METHODS["shell"]] = {
+            "reason": "disabled_by_configuration",
+            "toggle": "A2A_ENABLE_SESSION_SHELL",
+        }
 
     return {
         "protocol_version": protocol_version,
-        "supported_methods": sorted(supported_methods),
-        "conditionally_available_methods": sorted(conditionally_available_methods),
-        "core_http_endpoints": [
-            "POST /v1/message:send",
-            "POST /v1/message:stream",
-            "GET /v1/tasks/{id}",
-            "POST /v1/tasks/{id}:cancel",
-            "GET /v1/tasks/{id}:subscribe",
-        ],
-        "unsupported_method_error_contract": {
-            "code": -32601,
-            "data_type": "METHOD_NOT_SUPPORTED",
-            "data_fields": [
-                "type",
-                "method",
-                "supported_methods",
-                "protocol_version",
+        "preferred_transport": "HTTP+JSON",
+        "additional_transports": ["JSON-RPC"],
+        "core": {
+            "jsonrpc_methods": list(CORE_JSONRPC_METHODS),
+            "http_endpoints": list(CORE_HTTP_ENDPOINTS),
+        },
+        "extensions": {
+            "jsonrpc_methods": extension_jsonrpc_methods,
+            "conditionally_available_methods": conditionally_available_methods,
+            "extension_uris": [
+                SESSION_BINDING_EXTENSION_URI,
+                MODEL_SELECTION_EXTENSION_URI,
+                STREAMING_EXTENSION_URI,
+                SESSION_QUERY_EXTENSION_URI,
+                PROVIDER_DISCOVERY_EXTENSION_URI,
+                INTERRUPT_CALLBACK_EXTENSION_URI,
             ],
+        },
+        "all_jsonrpc_methods": build_supported_jsonrpc_methods(
+            session_shell_enabled=session_shell_enabled,
+        ),
+        "unsupported_method_error": {
+            "code": -32601,
+            "type": "METHOD_NOT_SUPPORTED",
+            "data_fields": list(WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS),
         },
     }

--- a/src/opencode_a2a_server/jsonrpc_ext.py
+++ b/src/opencode_a2a_server/jsonrpc_ext.py
@@ -41,8 +41,7 @@ logger = logging.getLogger(__name__)
 
 ERR_SESSION_NOT_FOUND = SESSION_QUERY_ERROR_BUSINESS_CODES["SESSION_NOT_FOUND"]
 ERR_SESSION_FORBIDDEN = SESSION_QUERY_ERROR_BUSINESS_CODES["SESSION_FORBIDDEN"]
-ERR_METHOD_DISABLED = SESSION_QUERY_ERROR_BUSINESS_CODES["METHOD_DISABLED"]
-ERR_METHOD_NOT_SUPPORTED = SESSION_QUERY_ERROR_BUSINESS_CODES["METHOD_NOT_SUPPORTED"]
+ERR_METHOD_NOT_SUPPORTED = -32601
 ERR_UPSTREAM_UNREACHABLE = SESSION_QUERY_ERROR_BUSINESS_CODES["UPSTREAM_UNREACHABLE"]
 ERR_UPSTREAM_HTTP_ERROR = SESSION_QUERY_ERROR_BUSINESS_CODES["UPSTREAM_HTTP_ERROR"]
 ERR_INTERRUPT_NOT_FOUND = INTERRUPT_ERROR_BUSINESS_CODES["INTERRUPT_REQUEST_NOT_FOUND"]
@@ -602,7 +601,8 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         *args: Any,
         opencode_client: OpencodeClient,
         methods: dict[str, str],
-        enable_session_shell: bool = False,
+        protocol_version: str,
+        supported_methods: list[str],
         directory_resolver: Callable[[str | None], str | None] | None = None,
         session_claim: Callable[..., Awaitable[bool]] | None = None,
         session_claim_finalize: Callable[..., Awaitable[None]] | None = None,
@@ -615,13 +615,14 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         self._method_get_session_messages = methods["get_session_messages"]
         self._method_prompt_async = methods["prompt_async"]
         self._method_command = methods["command"]
-        self._method_shell = methods["shell"]
+        self._method_shell = methods.get("shell")
         self._method_list_providers = methods["list_providers"]
         self._method_list_models = methods["list_models"]
         self._method_reply_permission = methods["reply_permission"]
         self._method_reply_question = methods["reply_question"]
         self._method_reject_question = methods["reject_question"]
-        self._enable_session_shell = bool(enable_session_shell)
+        self._protocol_version = protocol_version
+        self._supported_methods = list(supported_methods)
         missing_control_hooks = [
             name
             for name, hook in (
@@ -640,18 +641,6 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         self._session_claim = cast(Callable[..., Awaitable[bool]], session_claim)
         self._session_claim_finalize = cast(Callable[..., Awaitable[None]], session_claim_finalize)
         self._session_claim_release = cast(Callable[..., Awaitable[None]], session_claim_release)
-        self._all_supported_methods = {
-            "message/send",
-            "message/stream",
-            "tasks/get",
-            "tasks/cancel",
-            "tasks/resubscribe",
-            *methods.values(),
-        }
-        card = kwargs.get("agent_card")
-        if card is None and args:
-            card = args[0]
-        self._protocol_version = getattr(card, "protocol_version", "1.0.0") if card else "1.0.0"
 
     def _session_forbidden_response(
         self,
@@ -792,8 +781,9 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         session_control_methods = {
             self._method_prompt_async,
             self._method_command,
-            self._method_shell,
         }
+        if self._method_shell is not None:
+            session_control_methods.add(self._method_shell)
         interrupt_callback_methods = {
             self._method_reply_permission,
             self._method_reply_question,
@@ -827,7 +817,7 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                     data={
                         "type": "METHOD_NOT_SUPPORTED",
                         "method": base_request.method,
-                        "supported_methods": sorted(list(self._all_supported_methods)),
+                        "supported_methods": self._supported_methods,
                         "protocol_version": self._protocol_version,
                     },
                 ),
@@ -1257,23 +1247,6 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                         message=str(exc),
                         data={"type": "INVALID_FIELD", "field": "metadata.opencode.directory"},
                     )
-                ),
-            )
-
-        if base_request.method == self._method_shell and not self._enable_session_shell:
-            _log_shell_audit("disabled")
-            if base_request.id is None:
-                return Response(status_code=204)
-            return self._generate_error_response(
-                base_request.id,
-                JSONRPCError(
-                    code=ERR_METHOD_DISABLED,
-                    message="Method disabled",
-                    data={
-                        "type": "METHOD_DISABLED",
-                        "method": base_request.method,
-                        "session_id": session_id,
-                    },
                 ),
             )
 

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -1,10 +1,12 @@
 from opencode_a2a_server.app import (
+    COMPATIBILITY_PROFILE_EXTENSION_URI,
     INTERRUPT_CALLBACK_EXTENSION_URI,
     MODEL_SELECTION_EXTENSION_URI,
     PROVIDER_DISCOVERY_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
     STREAMING_EXTENSION_URI,
+    WIRE_CONTRACT_EXTENSION_URI,
     build_agent_card,
 )
 from opencode_a2a_server.jsonrpc_ext import SESSION_CONTEXT_PREFIX
@@ -80,11 +82,10 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert session_query.params["control_methods"] == {
         "prompt_async": "opencode.sessions.prompt_async",
         "command": "opencode.sessions.command",
-        "shell": "opencode.sessions.shell",
     }
     assert session_query.params["methods"]["prompt_async"] == "opencode.sessions.prompt_async"
     assert session_query.params["methods"]["command"] == "opencode.sessions.command"
-    assert session_query.params["methods"]["shell"] == "opencode.sessions.shell"
+    assert "shell" not in session_query.params["methods"]
     assert session_query.params["control_method_flags"]["opencode.sessions.shell"] == {
         "enabled_by_default": False,
         "config_key": "A2A_ENABLE_SESSION_SHELL",
@@ -95,7 +96,6 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     ]
     prompt_contract = session_query.params["method_contracts"]["opencode.sessions.prompt_async"]
     command_contract = session_query.params["method_contracts"]["opencode.sessions.command"]
-    shell_contract = session_query.params["method_contracts"]["opencode.sessions.shell"]
     list_contract = session_query.params["method_contracts"]["opencode.sessions.list"]
     messages_contract = session_query.params["method_contracts"]["opencode.sessions.messages.list"]
     assert prompt_contract["params"]["required"] == ["session_id", "request.parts"]
@@ -106,12 +106,6 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
         "request.arguments",
     ]
     assert command_contract["result"]["fields"] == ["item"]
-    assert shell_contract["params"]["required"] == [
-        "session_id",
-        "request.agent",
-        "request.command",
-    ]
-    assert shell_contract["result"]["fields"] == ["item"]
     assert list_contract["notification_response_status"] == 204
     assert messages_contract["notification_response_status"] == 204
     assert prompt_contract["notification_response_status"] == 204
@@ -120,7 +114,8 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert result_envelope["opencode.sessions.messages.list"]["fields"] == ["items"]
     assert result_envelope["opencode.sessions.prompt_async"]["fields"] == ["ok", "session_id"]
     assert result_envelope["opencode.sessions.command"]["fields"] == ["item"]
-    assert result_envelope["opencode.sessions.shell"]["fields"] == ["item"]
+    assert "opencode.sessions.shell" not in session_query.params["method_contracts"]
+    assert "opencode.sessions.shell" not in result_envelope
     assert (
         session_query.params["context_semantics"]["a2a_context_id_prefix"] == SESSION_CONTEXT_PREFIX
     )
@@ -131,11 +126,17 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert session_query.params["errors"]["business_codes"] == {
         "SESSION_NOT_FOUND": -32001,
         "SESSION_FORBIDDEN": -32006,
-        "METHOD_DISABLED": -32007,
         "UPSTREAM_UNREACHABLE": -32002,
         "UPSTREAM_HTTP_ERROR": -32003,
         "UPSTREAM_PAYLOAD_ERROR": -32005,
     }
+    assert session_query.params["errors"]["error_data_fields"] == [
+        "type",
+        "method",
+        "session_id",
+        "upstream_status",
+        "detail",
+    ]
     assert session_query.params["errors"]["invalid_params_data_fields"] == [
         "type",
         "field",
@@ -196,8 +197,49 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
             interrupt.params["method_contracts"][method_name]["notification_response_status"] == 204
         )
 
+    compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
+    assert compatibility.params["extension_retention"][MODEL_SELECTION_EXTENSION_URI] == {
+        "surface": "core-runtime-metadata",
+        "availability": "always",
+        "retention": "stable",
+    }
+    shell_policy = compatibility.params["method_retention"]["opencode.sessions.shell"]
+    assert shell_policy["availability"] == "disabled"
+    assert shell_policy["retention"] == "deployment-conditional"
+    assert shell_policy["toggle"] == "A2A_ENABLE_SESSION_SHELL"
+
+    wire_contract = ext_by_uri[WIRE_CONTRACT_EXTENSION_URI]
+    assert MODEL_SELECTION_EXTENSION_URI in wire_contract.params["extensions"]["extension_uris"]
+    assert "opencode.sessions.shell" not in wire_contract.params["all_jsonrpc_methods"]
+    assert wire_contract.params["extensions"]["conditionally_available_methods"] == {
+        "opencode.sessions.shell": {
+            "reason": "disabled_by_configuration",
+            "toggle": "A2A_ENABLE_SESSION_SHELL",
+        }
+    }
+
 
 def test_agent_card_chat_examples_include_project_hint_when_configured() -> None:
     card = build_agent_card(make_settings(a2a_bearer_token="test-token", a2a_project="alpha"))
     chat_skill = next(skill for skill in card.skills if skill.id == "opencode.chat")
     assert any("project alpha" in example for example in chat_skill.examples)
+
+
+def test_agent_card_contracts_include_shell_when_enabled() -> None:
+    card = build_agent_card(
+        make_settings(a2a_bearer_token="test-token", a2a_enable_session_shell=True)
+    )
+    ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
+
+    session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
+    assert session_query.params["control_methods"]["shell"] == "opencode.sessions.shell"
+    assert session_query.params["methods"]["shell"] == "opencode.sessions.shell"
+    assert "opencode.sessions.shell" in session_query.params["method_contracts"]
+
+    compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
+    shell_policy = compatibility.params["method_retention"]["opencode.sessions.shell"]
+    assert shell_policy["availability"] == "enabled"
+
+    wire_contract = ext_by_uri[WIRE_CONTRACT_EXTENSION_URI]
+    assert "opencode.sessions.shell" in wire_contract.params["all_jsonrpc_methods"]
+    assert wire_contract.params["extensions"]["conditionally_available_methods"] == {}

--- a/tests/test_extension_contract_consistency.py
+++ b/tests/test_extension_contract_consistency.py
@@ -15,8 +15,6 @@ from opencode_a2a_server.app import (
 )
 from opencode_a2a_server.extension_contracts import (
     INTERRUPT_CALLBACK_METHODS,
-    PROVIDER_DISCOVERY_METHODS,
-    SESSION_QUERY_METHODS,
     build_compatibility_profile_params,
     build_interrupt_callback_extension_params,
     build_model_selection_extension_params,
@@ -66,6 +64,7 @@ def test_extension_ssot_matches_agent_card_contracts() -> None:
     )
     expected_compatibility_profile = build_compatibility_profile_params(
         protocol_version=settings.a2a_protocol_version,
+        deployment_context=deployment_context,
     )
     expected_wire_contract = build_wire_contract_params(
         protocol_version=settings.a2a_protocol_version,
@@ -138,6 +137,7 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     )
     expected_compatibility_profile = build_compatibility_profile_params(
         protocol_version=settings.a2a_protocol_version,
+        deployment_context=deployment_context,
     )
     expected_wire_contract = build_wire_contract_params(
         protocol_version=settings.a2a_protocol_version,
@@ -187,8 +187,8 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
         value.get("value", {}).get("method") for value in example_values if isinstance(value, dict)
     }
     expected_methods = (
-        set(SESSION_QUERY_METHODS.values())
-        | set(PROVIDER_DISCOVERY_METHODS.values())
+        set(session_query["methods"].values())
+        | set(provider_discovery["methods"].values())
         | set(INTERRUPT_CALLBACK_METHODS.values())
     )
     missing_methods = sorted(method for method in expected_methods if method not in example_methods)

--- a/tests/test_jsonrpc_unsupported_method.py
+++ b/tests/test_jsonrpc_unsupported_method.py
@@ -1,5 +1,6 @@
 import httpx
 import pytest
+
 from opencode_a2a_server.app import create_app
 from tests.helpers import make_settings
 
@@ -52,3 +53,33 @@ async def test_unsupported_method_notification_returns_204() -> None:
     # Note: OpencodeSessionQueryJSONRPCApplication._handle_requests returns 204 for notifications
     # if it catches the method. For unsupported methods, it now also returns 204 if id is None.
     assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_disabled_shell_reports_current_supported_methods() -> None:
+    settings = make_settings(a2a_bearer_token="test-token", a2a_enable_session_shell=False)
+    app = create_app(settings)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/",
+            headers={"Authorization": "Bearer test-token"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 124,
+                "method": "opencode.sessions.shell",
+                "params": {
+                    "session_id": "s-1",
+                    "request": {"agent": "code-reviewer", "command": "pwd"},
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    error = body["error"]
+    assert error["code"] == -32601
+    assert error["data"]["type"] == "METHOD_NOT_SUPPORTED"
+    assert error["data"]["method"] == "opencode.sessions.shell"
+    assert "opencode.sessions.shell" not in error["data"]["supported_methods"]

--- a/tests/test_opencode_session_extension.py
+++ b/tests/test_opencode_session_extension.py
@@ -1324,8 +1324,9 @@ async def test_session_shell_extension_disabled_by_default(monkeypatch):
             },
         )
         payload = resp.json()
-        assert payload["error"]["code"] == -32007
-        assert payload["error"]["data"]["type"] == "METHOD_DISABLED"
+        assert payload["error"]["code"] == -32601
+        assert payload["error"]["data"]["type"] == "METHOD_NOT_SUPPORTED"
+        assert "opencode.sessions.shell" not in payload["error"]["data"]["supported_methods"]
         assert dummy.shell_calls == []
 
 


### PR DESCRIPTION
## 摘要
本 PR 完成 OpenCode A2A 互操作性契约对齐，建立并收敛了 Compatibility Profile 与 Wire Contract 的机器可读声明，并将 unsupported method 的运行时返回、Agent Card、OpenAPI 与测试基线统一到同一份 runtime truth。

## 模块变更

### `src/opencode_a2a_server/extension_contracts.py`
- 新增并收口 Compatibility Profile / Wire Contract 的 SSOT 结构。
- 引入 core JSON-RPC methods、core HTTP endpoints、runtime supported methods 的统一构建逻辑。
- 将 `model-selection`、`session-binding`、`streaming`、`session-query`、`provider-discovery`、`interrupt-callback` 统一纳入 extension retention / extension URIs 声明。
- 将 `opencode.sessions.shell` 明确标记为 deployment-conditional method，并在 shell 关闭时从 active method set 中移除。
- 将 extension URI 常量收口到同一处，避免 app 与 contract builder 之间的硬编码漂移。

### `src/opencode_a2a_server/app.py`
- Agent Card 与 OpenAPI `POST /` 的 `x-a2a-extension-contracts` 统一注入 Compatibility Profile / Wire Contract。
- JSON-RPC OpenAPI 描述与 examples 改为感知 `A2A_ENABLE_SESSION_SHELL`，禁用 shell 时不再继续暴露该方法样例。
- `create_app()` 在 shell 关闭时不再把 `opencode.sessions.shell` 注册为 active JSON-RPC method，并显式注入当前 deployment 的 `supported_methods`。

### `src/opencode_a2a_server/jsonrpc_ext.py`
- unsupported method 统一返回 `-32601 / METHOD_NOT_SUPPORTED`，并返回当前 deployment 的 `supported_methods` 与 `protocol_version`。
- disabled shell 从“已注册但运行时拒绝”调整为“不属于当前 active method boundary”，使运行时错误与 wire contract 声明一致。

### `docs/guide.md`
- 将文档拆分为 `Wire Contract` 与 `Compatibility Profile` 两部分，明确两者职责边界。
- 补充 `all_jsonrpc_methods`、`conditionally_available_methods`、`extension_uris` 的发现语义。
- 明确 `model-selection` 属于稳定 runtime metadata contract，`opencode.sessions.shell` 属于 deployment-conditional method。

### 测试
- 更新 `tests/test_agent_card.py`，锁定 disabled / enabled shell 下的契约差异，以及 `model-selection` 的 retention / extension URI 声明。
- 更新 `tests/test_extension_contract_consistency.py`，确保 Agent Card / OpenAPI / SSOT 保持一致，并避免 shell-disabled 场景下 examples 漂移。
- 新增并扩展 `tests/test_jsonrpc_unsupported_method.py`，验证 unsupported method 统一错误契约，以及 disabled shell 不再出现在 runtime supported set 中。
- 更新 `tests/test_opencode_session_extension.py`，将 disabled shell 的返回契约对齐为 `METHOD_NOT_SUPPORTED`。

## 回归验证
- `uv run pytest`
- `uv run pre-commit run --all-files`

## 关联 Issue
- Closes #204
- Closes #207
