### PR TITLE
ops: add lightweight stream and interrupt metric logs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -717,13 +717,20 @@ If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscr
 - Upstream interruption is best-effort: if upstream returns 404, network errors, or other HTTP errors, A2A cancellation still completes with `TaskState.canceled`.
 - Idempotency contract: repeated `tasks/cancel` on an already `canceled` task returns the current terminal task state without error.
 - Terminal subscribe contract: calling `subscribe` on a terminal task replays one terminal `Task` snapshot and then closes the stream.
-- The cancel path emits metric log records (`logger=opencode_a2a_server.agent`):
+- The service emits lightweight metric log records (`logger=opencode_a2a_server.agent`):
+  - `a2a_stream_requests_total`
+  - `a2a_stream_active` (`value=1` when a stream starts, `value=-1` when it closes)
+  - `opencode_stream_retries_total`
+  - `tool_call_chunks_emitted_total`
+  - `interrupt_requests_total`
+  - `interrupt_resolved_total`
+- The cancel path also emits:
   - `a2a_cancel_requests_total`
   - `a2a_cancel_abort_attempt_total`
   - `a2a_cancel_abort_success_total`
   - `a2a_cancel_abort_timeout_total`
-- `a2a_cancel_abort_error_total`
-- `a2a_cancel_duration_ms` (with `abort_outcome` label)
+  - `a2a_cancel_abort_error_total`
+  - `a2a_cancel_duration_ms` (with `abort_outcome` label)
 
 ## Extension Contract Change Checklist
 

--- a/src/opencode_a2a_server/agent.py
+++ b/src/opencode_a2a_server/agent.py
@@ -46,6 +46,21 @@ _INTERRUPT_RESOLVED_EVENT_TYPES = {"permission.replied", "question.replied", "qu
 _USAGE_PART_TYPES = {"step-finish"}
 
 
+def _emit_metric(
+    name: str,
+    value: float = 1.0,
+    **labels: str | int | float | bool,
+) -> None:
+    if labels:
+        labels_text = ",".join(
+            f"{key}={str(label).lower() if isinstance(label, bool) else label}"
+            for key, label in sorted(labels.items())
+        )
+        logger.debug("metric=%s value=%s labels=%s", name, value, labels_text)
+        return
+    logger.debug("metric=%s value=%s", name, value)
+
+
 class BlockType(str, Enum):
     TEXT = "text"
     REASONING = "reasoning"
@@ -377,14 +392,7 @@ class OpencodeAgentExecutor(AgentExecutor):
         value: float = 1.0,
         **labels: str | int | float | bool,
     ) -> None:
-        if labels:
-            labels_text = ",".join(
-                f"{key}={str(label).lower() if isinstance(label, bool) else label}"
-                for key, label in sorted(labels.items())
-            )
-            logger.debug("metric=%s value=%s labels=%s", name, value, labels_text)
-            return
-        logger.debug("metric=%s value=%s", name, value)
+        _emit_metric(name, value, **labels)
 
     def _resolve_and_validate_directory(self, requested: str | None) -> str | None:
         """Normalizes and validates the directory parameter against workspace boundaries.
@@ -1146,6 +1154,8 @@ class OpencodeAgentExecutor(AgentExecutor):
                     effective_append,
                     chunk.content_key,
                 )
+                if chunk.block_type == BlockType.TOOL_CALL:
+                    _emit_metric("tool_call_chunks_emitted_total")
 
         async def _emit_interrupt_status(
             *,
@@ -1186,6 +1196,10 @@ class OpencodeAgentExecutor(AgentExecutor):
                     ),
                 )
             )
+            if phase == "asked":
+                _emit_metric("interrupt_requests_total")
+            elif phase == "resolved":
+                _emit_metric("interrupt_resolved_total")
 
         def _new_text_chunk(
             *,
@@ -1519,6 +1533,7 @@ class OpencodeAgentExecutor(AgentExecutor):
                 except Exception:
                     if stop_event.is_set():
                         break
+                    _emit_metric("opencode_stream_retries_total")
                     logger.exception("OpenCode event stream failed; retrying")
                     await asyncio.sleep(backoff)
                     backoff = min(backoff * 2, max_backoff)

--- a/src/opencode_a2a_server/app.py
+++ b/src/opencode_a2a_server/app.py
@@ -41,7 +41,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.responses import StreamingResponse
 
-from .agent import OpencodeAgentExecutor
+from .agent import OpencodeAgentExecutor, _emit_metric
 from .config import Settings
 from .extension_contracts import (
     COMPATIBILITY_PROFILE_EXTENSION_URI,
@@ -141,8 +141,11 @@ class OpencodeRequestHandler(DefaultRequestHandler):
             result_aggregator,
             producer_task,
         ) = await self._setup_message_execution(params, context)
+        _emit_metric("a2a_stream_requests_total")
+        _emit_metric("a2a_stream_active")
         consumer = EventConsumer(queue)
         producer_task.add_done_callback(consumer.agent_task_callback)
+        stream_completed = False
 
         try:
             async for event in result_aggregator.consume_and_emit(consumer):
@@ -150,12 +153,19 @@ class OpencodeRequestHandler(DefaultRequestHandler):
                     self._validate_task_id_match(task_id, event.id)
                 await self._send_push_notification_if_needed(task_id, result_aggregator)
                 yield event
+            stream_completed = True
         except (asyncio.CancelledError, GeneratorExit):
             logger.warning("Client disconnected. Cancelling producer task %s", task_id)
             producer_task.cancel()
             await queue.close(immediate=True)
             raise
         finally:
+            _emit_metric("a2a_stream_active", -1)
+            logger.debug(
+                "A2A stream request closed task_id=%s completed=%s",
+                task_id,
+                stream_completed,
+            )
             cleanup_task = asyncio.create_task(self._cleanup_producer(producer_task, task_id))
             cleanup_task.set_name(f"cleanup_producer:{task_id}")
             self._track_background_task(cleanup_task)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
+from a2a.types import Message, MessageSendParams, Role, Task, TaskState, TaskStatus, TextPart
+
+from opencode_a2a_server.agent import OpencodeAgentExecutor, _StreamOutputState
+from opencode_a2a_server.app import OpencodeRequestHandler
+from tests.helpers import DummyEventQueue, make_settings
+
+
+def _make_message_send_params() -> MessageSendParams:
+    return MessageSendParams(
+        message=Message(
+            message_id="msg-user-1",
+            role=Role.user,
+            parts=[TextPart(text="hello")],
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_request_metrics_track_total_and_active(caplog) -> None:
+    class _FakeAggregator:
+        async def consume_and_emit(self, _consumer):
+            yield Task(
+                id="task-1",
+                context_id="ctx-1",
+                status=TaskStatus(state=TaskState.working),
+            )
+            await asyncio.sleep(10)
+
+    class _TestHandler(OpencodeRequestHandler):
+        async def _setup_message_execution(self, params, context=None):  # noqa: ANN001
+            del params, context
+            queue = AsyncMock()
+            producer_task = asyncio.create_task(asyncio.sleep(10))
+            self._producer_task = producer_task
+            self._queue = queue
+            return MagicMock(), "task-1", queue, _FakeAggregator(), producer_task
+
+        async def _cleanup_producer(self, producer_task, task_id):  # noqa: ANN001
+            del task_id
+            producer_task.cancel()
+            try:
+                await producer_task
+            except asyncio.CancelledError:
+                pass
+
+    handler = _TestHandler(agent_executor=MagicMock(), task_store=InMemoryTaskStore())
+
+    with caplog.at_level(logging.DEBUG, logger="opencode_a2a_server.agent"):
+        stream = handler.on_message_send_stream(_make_message_send_params())
+        first_event = await stream.__anext__()
+        assert isinstance(first_event, Task)
+        await stream.aclose()
+        await asyncio.sleep(0)
+
+    messages = [record.message for record in caplog.records]
+    assert any("metric=a2a_stream_requests_total" in message for message in messages)
+    assert any("metric=a2a_stream_active value=1.0" in message for message in messages)
+    assert any("metric=a2a_stream_active value=-1" in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_streaming_metrics_capture_tool_call_and_interrupt_events(caplog) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.stream_timeout = None
+            self.directory = None
+            self.settings = make_settings(
+                a2a_bearer_token="test",
+                opencode_base_url="http://localhost",
+            )
+            self._interrupt_requests: dict[str, str] = {}
+
+        async def stream_events(self, stop_event=None, *, directory=None):  # noqa: ANN001
+            del stop_event, directory
+            yield {
+                "type": "permission.asked",
+                "properties": {
+                    "id": "perm-1",
+                    "sessionID": "ses-1",
+                    "permission": "read",
+                    "patterns": ["/tmp/secret"],
+                    "always": [],
+                },
+            }
+            yield {
+                "type": "permission.replied",
+                "properties": {
+                    "requestID": "perm-1",
+                    "sessionID": "ses-1",
+                },
+            }
+            yield {
+                "type": "message.part.updated",
+                "properties": {
+                    "part": {
+                        "id": "part-tool-1",
+                        "sessionID": "ses-1",
+                        "messageID": "msg-1",
+                        "type": "tool",
+                        "role": "assistant",
+                        "callID": "call-1",
+                        "tool": "bash",
+                        "state": {"status": "running"},
+                    }
+                },
+            }
+
+        def remember_interrupt_request(
+            self,
+            *,
+            request_id: str,
+            session_id: str,
+            interrupt_type: str | None = None,
+            identity: str | None = None,
+            task_id: str | None = None,
+            context_id: str | None = None,
+            ttl_seconds: float | None = None,
+        ) -> None:
+            del interrupt_type, identity, task_id, context_id, ttl_seconds
+            self._interrupt_requests[request_id] = session_id
+
+        def discard_interrupt_request(self, request_id: str) -> None:
+            self._interrupt_requests.pop(request_id, None)
+
+    executor = OpencodeAgentExecutor(_Client(), streaming_enabled=True)
+
+    with caplog.at_level(logging.DEBUG, logger="opencode_a2a_server.agent"):
+        await executor._consume_opencode_stream(
+            session_id="ses-1",
+            identity="user-1",
+            task_id="task-1",
+            context_id="ctx-1",
+            artifact_id="task-1:stream",
+            stream_state=_StreamOutputState(
+                user_text="hello",
+                stable_message_id="task-1:ctx-1:assistant",
+                event_id_namespace="task-1:ctx-1:task-1:stream",
+            ),
+            event_queue=DummyEventQueue(),
+            stop_event=asyncio.Event(),
+        )
+
+    messages = [record.message for record in caplog.records]
+    assert any("metric=interrupt_requests_total" in message for message in messages)
+    assert any("metric=interrupt_resolved_total" in message for message in messages)
+    assert any("metric=tool_call_chunks_emitted_total" in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_metric_increments_once_per_retry(monkeypatch, caplog) -> None:
+    class _FlakyClient:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.stream_timeout = None
+            self.directory = None
+            self.settings = make_settings(
+                a2a_bearer_token="test",
+                opencode_base_url="http://localhost",
+            )
+
+        async def stream_events(self, stop_event=None, *, directory=None):  # noqa: ANN001
+            del stop_event, directory
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("boom")
+            if False:
+                yield {}
+
+    async def _fast_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("opencode_a2a_server.agent.asyncio.sleep", _fast_sleep)
+
+    executor = OpencodeAgentExecutor(_FlakyClient(), streaming_enabled=True)
+
+    with caplog.at_level(logging.DEBUG, logger="opencode_a2a_server.agent"):
+        await executor._consume_opencode_stream(
+            session_id="ses-1",
+            identity="user-1",
+            task_id="task-1",
+            context_id="ctx-1",
+            artifact_id="task-1:stream",
+            stream_state=_StreamOutputState(
+                user_text="hello",
+                stable_message_id="task-1:ctx-1:assistant",
+                event_id_namespace="task-1:ctx-1:task-1:stream",
+            ),
+            event_queue=DummyEventQueue(),
+            stop_event=asyncio.Event(),
+        )
+
+    messages = [record.message for record in caplog.records]
+    assert sum("metric=opencode_stream_retries_total" in message for message in messages) == 1


### PR DESCRIPTION
## 概要

本 PR 针对 `#209`，沿用仓库现有 `_emit_metric(...)` 的轻量 metric log 方案，为流式请求、上游 retry、tool_call 发射和 interrupt 生命周期补充最小指标集，不引入新的 registry、`/metrics` 端点或额外协议面。

## 按模块说明

### Request Handler
- 在 `message/stream` 请求入口补充 `a2a_stream_requests_total`
- 在流式请求开始/结束时补充 `a2a_stream_active`，以 `value=1` / `value=-1` 表示增减量
- 保留现有请求生命周期与断连清理语义，不改变 A2A 行为契约

### Stream Executor
- 在 OpenCode stream retry 分支补充 `opencode_stream_retries_total`
- 在 tool_call chunk 实际发射点补充 `tool_call_chunks_emitted_total`
- 在 interrupt asked / resolved 状态发射点补充 `interrupt_requests_total` 与 `interrupt_resolved_total`
- 复用现有 metric log helper，保持 cancel / stream / interrupt 路径的一致日志格式

### Tests
- 新增 `tests/test_metrics.py`
- 覆盖 stream request total / active 指标发射
- 覆盖 interrupt asked / resolved 与 tool_call 指标发射
- 覆盖 stream retry 指标按重试次数递增

### Docs
- 在 `docs/guide.md` 补充新增 metric log 名称与语义
- 明确 `a2a_stream_active` 采用 delta-style log 表达活跃流数量变化

## 验证

- `uv run pytest`
- `uv run pre-commit run --all-files`

## 审查结论

- 本次变更与 `#209` 的问题定义一致，范围控制合理
- 当前实现延续仓库已存在的 cancel metric log 路线，符合当前代码基线的最佳实践
- 当前 open issues 中没有适合与本 PR 一并开发的高相关项，建议保持独立合并

Closes #209
