### PR TITLE
fix: prefer non-interactive sudo readiness probes

### DIFF
--- a/scripts/init_system.sh
+++ b/scripts/init_system.sh
@@ -84,8 +84,17 @@ if [[ "${EUID}" -ne 0 ]]; then
   fi
   SUDO="sudo"
   log_start "Checking sudo access..."
-  sudo -v
-  log_done "Sudo access ready."
+  if sudo -n true 2>/dev/null; then
+    log_done "Sudo access ready."
+  elif [[ -t 0 ]]; then
+    if sudo -v; then
+      log_done "Sudo access ready."
+    else
+      die "sudo authentication failed."
+    fi
+  else
+    die "sudo requires a password or is not permitted (non-interactive). Run in an interactive shell, or configure NOPASSWD for required commands."
+  fi
 fi
 
 log_start "Detecting package manager..."

--- a/scripts/shell_helpers.sh
+++ b/scripts/shell_helpers.sh
@@ -16,13 +16,19 @@ ensure_sudo_ready() {
     echo "sudo not found; run as root or install sudo." >&2
     exit 1
   fi
-  if [[ -t 0 ]]; then
-    sudo -v
+  # Prefer a non-interactive probe first because some sudoers policies still
+  # prompt for `sudo -v` even when NOPASSWD command execution is allowed.
+  if sudo -n true 2>/dev/null; then
     return 0
   fi
-  if ! sudo -n true 2>/dev/null; then
-    echo "sudo requires a password or is not permitted (non-interactive). Refusing to apply." >&2
-    echo "Run in an interactive shell, or configure NOPASSWD for required commands." >&2
+  if [[ -t 0 ]]; then
+    if sudo -v; then
+      return 0
+    fi
+    echo "sudo authentication failed." >&2
     exit 1
   fi
+  echo "sudo requires a password or is not permitted (non-interactive). Refusing to apply." >&2
+  echo "Run in an interactive shell, or configure NOPASSWD for required commands." >&2
+  exit 1
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -236,16 +236,21 @@ if [[ "$APPLY" == "true" ]]; then
     echo "sudo not found; cannot apply uninstall." >&2
     exit 1
   fi
-  if [[ -t 0 ]]; then
-    # Interactive terminal: refresh credentials.
-    sudo -v
-  else
-    # Non-interactive: require passwordless sudo for this run.
-    if ! sudo -n true 2>/dev/null; then
-      echo "sudo requires a password or is not permitted (non-interactive). Refusing to apply." >&2
-      echo "Run in an interactive shell, or configure NOPASSWD for required commands." >&2
+  # Prefer a non-interactive probe first because some sudoers policies still
+  # prompt for `sudo -v` even when NOPASSWD command execution is allowed.
+  if sudo -n true 2>/dev/null; then
+    :
+  elif [[ -t 0 ]]; then
+    if sudo -v; then
+      :
+    else
+      echo "sudo authentication failed." >&2
       exit 1
     fi
+  else
+    echo "sudo requires a password or is not permitted (non-interactive). Refusing to apply." >&2
+    echo "Run in an interactive shell, or configure NOPASSWD for required commands." >&2
+    exit 1
   fi
 fi
 

--- a/tests/test_jsonrpc_models.py
+++ b/tests/test_jsonrpc_models.py
@@ -51,9 +51,7 @@ def test_parse_get_session_messages_params_applies_default_limit() -> None:
 
 def test_parse_get_session_messages_params_rejects_ambiguous_limit() -> None:
     with pytest.raises(JsonRpcParamsValidationError) as exc_info:
-        parse_get_session_messages_params(
-            {"session_id": "s-1", "limit": 5, "query": {"limit": 6}}
-        )
+        parse_get_session_messages_params({"session_id": "s-1", "limit": 5, "query": {"limit": 6}})
 
     assert str(exc_info.value) == "limit is ambiguous between params.limit and params.query.limit"
     assert exc_info.value.data == {"type": "INVALID_FIELD", "field": "limit"}


### PR DESCRIPTION
Closes #216

## 变更概览

本 PR 修复 deploy/init/uninstall 脚本对 `sudo -v` 的错误依赖。
在部分 `sudoers` 策略下，`sudo -n true` 可以成功，但 `sudo -v` 仍会要求输入密码；原有逻辑把“有 TTY”直接等同于“应使用 `sudo -v` 预检查”，会导致实际可执行的 `sudo` 命令在预检查阶段被错误阻塞。

## scripts/shell_helpers.sh

- 调整 `ensure_sudo_ready()` 的检查顺序：优先尝试 `sudo -n true`
- 当已具备无交互 `sudo` 能力时直接通过，不再额外触发 `sudo -v`
- 仅当 `sudo -n true` 不可用且当前为交互式终端时，才回退到 `sudo -v`
- 保留非交互场景的拒绝策略，并继续给出明确错误提示

## scripts/init_system.sh

- 同步 deploy 路径的 sudo 就绪检查顺序
- 避免初始化流程在 `NOPASSWD` 可用但 `sudo -v` 仍提示密码的环境下误判失败
- 将交互式认证失败与非交互权限不足拆分为更明确的错误路径

## scripts/uninstall.sh

- 同步卸载 apply 模式的 sudo 预检查逻辑
- 保持 uninstall 与 deploy/init 的行为一致，避免只修一条路径

## tests

- 重新执行仓库基线回归
- `ruff format` 按仓库现有格式规则自动整理了 `tests/test_jsonrpc_models.py` 的一处换行；无行为变化

## 风险与评估

- 本次改动不改变真正执行阶段的 `sudo` 权限要求，只修正“预检查误判”问题
- 交互式场景仍支持通过 `sudo -v` 完成认证，非交互场景仍要求 `sudo -n true` 可用
- 未发现需要额外关联的 open issues；本 PR 直接完成 `#216` 描述的问题修复，使用 `Closes #216` 是准确的

## 验证

- `bash -n scripts/shell_helpers.sh scripts/init_system.sh scripts/uninstall.sh scripts/deploy.sh`
- `uv run pre-commit run --all-files`
- `uv run pytest`
