### PR TITLE
fix: align stream text extraction with upstream snapshot parts

### DIFF
--- a/src/opencode_a2a_server/agent.py
+++ b/src/opencode_a2a_server/agent.py
@@ -1528,15 +1528,17 @@ class OpencodeAgentExecutor(AgentExecutor):
                                     message_id=message_id,
                                 )
                             )
-                        elif isinstance(part.get("text"), str):
-                            chunks.extend(
-                                _snapshot_chunks(
-                                    state=state,
-                                    snapshot=part["text"],
-                                    message_id=message_id,
-                                    part_id=part_id,
+                        else:
+                            snapshot_text = _extract_stream_snapshot_text(part)
+                            if snapshot_text is not None:
+                                chunks.extend(
+                                    _snapshot_chunks(
+                                        state=state,
+                                        snapshot=snapshot_text,
+                                        message_id=message_id,
+                                        part_id=part_id,
+                                    )
                                 )
-                            )
 
                         if chunks:
                             await _emit_chunks(chunks)
@@ -1982,6 +1984,15 @@ def _extract_stream_part_type(part: Mapping[str, Any], props: Mapping[str, Any])
     return None
 
 
+def _extract_stream_snapshot_text(part: Mapping[str, Any]) -> str | None:
+    part_type = _extract_stream_part_type(part, {})
+    if part_type in {"step-start", "step-finish", "snapshot"}:
+        return _extract_first_nonempty_string(part, ("snapshot",))
+    if part_type in {"text", "reasoning"}:
+        return _extract_first_nonempty_string(part, ("text",))
+    return None
+
+
 def _preview_log_value(value: Any, *, limit: int) -> str:
     try:
         rendered = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
@@ -2041,7 +2052,7 @@ def _log_stream_event_debug(event: Mapping[str, Any], *, limit: int) -> None:
 def _map_part_type_to_block_type(part_type: str | None) -> BlockType | None:
     if not part_type:
         return None
-    if part_type == "text":
+    if part_type in {"text", "snapshot", "step-start", "step-finish"}:
         return BlockType.TEXT
     if part_type == "reasoning":
         return BlockType.REASONING

--- a/src/opencode_a2a_server/text_parts.py
+++ b/src/opencode_a2a_server/text_parts.py
@@ -7,9 +7,22 @@ def extract_text_from_parts(parts: Any) -> str:
     if not isinstance(parts, list):
         return ""
     texts: list[str] = []
+    snapshots: list[str] = []
     for part in parts:
-        if isinstance(part, dict) and part.get("type") == "text":
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type == "text":
             part_text = part.get("text")
             if isinstance(part_text, str):
                 texts.append(part_text)
-    return "".join(texts).strip()
+            continue
+        if part_type in {"snapshot", "step-start", "step-finish"}:
+            snapshot = part.get("snapshot")
+            if isinstance(snapshot, str) and snapshot.strip():
+                snapshots.append(snapshot)
+    if texts:
+        return "".join(texts).strip()
+    if snapshots:
+        return snapshots[-1].strip()
+    return ""

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -724,6 +724,60 @@ async def test_streaming_final_status_state_is_completed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_emits_text_from_step_finish_snapshot_part() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "part": {
+                        "id": "prt-step-finish-snapshot",
+                        "sessionID": "ses-1",
+                        "messageID": "msg-1",
+                        "type": "step-finish",
+                        "reason": "stop",
+                        "snapshot": "final answer from snapshot",
+                        "cost": 0.0,
+                        "tokens": {
+                            "input": 1,
+                            "output": 4,
+                            "reasoning": 0,
+                            "cache": {"read": 0, "write": 0},
+                        },
+                    }
+                },
+            }
+        ],
+        response_text="",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    await executor.execute(
+        make_request_context(
+            task_id="task-step-finish", context_id="ctx-step-finish", text="hello"
+        ),
+        queue,
+    )
+
+    updates = _artifact_updates(queue)
+    assert updates
+    text_updates = [
+        event for event in updates if _artifact_stream_meta(event)["block_type"] == "text"
+    ]
+    assert text_updates
+    assert _part_text(text_updates[-1]) == "final answer from snapshot"
+
+    final_status = [
+        event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
+    ][-1]
+    usage = _status_shared_meta(final_status)["usage"]
+    assert usage["input_tokens"] == 1
+    assert usage["output_tokens"] == 4
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_response_task_state_is_completed() -> None:
     client = DummyStreamingClient(
         stream_events_payload=[],

--- a/tests/test_text_parts.py
+++ b/tests/test_text_parts.py
@@ -1,0 +1,31 @@
+from opencode_a2a_server.text_parts import extract_text_from_parts
+
+
+def test_extract_text_from_parts_falls_back_to_latest_snapshot() -> None:
+    parts = [
+        {
+            "type": "step-start",
+            "snapshot": "partial answer",
+        },
+        {
+            "type": "step-finish",
+            "snapshot": "final answer",
+        },
+    ]
+
+    assert extract_text_from_parts(parts) == "final answer"
+
+
+def test_extract_text_from_parts_prefers_text_parts_over_snapshots() -> None:
+    parts = [
+        {
+            "type": "step-finish",
+            "snapshot": "snapshot answer",
+        },
+        {
+            "type": "text",
+            "text": "final answer",
+        },
+    ]
+
+    assert extract_text_from_parts(parts) == "final answer"


### PR DESCRIPTION
## 背景

当前流式链路在上游 `opencode serve` 返回 `snapshot` / `step-start` / `step-finish` part 时，没有把正文正确转译为 A2A artifact update，下游只会看到状态事件，最终表现为 `Content unavailable`。

本次修复按上游实际 part 协议对齐，不通过额外兜底猜测补内容。

Closes #240

## 改动

### 流式协议转译
- 在 `agent.py` 中补充对 `snapshot`、`step-start`、`step-finish` part 的正文提取
- 将上述 upstream part 统一映射到 A2A 的 `text` block
- 保持现有 usage 聚合逻辑，继续从 `step-finish` 读取 token 信息

### 最终正文提取
- 在 `text_parts.py` 中支持从最终响应的 `snapshot`、`step-start`、`step-finish` parts 提取正文
- 当响应里同时存在显式 `text` parts 时，继续优先使用 `text` parts，避免改变已有语义

### 回归测试
- 新增流式测试，覆盖 `step-finish.snapshot` 直接承载最终正文的场景
- 新增 `text_parts` 单测，覆盖 snapshot 回退与 text 优先级

## 验证
- `uv run pytest`
- `uv run pre-commit run --files src/opencode_a2a_server/agent.py src/opencode_a2a_server/text_parts.py tests/test_streaming_output_contract.py tests/test_text_parts.py`
