### PR TITLE
fix: tighten extension result envelope contracts

### DIFF
--- a/src/opencode_a2a_server/extension_contracts.py
+++ b/src/opencode_a2a_server/extension_contracts.py
@@ -559,7 +559,6 @@ def build_provider_discovery_extension_params(
     deployment_context: dict[str, str | bool],
 ) -> dict[str, Any]:
     method_contracts: dict[str, Any] = {}
-    result_envelope_by_method: dict[str, Any] = {}
 
     for method_contract in PROVIDER_DISCOVERY_METHOD_CONTRACTS.values():
         params_contract = _build_method_contract_params(
@@ -581,17 +580,9 @@ def build_provider_discovery_extension_params(
             )
         method_contracts[method_contract.method] = contract_doc
 
-        envelope_doc: dict[str, Any] = {"fields": list(method_contract.result_fields)}
-        if method_contract.items_field:
-            envelope_doc["items_field"] = method_contract.items_field
-        result_envelope_by_method[method_contract.method] = envelope_doc
-
     return {
         "methods": dict(PROVIDER_DISCOVERY_METHODS),
         "method_contracts": method_contracts,
-        "result_envelope": {
-            "by_method": result_envelope_by_method,
-        },
         "supported_metadata": ["opencode.directory"],
         "provider_private_metadata": ["opencode.directory"],
         "context_fields": {

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -159,8 +159,17 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
         "list_providers": "opencode.providers.list",
         "list_models": "opencode.models.list",
     }
+    assert "result_envelope" not in provider_discovery.params
+    assert provider_discovery.params["method_contracts"]["opencode.providers.list"]["result"] == {
+        "fields": ["items", "default_by_provider", "connected"],
+        "items_type": "ProviderSummary[]",
+    }
     assert provider_discovery.params["method_contracts"]["opencode.models.list"]["params"] == {
         "optional": ["provider_id"]
+    }
+    assert provider_discovery.params["method_contracts"]["opencode.models.list"]["result"] == {
+        "fields": ["items", "default_by_provider", "connected"],
+        "items_type": "ModelSummary[]",
     }
     assert provider_discovery.params["errors"]["business_codes"] == {
         "UPSTREAM_UNREACHABLE": -32002,


### PR DESCRIPTION
Closes #215
Closes #218

## 变更概览

本 PR 收敛两处 extension contract 的统一 envelope 语义边界：
- `session-query`
- `provider-discovery`

两者此前都把方法级结果描述重复写进 `result_envelope.by_method`。但 `result_envelope` 在 consumer 侧被视为统一 envelope 映射区，只应承载 `items` / `pagination` / `raw` 这类统一结果映射。继续保留 `by_method` 会造成 contract 语义越界，并在更严格的解析端触发 hard fail。

## extension_contracts

- 移除 `build_session_query_extension_params()` 中的 `result_envelope.by_method`
- 移除 `build_provider_discovery_extension_params()` 中的 `result_envelope.by_method`
- 保留 `method_contracts.<method>.result` 作为方法级结果契约的唯一来源
- 不改动运行时行为，仅收敛 Agent Card / OpenAPI contract 结构

## tests

- 更新 `tests/test_agent_card.py`
- 显式断言 `session-query` 不再输出 `result_envelope`
- 显式断言 `provider-discovery` 不再输出 `result_envelope`
- 补充断言，确保两类 extension 的方法级 `result` 契约仍然完整保留在 `method_contracts`

## 审查与评估

- `#215` 需求仍然有效，当前主干确实仍存在 `session-query.result_envelope.by_method`
- `provider-discovery` 存在完全同类的问题，因此在同一分支内一并处理是合理的
- 已复查仓库内其它 extension contract，当前未再发现其它 `result_envelope.by_method` 残留
- 本次改动属于 contract 去冗余与语义收敛，不涉及运行时接口执行路径

## 风险

- 如果存在外部 consumer 依赖了非契约化的 `result_envelope.by_method`，升级后将不再读取到该字段
- 但从当前仓库和 Hub 的严格解析约束看，移除该字段是必要的正确方向；方法级结果信息仍可通过 `method_contracts.<method>.result` 获取

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
