### PR TITLE
fix: authenticate deploy health probes

### DIFF
--- a/docs/agent_deploy_sop.md
+++ b/docs/agent_deploy_sop.md
@@ -195,7 +195,7 @@ sudo systemctl status opencode-a2a-server@alpha.service --no-pager
 Check health:
 
 ```bash
-curl -fsS http://127.0.0.1:8010/health
+curl -fsS -H "Authorization: Bearer <token>" http://127.0.0.1:8010/health
 ```
 
 Optional Agent Card check:
@@ -210,7 +210,7 @@ Success criteria:
 - the command prints one JSON status line with `{"status":"ok","category":"ready",...}`
 - `opencode@<project>.service` and `opencode-a2a-server@<project>.service`
   are active/running
-- `GET /health` returns HTTP 200 with `{"status":"ok"}`
+- authenticated `GET /health` returns HTTP 200 with `{"status":"ok"}`
 - requests above `A2A_MAX_REQUEST_BODY_BYTES` are rejected with HTTP `413`
 
 Inspect hardening overrides:

--- a/scripts/deploy/enable_instance.sh
+++ b/scripts/deploy/enable_instance.sh
@@ -16,11 +16,13 @@ if [[ -z "$PROJECT_NAME" ]]; then
 fi
 
 FORCE_RESTART="${FORCE_RESTART:-false}"
+: "${DATA_ROOT:=/data/opencode-a2a}"
 : "${A2A_HOST:=127.0.0.1}"
 : "${A2A_PORT:=8000}"
 : "${DEPLOY_HEALTHCHECK_TIMEOUT_SECONDS:=30}"
 : "${DEPLOY_HEALTHCHECK_INTERVAL_SECONDS:=1}"
 A2A_HEALTHCHECK_URL="${A2A_HEALTHCHECK_URL:-}"
+A2A_HEALTHCHECK_AUTH_HEADER_FILE=""
 
 json_escape() {
   local value="${1//\\/\\\\}"
@@ -49,6 +51,14 @@ fail_with_status() {
   exit "$exit_code"
 }
 
+cleanup_healthcheck_auth() {
+  if [[ -n "$A2A_HEALTHCHECK_AUTH_HEADER_FILE" ]]; then
+    rm -f "$A2A_HEALTHCHECK_AUTH_HEADER_FILE"
+  fi
+}
+
+trap cleanup_healthcheck_auth EXIT
+
 require_positive_integer() {
   local key="$1"
   local value="$2"
@@ -76,6 +86,35 @@ require_unit_active() {
   fi
 }
 
+resolve_healthcheck_bearer_token() {
+  if [[ -n "${A2A_BEARER_TOKEN:-}" ]]; then
+    printf '%s' "${A2A_BEARER_TOKEN}"
+    return 0
+  fi
+
+  local secret_file="${DATA_ROOT}/${PROJECT_NAME}/config/a2a.secret.env"
+  if ! sudo test -f "$secret_file"; then
+    fail_with_status 25 "missing_runtime_secret" "Missing Bearer Token secret file for health probe: ${secret_file}"
+  fi
+
+  local token=""
+  token="$(sudo sed -n 's/^A2A_BEARER_TOKEN=//p' "$secret_file" | head -n 1)"
+  if [[ -z "$token" ]]; then
+    fail_with_status 25 "missing_runtime_secret" "A2A_BEARER_TOKEN is not defined in ${secret_file}"
+  fi
+
+  printf '%s' "$token"
+}
+
+prepare_healthcheck_auth_header() {
+  local token="$1"
+  local header_file
+  header_file="$(mktemp)"
+  chmod 600 "$header_file"
+  printf 'Authorization: Bearer %s\n' "$token" >"$header_file"
+  A2A_HEALTHCHECK_AUTH_HEADER_FILE="$header_file"
+}
+
 wait_for_health() {
   local timeout="$1"
   local interval="$2"
@@ -84,7 +123,7 @@ wait_for_health() {
   while (( elapsed < timeout )); do
     require_unit_active "opencode@${PROJECT_NAME}.service"
     require_unit_active "opencode-a2a-server@${PROJECT_NAME}.service"
-    if response="$(curl -fsS "$A2A_HEALTHCHECK_URL" 2>/dev/null)" && [[ "$response" == *'"status"'*'"ok"'* ]]; then
+    if response="$(curl -fsS -H "@${A2A_HEALTHCHECK_AUTH_HEADER_FILE}" "$A2A_HEALTHCHECK_URL" 2>/dev/null)" && [[ "$response" == *'"status"'*'"ok"'* ]]; then
       return 0
     fi
     sleep "$interval"
@@ -103,6 +142,7 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 A2A_HEALTHCHECK_URL="${A2A_HEALTHCHECK_URL:-http://$(resolve_healthcheck_host):${A2A_PORT}/health}"
+prepare_healthcheck_auth_header "$(resolve_healthcheck_bearer_token)"
 
 if ! sudo systemctl daemon-reload; then
   fail_with_status 20 "systemd_reload_failed" "systemctl daemon-reload failed"

--- a/scripts/deploy_readme.md
+++ b/scripts/deploy_readme.md
@@ -42,7 +42,8 @@ Its contract is intentionally simple:
 - refuse non-interactive runs when `sudo -n` is unavailable for required systemd steps
 - provision or update one isolated instance directory per `project`
 - install/start the corresponding systemd units for that instance
-- wait for `GET /health` to return `{"status":"ok"}` within a bounded timeout
+- wait for an authenticated `GET /health` probe to return `{"status":"ok"}`
+  within a bounded timeout
 - print one machine-readable JSON status line on success or failure
 - exit non-zero when validation, setup, or service startup fails
 
@@ -173,7 +174,7 @@ For values that support both environment variables and CLI keys:
 | `A2A_SYSTEMD_LIMIT_NOFILE` | `a2a_systemd_limit_nofile` | Optional | `65536` | Per-instance `LimitNOFILE` systemd override. |
 | `A2A_SYSTEMD_MEMORY_MAX` | `a2a_systemd_memory_max` | Optional | None | Optional per-instance `MemoryMax` override. |
 | `A2A_SYSTEMD_CPU_QUOTA` | `a2a_systemd_cpu_quota` | Optional | None | Optional per-instance `CPUQuota` override. |
-| `DEPLOY_HEALTHCHECK_TIMEOUT_SECONDS` | `deploy_healthcheck_timeout_seconds` | Optional | `30` | Deploy readiness timeout for `GET /health`. |
+| `DEPLOY_HEALTHCHECK_TIMEOUT_SECONDS` | `deploy_healthcheck_timeout_seconds` | Optional | `30` | Deploy readiness timeout for the authenticated `GET /health` probe. |
 | `DEPLOY_HEALTHCHECK_INTERVAL_SECONDS` | `deploy_healthcheck_interval_seconds` | Optional | `1` | Poll interval for deploy readiness checks. |
 
 ### Auto-Generated Runtime Variables
@@ -306,6 +307,7 @@ Deploy status contract:
 - `22`: `systemd_not_active`
 - `23`: `readiness_timeout`
 - `24`: `missing_dependency`
+- `25`: `missing_runtime_secret`
 - `31`: `invalid_argument`
 
 Follow logs:

--- a/tests/test_deploy_security_contract.py
+++ b/tests/test_deploy_security_contract.py
@@ -89,7 +89,17 @@ def test_deploy_supports_release_and_source_install_modes() -> None:
 
 def test_enable_instance_enforces_readiness_contract() -> None:
     assert 'A2A_HEALTHCHECK_URL="${A2A_HEALTHCHECK_URL:-http://' in ENABLE_INSTANCE_TEXT
+    assert "resolve_healthcheck_bearer_token()" in ENABLE_INSTANCE_TEXT
+    assert (
+        'prepare_healthcheck_auth_header "$(resolve_healthcheck_bearer_token)"'
+        in ENABLE_INSTANCE_TEXT
+    )
+    assert (
+        'curl -fsS -H "@${A2A_HEALTHCHECK_AUTH_HEADER_FILE}" "$A2A_HEALTHCHECK_URL"'
+        in ENABLE_INSTANCE_TEXT
+    )
     assert "curl not found in PATH; cannot probe /health" in ENABLE_INSTANCE_TEXT
+    assert 'fail_with_status 25 "missing_runtime_secret"' in ENABLE_INSTANCE_TEXT
     assert 'fail_with_status 23 "readiness_timeout"' in ENABLE_INSTANCE_TEXT
     assert (
         'emit_status "ok" "ready" "systemd units active and /health returned ok"'
@@ -118,6 +128,8 @@ def test_security_docs_emphasize_single_tenant_boundary_and_secret_strategy() ->
     assert "refuse non-interactive runs when `sudo -n` is unavailable" in DEPLOY_README_TEXT
     assert "machine-readable JSON status line" in DEPLOY_README_TEXT
     assert "DEPLOY_HEALTHCHECK_TIMEOUT_SECONDS" in DEPLOY_README_TEXT
+    assert "authenticated `GET /health` probe" in DEPLOY_README_TEXT
+    assert "missing_runtime_secret" in DEPLOY_README_TEXT
     assert "systemd_start_failed" in DEPLOY_README_TEXT
     assert "opencode.auth.env" in DEPLOY_README_TEXT
     assert "a2a.secret.env" in DEPLOY_README_TEXT
@@ -125,6 +137,10 @@ def test_security_docs_emphasize_single_tenant_boundary_and_secret_strategy() ->
     assert "source-based multi-instance systemd deployment" in SCRIPTS_INDEX_TEXT
     assert "release-based, systemd-managed, recommended" in AGENT_DEPLOY_SOP_TEXT
     assert "non-interactive sudo preflight" in AGENT_DEPLOY_SOP_TEXT
+    assert (
+        'curl -fsS -H "Authorization: Bearer <token>" http://127.0.0.1:8010/health'
+        in AGENT_DEPLOY_SOP_TEXT
+    )
     assert '{"status":"ok","category":"ready"' in AGENT_DEPLOY_SOP_TEXT
     assert "deploy_light.sh" not in README_TEXT
     assert "deploy_light.sh" not in SCRIPTS_INDEX_TEXT


### PR DESCRIPTION
Closes #220

## 变更概览

本 PR 修复 deploy / deploy_release 在默认 Bearer Token 认证边界下，对 `/health` 进行未认证探测而误报 `readiness_timeout` 的问题。

## scripts/deploy/enable_instance.sh

- 为 deploy readiness probe 增加 Bearer Token 解析逻辑
- 优先读取当前进程环境中的 `A2A_BEARER_TOKEN`
- 若环境变量未提供，则读取 `${DATA_ROOT}/<project>/config/a2a.secret.env`
- 对 `/health` 统一发送带 `Authorization: Bearer ...` 的 authenticated probe
- 当实例 secret file 缺失或未定义 `A2A_BEARER_TOKEN` 时，返回新的 `missing_runtime_secret` 状态，避免把 401 或 secret 缺失误判成 `readiness_timeout`

## docs

- 更新 `scripts/deploy_readme.md` 中 deploy readiness contract 的描述，明确 `/health` 探测是 authenticated probe
- 在 deploy 状态码列表中补充 `missing_runtime_secret`
- 更新 `docs/agent_deploy_sop.md` 中 `/health` 示例，改为携带 Bearer Token

## tests

- 在 `tests/test_deploy_security_contract.py` 增加脚本契约断言，锁定以下行为：
  - deploy health probe 必须解析 Bearer Token
  - `/health` 请求必须携带认证头
  - secret 缺失时返回 `missing_runtime_secret`
  - 文档与脚本契约保持一致

## 审查与评估

- 需求仍然有效：当前运行时要求 `/health` 认证，而 deploy 探针未认证，确实会把“服务已启动但返回 401”的场景误报为超时
- 实现边界合理：本 PR 不放宽 `/health` 的运行时认证要求，只修正 deploy 探针，保持运行时安全边界不变
- 方案较稳妥：优先使用进程环境，回退到实例 root-only secret file，兼容 `ENABLE_SECRET_PERSISTENCE=true` 与默认双阶段 secret provisioning 场景

## 风险

- 低风险：deploy 现在依赖 `a2a.secret.env` 中的 `A2A_BEARER_TOKEN` 可读且格式正确；若该文件缺失或内容不完整，会显式失败为 `missing_runtime_secret`
- 该行为与当前 secret contract 一致，不属于新的兼容性回归

## 验证

- `bash -n scripts/deploy/enable_instance.sh`
- `uv run pre-commit run --all-files`
- `uv run pytest`
