### PR TITLE
fix: configure REST SSE keepalive explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ OPENCODE_BASE_URL=http://127.0.0.1:4096 \
 A2A_HOST=127.0.0.1 \
 A2A_PORT=8000 \
 A2A_PUBLIC_URL=http://127.0.0.1:8000 \
+A2A_STREAM_SSE_PING_SECONDS=15 \
 OPENCODE_WORKSPACE_ROOT=/abs/path/to/workspace \
 opencode-a2a-server serve
 ```
@@ -75,6 +76,7 @@ Default local address: `http://127.0.0.1:8000`
   `/v1/message:stream`
 - A2A JSON-RPC support on `POST /`
 - SSE streaming with normalized `text`, `reasoning`, and `tool_call` blocks
+- Explicit REST SSE keepalive configurable through `A2A_STREAM_SSE_PING_SECONDS`
 - Session continuity through `metadata.shared.session.id`
 - Request-scoped model selection through `metadata.shared.model`
 - OpenCode-oriented JSON-RPC extensions for session and model/provider queries

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -42,6 +42,9 @@ Key variables to understand protocol behavior:
 - `A2A_LOG_PAYLOADS` / `A2A_LOG_BODY_LIMIT`: payload logging behavior and
   truncation. When `A2A_LOG_LEVEL=DEBUG`, upstream OpenCode stream events are
   also logged with preview truncation controlled by `A2A_LOG_BODY_LIMIT`.
+- `A2A_STREAM_SSE_PING_SECONDS`: explicit SSE keepalive interval for REST
+  streaming endpoints (`/v1/message:stream` and `/v1/tasks/{id}:subscribe`).
+  Default: `15`.
 - `A2A_MAX_REQUEST_BODY_BYTES`: runtime request-body limit. Oversized requests
   return HTTP `413`.
 - `A2A_SESSION_CACHE_TTL_SECONDS` / `A2A_SESSION_CACHE_MAXSIZE`: session cache

--- a/src/opencode_a2a_server/app.py
+++ b/src/opencode_a2a_server/app.py
@@ -5,13 +5,19 @@ import hashlib
 import json
 import logging
 import secrets
+from collections.abc import AsyncIterable, AsyncIterator
 from contextlib import asynccontextmanager
 from contextvars import ContextVar, Token
 from typing import TYPE_CHECKING, Any, cast
 
 import uvicorn
 from a2a.server.apps.jsonrpc.jsonrpc_app import DefaultCallContextBuilder
-from a2a.server.apps.rest.rest_adapter import RESTAdapter
+from a2a.server.apps.rest.rest_adapter import (
+    EventSourceResponse,
+    InvalidRequestError,
+    RESTAdapter,
+    rest_stream_error_handler,
+)
 from a2a.server.events import EventConsumer
 from a2a.server.request_handlers.default_request_handler import (
     TERMINAL_TASK_STATES,
@@ -264,6 +270,60 @@ class IdentityAwareCallContextBuilder(DefaultCallContextBuilder):
             context.state["identity"] = identity
 
         return context
+
+
+class KeepaliveRESTAdapter(RESTAdapter):
+    def __init__(self, *args: Any, sse_ping_seconds: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._sse_ping_seconds = sse_ping_seconds
+
+    @rest_stream_error_handler
+    async def _handle_streaming_request(
+        self,
+        method,
+        request,
+    ):
+        try:
+            await request.body()
+        except (ValueError, RuntimeError, OSError) as exc:
+            raise ServerError(
+                error=InvalidRequestError(message=f"Failed to pre-consume request body: {exc}")
+            ) from exc
+
+        call_context = self._context_builder.build(request)
+
+        async def event_generator(
+            stream: AsyncIterable[Any],
+        ) -> AsyncIterator[dict[str, dict[str, Any]]]:
+            async for item in stream:
+                yield {"data": item}
+
+        return EventSourceResponse(
+            event_generator(method(request, call_context)),
+            ping=self._sse_ping_seconds,
+        )
+
+    def routes(self) -> dict[tuple[str, str], Any]:
+        routes = super().routes()
+
+        async def message_stream(request):
+            return await self._handle_streaming_request(
+                self.handler.on_message_send_stream,
+                request,
+            )
+
+        async def subscribe(request):
+            return await self._handle_streaming_request(
+                self.handler.on_resubscribe_to_task,
+                request,
+            )
+
+        message_stream.__annotations__ = {"request": Request}
+        subscribe.__annotations__ = {"request": Request}
+
+        routes[("/v1/message:stream", "POST")] = message_stream
+        routes[("/v1/tasks/{id}:subscribe", "GET")] = subscribe
+        return routes
 
 
 def _build_deployment_context(settings: Settings) -> dict[str, str | bool]:
@@ -1021,10 +1081,11 @@ def create_app(settings: Settings) -> FastAPI:
     deployment_context = _build_deployment_context(settings)
     _patch_jsonrpc_openapi_contract(app, settings, deployment_context=deployment_context)
 
-    rest_adapter = RESTAdapter(
+    rest_adapter = KeepaliveRESTAdapter(
         agent_card=agent_card,
         http_handler=handler,
         context_builder=context_builder,
+        sse_ping_seconds=settings.a2a_stream_sse_ping_seconds,
     )
     for route, callback in rest_adapter.routes().items():
         app.add_api_route(route[0], callback, methods=[route[1]])

--- a/src/opencode_a2a_server/config.py
+++ b/src/opencode_a2a_server/config.py
@@ -38,6 +38,11 @@ class Settings(BaseSettings):
     a2a_log_level: str = Field(default="WARNING", alias="A2A_LOG_LEVEL")
     a2a_log_payloads: bool = Field(default=False, alias="A2A_LOG_PAYLOADS")
     a2a_log_body_limit: int = Field(default=0, alias="A2A_LOG_BODY_LIMIT")
+    a2a_stream_sse_ping_seconds: int = Field(
+        default=15,
+        ge=1,
+        alias="A2A_STREAM_SSE_PING_SECONDS",
+    )
     a2a_max_request_body_bytes: int = Field(
         default=1_048_576,
         ge=0,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,6 +23,7 @@ def test_settings_valid():
         "A2A_BEARER_TOKEN": "test-token",
         "OPENCODE_TIMEOUT": "300",
         "OPENCODE_WORKSPACE_ROOT": "/srv/workspaces/alpha",
+        "A2A_STREAM_SSE_PING_SECONDS": "20",
         "A2A_MAX_REQUEST_BODY_BYTES": "2048",
         "A2A_CANCEL_ABORT_TIMEOUT_SECONDS": "0.75",
         "A2A_ENABLE_SESSION_SHELL": "true",
@@ -32,6 +33,7 @@ def test_settings_valid():
         assert settings.a2a_bearer_token == "test-token"
         assert settings.opencode_timeout == 300.0
         assert settings.opencode_workspace_root == "/srv/workspaces/alpha"
+        assert settings.a2a_stream_sse_ping_seconds == 20
         assert settings.a2a_max_request_body_bytes == 2048
         assert settings.a2a_cancel_abort_timeout_seconds == 0.75
         assert settings.a2a_enable_session_shell is True
@@ -60,3 +62,16 @@ def test_settings_reject_negative_max_request_body_bytes():
 
     field_names = [e["loc"][0] for e in excinfo.value.errors()]
     assert "A2A_MAX_REQUEST_BODY_BYTES" in field_names
+
+
+def test_settings_reject_non_positive_stream_sse_ping_seconds() -> None:
+    env = {
+        "A2A_BEARER_TOKEN": "test-token",
+        "A2A_STREAM_SSE_PING_SECONDS": "0",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValidationError) as excinfo:
+            Settings.from_env()
+
+    field_names = [e["loc"][0] for e in excinfo.value.errors()]
+    assert "A2A_STREAM_SSE_PING_SECONDS" in field_names

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -1,10 +1,17 @@
 import logging
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
 from a2a.types import TransportProtocol
+from starlette.requests import Request
 
-from opencode_a2a_server.app import _normalize_log_level, build_agent_card, create_app
+from opencode_a2a_server.app import (
+    KeepaliveRESTAdapter,
+    _normalize_log_level,
+    build_agent_card,
+    create_app,
+)
 from tests.helpers import DummyChatOpencodeClient, make_settings
 
 
@@ -27,6 +34,77 @@ def test_rest_subscription_route_matches_current_sdk_contract() -> None:
 
     assert "/v1/tasks/{id}:subscribe" in route_paths
     assert "/v1/tasks/{id}:resubscribe" not in route_paths
+
+
+def _request(path: str, body: bytes = b"{}") -> Request:
+    sent = False
+
+    async def receive() -> dict:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "state": {},
+    }
+    req = Request(scope, receive)
+    req.state.user_identity = "opaque:test-id"
+    return req
+
+
+@pytest.mark.asyncio
+async def test_keepalive_rest_adapter_sets_explicit_sse_ping() -> None:
+    adapter = KeepaliveRESTAdapter(
+        agent_card=build_agent_card(make_settings(a2a_bearer_token="test-token")),
+        http_handler=MagicMock(),
+        sse_ping_seconds=27,
+    )
+
+    async def _stream(_request: Request, _context):  # noqa: ANN001
+        yield {"id": "evt-1"}
+
+    response = await adapter._handle_streaming_request(_stream, _request("/v1/message:stream"))
+
+    assert response.ping_interval == 27
+
+
+def test_create_app_wires_configured_sse_ping_into_rest_adapter(monkeypatch) -> None:
+    import opencode_a2a_server.app as app_module
+
+    captured: dict[str, int] = {}
+    original = app_module.KeepaliveRESTAdapter
+
+    class SpyKeepaliveRESTAdapter:
+        def __init__(self, *args, sse_ping_seconds: int, **kwargs):  # noqa: ANN002, ANN003
+            captured["sse_ping_seconds"] = sse_ping_seconds
+            self._delegate = original(*args, sse_ping_seconds=sse_ping_seconds, **kwargs)
+
+        def routes(self):
+            return self._delegate.routes()
+
+    monkeypatch.setattr(app_module, "KeepaliveRESTAdapter", SpyKeepaliveRESTAdapter)
+
+    app_module.create_app(
+        make_settings(
+            a2a_bearer_token="test-token",
+            a2a_stream_sse_ping_seconds=22,
+        )
+    )
+
+    assert captured["sse_ping_seconds"] == 22
 
 
 def test_openapi_rest_message_routes_include_schema_and_examples() -> None:


### PR DESCRIPTION
## 变更概览

本 PR 将 REST streaming 的 SSE keepalive 从“隐式依赖 SDK / `sse-starlette` 默认值”收敛为“应用层显式配置且默认行为兼容”，解决长时间无业务 chunk 输出时 keepalive 周期不可见、不可配的问题。

## 按模块说明

### `src/opencode_a2a_server/config.py`
- 新增配置项 `A2A_STREAM_SSE_PING_SECONDS`。
- 默认值设为 `15`，与当前 `sse-starlette` 默认 ping 周期保持一致，避免无必要的行为漂移。
- 对配置值增加 `ge=1` 校验，避免无效 keepalive 周期进入运行时。

### `src/opencode_a2a_server/app.py`
- 新增本地 `KeepaliveRESTAdapter`，继承 SDK `RESTAdapter`，仅收敛 REST streaming 响应构造。
- 对 `/v1/message:stream` 与 `/v1/tasks/{id}:subscribe` 的 SSE 响应显式传入 `EventSourceResponse(..., ping=settings.a2a_stream_sse_ping_seconds)`。
- 保持现有 REST 路由路径、OpenAPI 入口、handler 绑定方式兼容；未引入业务层 heartbeat 事件。
- 实现上避免复制整套 SDK REST 路由逻辑，仅覆盖 streaming 路径的 keepalive 注入点，降低后续 SDK 漂移带来的维护成本。

### `tests/test_settings.py`
- 增加配置加载测试，验证 `A2A_STREAM_SSE_PING_SECONDS` 可被环境变量驱动。
- 增加配置校验测试，验证 `0` 或其它非正值会被拒绝。

### `tests/test_transport_contract.py`
- 增加 adapter 行为测试，验证本地 `KeepaliveRESTAdapter` 会把显式 ping 注入 SSE 响应。
- 增加应用装配测试，验证 `create_app()` 会把配置值正确传入 REST streaming adapter。
- 保持现有 REST 路由契约和 streaming 路径测试可通过，确保 OpenAPI 与 transport contract 未被破坏。

### `README.md`
- 在启动示例中补充 `A2A_STREAM_SSE_PING_SECONDS`。
- 在能力说明中补充 REST SSE keepalive 已支持显式配置。

### `docs/guide.md`
- 补充 `A2A_STREAM_SSE_PING_SECONDS` 说明，明确其适用范围是 `/v1/message:stream` 与 `/v1/tasks/{id}:subscribe`。

## 提交记录
- `d23e27f` `fix: configure rest sse keepalive explicitly #245`

## 审查结论
- 当前实现方向合理，符合 `#245` 的真实目标：让 keepalive 周期由应用层显式控制，而不是继续隐式依赖第三方默认值。
- 当前实现相对主干结构是较优折中：没有复制整套 SDK REST 路由，而是通过本地 `RESTAdapter` 子类最小覆盖 streaming response 构造点，降低与上游 SDK 的分叉面。
- 未发现阻塞性问题。
- 残余风险主要在于：本地 adapter 仍然依赖 SDK `RESTAdapter.routes()` 的整体结构；如果上游 SDK 后续大改 streaming route 装配方式，这一覆盖点仍需同步复核。但相较于整套本地复制路由，这已经是更稳的方案。

## 验证
- `uv run pre-commit run --all-files`
- `uv run mypy src/opencode_a2a_server`
- `uv run pytest`

## 关联 Issue
Closes #245
