### PR TITLE
feat: publish execution environment boundary metadata

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -34,6 +34,17 @@ Key variables to understand protocol behavior:
   `metadata.opencode.directory`.
 - `A2A_ENABLE_SESSION_SHELL`: gates high-risk JSON-RPC method
   `opencode.sessions.shell`.
+- `A2A_SANDBOX_MODE` / `A2A_SANDBOX_FILESYSTEM_SCOPE` /
+  `A2A_SANDBOX_WRITABLE_ROOTS`: declarative execution-boundary metadata for
+  sandbox mode, filesystem scope, and optional writable roots.
+- `A2A_NETWORK_ACCESS` / `A2A_NETWORK_ALLOWED_DOMAINS`: declarative
+  execution-boundary metadata for network policy and optional allowlist
+  disclosure.
+- `A2A_APPROVAL_POLICY` / `A2A_APPROVAL_ESCALATION_BEHAVIOR`: declarative
+  execution-boundary metadata for approval workflow.
+- `A2A_WRITE_ACCESS_SCOPE` / `A2A_WRITE_ACCESS_OUTSIDE_WORKSPACE`: declarative
+  execution-boundary metadata for write scope and whether writes may extend
+  outside the primary workspace boundary.
 - `A2A_HOST` / `A2A_PORT`: runtime bind address. Defaults:
   `127.0.0.1:8000`.
 - `A2A_PUBLIC_URL`: public base URL advertised by the Agent Card. Default:
@@ -54,6 +65,11 @@ Key variables to understand protocol behavior:
 - `OPENCODE_TIMEOUT` / `OPENCODE_TIMEOUT_STREAM`: upstream request timeout and
   optional stream timeout override.
 - Runtime authentication is bearer-token only via `A2A_BEARER_TOKEN`.
+
+Execution-boundary metadata is intentionally declarative deployment metadata:
+it is published through `RuntimeProfile`, Agent Card, OpenAPI, and `/health`,
+and should not be interpreted as a live per-request privilege snapshot or a
+runtime CLI self-inspection result.
 
 Recommended two-process example:
 
@@ -247,13 +263,25 @@ Current profile shape:
   - `directory_binding.scope=workspace_root_or_descendant|workspace_root_only`
   - `session_shell.enabled=true|false`
   - `session_shell.availability=enabled|disabled`
+  - `execution_environment.sandbox.mode=unknown|read-only|workspace-write|danger-full-access|custom`
+  - `execution_environment.sandbox.filesystem_scope=unknown|workspace_only|workspace_and_declared_roots|unrestricted|custom`
+  - `execution_environment.network.access=unknown|disabled|enabled|restricted|custom`
+  - `execution_environment.approval.policy=unknown|never|on-request|on-failure|untrusted|custom`
+  - `execution_environment.approval.escalation_behavior=unknown|manual|automatic|unsupported|custom`
+  - `execution_environment.write_access.scope=unknown|none|workspace_only|workspace_and_declared_roots|unrestricted|custom`
+  - `execution_environment.write_access.outside_workspace=unknown|allowed|disallowed|custom`
   - `service_features.streaming.enabled=true`
   - `service_features.health_endpoint.enabled=true`
+- Optional disclosure fields are emitted only when explicitly configured:
+  - `execution_environment.sandbox.writable_roots`
+  - `execution_environment.network.allowed_domains`
 - Core methods and endpoints are declared under `core`.
 - Extension retention policy is declared under `extension_retention`.
 - Per-method retention and availability are declared under `method_retention`.
 - Extension params and `/health` expose the same structured `profile` object; there is no
   separate legacy deployment-context shape.
+- Execution-environment values are deployment declarations, not a per-turn
+  runtime approval or sandbox result.
 
 Retention guidance:
 

--- a/src/opencode_a2a_server/config.py
+++ b/src/opencode_a2a_server/config.py
@@ -1,11 +1,62 @@
 from __future__ import annotations
 
-from typing import cast
+import json
+from typing import Annotated, Any, Literal, cast
 
-from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from opencode_a2a_server import __version__
+
+SandboxMode = Literal[
+    "unknown",
+    "read-only",
+    "workspace-write",
+    "danger-full-access",
+    "custom",
+]
+SandboxFilesystemScope = Literal[
+    "unknown",
+    "workspace_only",
+    "workspace_and_declared_roots",
+    "unrestricted",
+    "custom",
+]
+NetworkAccess = Literal["unknown", "disabled", "enabled", "restricted", "custom"]
+ApprovalPolicy = Literal["unknown", "never", "on-request", "on-failure", "untrusted", "custom"]
+EscalationBehavior = Literal["unknown", "manual", "automatic", "unsupported", "custom"]
+WriteAccessScope = Literal[
+    "unknown",
+    "none",
+    "workspace_only",
+    "workspace_and_declared_roots",
+    "unrestricted",
+    "custom",
+]
+OutsideWorkspaceAccess = Literal["unknown", "allowed", "disallowed", "custom"]
+DeclaredStringList = Annotated[tuple[str, ...], NoDecode]
+
+
+def _parse_declared_list(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return ()
+        if raw.startswith("["):
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                parsed = None
+            else:
+                if not isinstance(parsed, list):
+                    raise TypeError("Expected a JSON array for declared list values.")
+                return tuple(str(item).strip() for item in parsed if str(item).strip())
+        return tuple(item.strip() for item in raw.split(",") if item.strip())
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    raise TypeError("Expected a comma-separated string, JSON array, or sequence.")
 
 
 class Settings(BaseSettings):
@@ -51,6 +102,36 @@ class Settings(BaseSettings):
     a2a_documentation_url: str | None = Field(default=None, alias="A2A_DOCUMENTATION_URL")
     a2a_allow_directory_override: bool = Field(default=True, alias="A2A_ALLOW_DIRECTORY_OVERRIDE")
     a2a_enable_session_shell: bool = Field(default=False, alias="A2A_ENABLE_SESSION_SHELL")
+    a2a_sandbox_mode: SandboxMode = Field(default="unknown", alias="A2A_SANDBOX_MODE")
+    a2a_sandbox_filesystem_scope: SandboxFilesystemScope = Field(
+        default="unknown",
+        alias="A2A_SANDBOX_FILESYSTEM_SCOPE",
+    )
+    a2a_sandbox_writable_roots: DeclaredStringList = Field(
+        default=(),
+        alias="A2A_SANDBOX_WRITABLE_ROOTS",
+    )
+    a2a_network_access: NetworkAccess = Field(default="unknown", alias="A2A_NETWORK_ACCESS")
+    a2a_network_allowed_domains: DeclaredStringList = Field(
+        default=(),
+        alias="A2A_NETWORK_ALLOWED_DOMAINS",
+    )
+    a2a_approval_policy: ApprovalPolicy = Field(
+        default="unknown",
+        alias="A2A_APPROVAL_POLICY",
+    )
+    a2a_approval_escalation_behavior: EscalationBehavior = Field(
+        default="unknown",
+        alias="A2A_APPROVAL_ESCALATION_BEHAVIOR",
+    )
+    a2a_write_access_scope: WriteAccessScope = Field(
+        default="unknown",
+        alias="A2A_WRITE_ACCESS_SCOPE",
+    )
+    a2a_write_access_outside_workspace: OutsideWorkspaceAccess = Field(
+        default="unknown",
+        alias="A2A_WRITE_ACCESS_OUTSIDE_WORKSPACE",
+    )
     a2a_host: str = Field(default="127.0.0.1", alias="A2A_HOST")
     a2a_port: int = Field(default=8000, alias="A2A_PORT")
     a2a_bearer_token: str = Field(..., min_length=1, alias="A2A_BEARER_TOKEN")
@@ -63,6 +144,11 @@ class Settings(BaseSettings):
         ge=0.0,
         alias="A2A_CANCEL_ABORT_TIMEOUT_SECONDS",
     )
+
+    @field_validator("a2a_sandbox_writable_roots", "a2a_network_allowed_domains", mode="before")
+    @classmethod
+    def _normalize_declared_lists(cls, value: Any) -> tuple[str, ...]:
+        return _parse_declared_list(value)
 
     @classmethod
     def from_env(cls) -> Settings:

--- a/src/opencode_a2a_server/runtime_profile.py
+++ b/src/opencode_a2a_server/runtime_profile.py
@@ -68,6 +68,74 @@ class ServiceFeaturesProfile:
 
 
 @dataclass(frozen=True)
+class SandboxProfile:
+    mode: str
+    filesystem_scope: str
+    writable_roots: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "mode": self.mode,
+            "filesystem_scope": self.filesystem_scope,
+        }
+        if self.writable_roots:
+            payload["writable_roots"] = list(self.writable_roots)
+        return payload
+
+
+@dataclass(frozen=True)
+class NetworkProfile:
+    access: str
+    allowed_domains: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"access": self.access}
+        if self.allowed_domains:
+            payload["allowed_domains"] = list(self.allowed_domains)
+        return payload
+
+
+@dataclass(frozen=True)
+class ApprovalProfile:
+    policy: str
+    escalation_behavior: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "policy": self.policy,
+            "escalation_behavior": self.escalation_behavior,
+        }
+
+
+@dataclass(frozen=True)
+class WriteAccessProfile:
+    scope: str
+    outside_workspace: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "scope": self.scope,
+            "outside_workspace": self.outside_workspace,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionEnvironmentProfile:
+    sandbox: SandboxProfile
+    network: NetworkProfile
+    approval: ApprovalProfile
+    write_access: WriteAccessProfile
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sandbox": self.sandbox.as_dict(),
+            "network": self.network.as_dict(),
+            "approval": self.approval.as_dict(),
+            "write_access": self.write_access.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
 class RuntimeContext:
     project: str | None = None
     workspace_root: str | None = None
@@ -93,6 +161,7 @@ class RuntimeProfile:
     deployment: DeploymentProfile
     directory_binding: DirectoryBindingProfile
     session_shell: SessionShellProfile
+    execution_environment: ExecutionEnvironmentProfile
     service_features: ServiceFeaturesProfile
     runtime_context: RuntimeContext
 
@@ -104,6 +173,7 @@ class RuntimeProfile:
         return {
             "directory_binding": self.directory_binding.as_dict(),
             "session_shell": self.session_shell.as_dict(),
+            "execution_environment": self.execution_environment.as_dict(),
             "service_features": self.service_features.as_dict(),
         }
 
@@ -151,6 +221,25 @@ def build_runtime_profile(settings: Settings) -> RuntimeProfile:
         session_shell=SessionShellProfile(
             enabled=settings.a2a_enable_session_shell,
             availability="enabled" if settings.a2a_enable_session_shell else "disabled",
+        ),
+        execution_environment=ExecutionEnvironmentProfile(
+            sandbox=SandboxProfile(
+                mode=settings.a2a_sandbox_mode,
+                filesystem_scope=settings.a2a_sandbox_filesystem_scope,
+                writable_roots=settings.a2a_sandbox_writable_roots,
+            ),
+            network=NetworkProfile(
+                access=settings.a2a_network_access,
+                allowed_domains=settings.a2a_network_allowed_domains,
+            ),
+            approval=ApprovalProfile(
+                policy=settings.a2a_approval_policy,
+                escalation_behavior=settings.a2a_approval_escalation_behavior,
+            ),
+            write_access=WriteAccessProfile(
+                scope=settings.a2a_write_access_scope,
+                outside_workspace=settings.a2a_write_access_outside_workspace,
+            ),
         ),
         service_features=ServiceFeaturesProfile(
             streaming={"enabled": True, "availability": "always"},

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -42,6 +42,15 @@ def test_agent_card_injects_profile_into_extensions() -> None:
             opencode_agent="code-reviewer",
             opencode_variant="safe",
             a2a_allow_directory_override=False,
+            a2a_sandbox_mode="workspace-write",
+            a2a_sandbox_filesystem_scope="workspace_and_declared_roots",
+            a2a_sandbox_writable_roots=("/srv/workspaces/alpha", "/tmp/opencode"),
+            a2a_network_access="restricted",
+            a2a_network_allowed_domains=("api.openai.com", "github.com"),
+            a2a_approval_policy="never",
+            a2a_approval_escalation_behavior="unsupported",
+            a2a_write_access_scope="workspace_and_declared_roots",
+            a2a_write_access_outside_workspace="disallowed",
         )
     )
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
@@ -71,6 +80,25 @@ def test_agent_card_injects_profile_into_extensions() -> None:
         "allow_override": False,
         "scope": "workspace_root_only",
         "metadata_field": "metadata.opencode.directory",
+    }
+    assert profile["runtime_features"]["execution_environment"] == {
+        "sandbox": {
+            "mode": "workspace-write",
+            "filesystem_scope": "workspace_and_declared_roots",
+            "writable_roots": ["/srv/workspaces/alpha", "/tmp/opencode"],
+        },
+        "network": {
+            "access": "restricted",
+            "allowed_domains": ["api.openai.com", "github.com"],
+        },
+        "approval": {
+            "policy": "never",
+            "escalation_behavior": "unsupported",
+        },
+        "write_access": {
+            "scope": "workspace_and_declared_roots",
+            "outside_workspace": "disallowed",
+        },
     }
 
     model_selection = ext_by_uri[MODEL_SELECTION_EXTENSION_URI]

--- a/tests/test_app_behaviors.py
+++ b/tests/test_app_behaviors.py
@@ -150,6 +150,23 @@ def test_agent_card_helper_builders_cover_optional_branches() -> None:
                 "availability": "enabled",
                 "toggle": "A2A_ENABLE_SESSION_SHELL",
             },
+            "execution_environment": {
+                "sandbox": {
+                    "mode": "unknown",
+                    "filesystem_scope": "unknown",
+                },
+                "network": {
+                    "access": "unknown",
+                },
+                "approval": {
+                    "policy": "unknown",
+                    "escalation_behavior": "unknown",
+                },
+                "write_access": {
+                    "scope": "unknown",
+                    "outside_workspace": "unknown",
+                },
+            },
             "service_features": {
                 "streaming": {
                     "enabled": True,
@@ -244,6 +261,23 @@ async def test_auth_health_lifespan_and_openapi_cache(monkeypatch) -> None:
                         "enabled": True,
                         "availability": "enabled",
                         "toggle": "A2A_ENABLE_SESSION_SHELL",
+                    },
+                    "execution_environment": {
+                        "sandbox": {
+                            "mode": "unknown",
+                            "filesystem_scope": "unknown",
+                        },
+                        "network": {
+                            "access": "unknown",
+                        },
+                        "approval": {
+                            "policy": "unknown",
+                            "escalation_behavior": "unknown",
+                        },
+                        "write_access": {
+                            "scope": "unknown",
+                            "outside_workspace": "unknown",
+                        },
                     },
                     "service_features": {
                         "streaming": {

--- a/tests/test_runtime_profile.py
+++ b/tests/test_runtime_profile.py
@@ -7,6 +7,15 @@ def test_runtime_profile_splits_deployment_runtime_features_and_health_payload()
         a2a_bearer_token="test-token",
         a2a_allow_directory_override=False,
         a2a_enable_session_shell=False,
+        a2a_sandbox_mode="workspace-write",
+        a2a_sandbox_filesystem_scope="workspace_and_declared_roots",
+        a2a_sandbox_writable_roots=("/workspace", "/tmp/opencode"),
+        a2a_network_access="restricted",
+        a2a_network_allowed_domains=("api.openai.com", "github.com"),
+        a2a_approval_policy="on-request",
+        a2a_approval_escalation_behavior="manual",
+        a2a_write_access_scope="workspace_and_declared_roots",
+        a2a_write_access_outside_workspace="disallowed",
         a2a_project="alpha",
         opencode_workspace_root="/workspace",
         opencode_agent="planner",
@@ -35,6 +44,25 @@ def test_runtime_profile_splits_deployment_runtime_features_and_health_payload()
                 "availability": "disabled",
                 "toggle": "A2A_ENABLE_SESSION_SHELL",
             },
+            "execution_environment": {
+                "sandbox": {
+                    "mode": "workspace-write",
+                    "filesystem_scope": "workspace_and_declared_roots",
+                    "writable_roots": ["/workspace", "/tmp/opencode"],
+                },
+                "network": {
+                    "access": "restricted",
+                    "allowed_domains": ["api.openai.com", "github.com"],
+                },
+                "approval": {
+                    "policy": "on-request",
+                    "escalation_behavior": "manual",
+                },
+                "write_access": {
+                    "scope": "workspace_and_declared_roots",
+                    "outside_workspace": "disallowed",
+                },
+            },
             "service_features": {
                 "streaming": {
                     "enabled": True,
@@ -62,4 +90,28 @@ def test_runtime_profile_splits_deployment_runtime_features_and_health_payload()
         "service": "opencode-a2a-server",
         "version": settings.a2a_version,
         "profile": profile.summary_dict(protocol_version=settings.a2a_protocol_version),
+    }
+
+
+def test_runtime_profile_uses_conservative_execution_environment_defaults() -> None:
+    settings = make_settings(a2a_bearer_token="test-token")
+
+    profile = build_runtime_profile(settings)
+
+    assert profile.runtime_features_dict()["execution_environment"] == {
+        "sandbox": {
+            "mode": "unknown",
+            "filesystem_scope": "unknown",
+        },
+        "network": {
+            "access": "unknown",
+        },
+        "approval": {
+            "policy": "unknown",
+            "escalation_behavior": "unknown",
+        },
+        "write_access": {
+            "scope": "unknown",
+            "outside_workspace": "unknown",
+        },
     }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -27,6 +27,15 @@ def test_settings_valid():
         "A2A_MAX_REQUEST_BODY_BYTES": "2048",
         "A2A_CANCEL_ABORT_TIMEOUT_SECONDS": "0.75",
         "A2A_ENABLE_SESSION_SHELL": "true",
+        "A2A_SANDBOX_MODE": "danger-full-access",
+        "A2A_SANDBOX_FILESYSTEM_SCOPE": "unrestricted",
+        "A2A_SANDBOX_WRITABLE_ROOTS": "/srv/workspaces/alpha,/tmp/opencode",
+        "A2A_NETWORK_ACCESS": "restricted",
+        "A2A_NETWORK_ALLOWED_DOMAINS": '["api.openai.com", "github.com"]',
+        "A2A_APPROVAL_POLICY": "never",
+        "A2A_APPROVAL_ESCALATION_BEHAVIOR": "unsupported",
+        "A2A_WRITE_ACCESS_SCOPE": "unrestricted",
+        "A2A_WRITE_ACCESS_OUTSIDE_WORKSPACE": "allowed",
     }
     with mock.patch.dict(os.environ, env, clear=True):
         settings = Settings.from_env()
@@ -37,6 +46,15 @@ def test_settings_valid():
         assert settings.a2a_max_request_body_bytes == 2048
         assert settings.a2a_cancel_abort_timeout_seconds == 0.75
         assert settings.a2a_enable_session_shell is True
+        assert settings.a2a_sandbox_mode == "danger-full-access"
+        assert settings.a2a_sandbox_filesystem_scope == "unrestricted"
+        assert settings.a2a_sandbox_writable_roots == ("/srv/workspaces/alpha", "/tmp/opencode")
+        assert settings.a2a_network_access == "restricted"
+        assert settings.a2a_network_allowed_domains == ("api.openai.com", "github.com")
+        assert settings.a2a_approval_policy == "never"
+        assert settings.a2a_approval_escalation_behavior == "unsupported"
+        assert settings.a2a_write_access_scope == "unrestricted"
+        assert settings.a2a_write_access_outside_workspace == "allowed"
         assert settings.a2a_version == __version__
 
 


### PR DESCRIPTION
## 关联

Closes #257
Related: #252, #255

## 变更概览

本 PR 在现有 `RuntimeProfile -> Agent Card / OpenAPI / /health` 单一来源链路上，补齐 execution environment boundary 的机器可发现声明；继续采用声明式 deployment metadata，不新增平行 public shape，也不把 per-turn runtime 审批结果误建模为稳定契约。

## 配置与模型

- 在 `src/opencode_a2a_server/config.py` 新增 execution environment 相关配置项：sandbox、network、approval、write access。
- 为可选披露列表新增统一解析逻辑，兼容 comma-separated string 与 JSON array。
- 在 `src/opencode_a2a_server/runtime_profile.py` 中新增 `ExecutionEnvironmentProfile` 及其子结构，并纳入 `runtime_features`。
- 对未配置项统一使用 `unknown` 保守默认值；仅在显式配置时输出 `writable_roots` / `allowed_domains`。

## 契约与文档

- 保持 Agent Card / OpenAPI / `/health` 继续复用同一份 `RuntimeProfile` 输出，不新增 legacy 或平行 discovery 面。
- 在 `docs/guide.md` 中补充新的环境变量、字段语义以及“声明式 deployment metadata，而非实时权限快照”的边界说明。

## 测试与验证

- 更新 `tests/test_runtime_profile.py`、`tests/test_app_behaviors.py`、`tests/test_agent_card.py`、`tests/test_settings.py`，覆盖 profile shape、health payload、Agent Card profile 注入、默认保守值与配置解析行为。
- 已执行：
  - `uv run pre-commit run --all-files`
  - `uv run pytest`

## 审查关注点

- 本 PR 与 #257 的关系应为 `Closes #257`，与 #252 / #255 的关系应为设计承接，因此保留 `Related` 更准确，不宜写成 `Closes`。
- 当前实现只声明 deployment-configured boundary，不尝试表达临时授权、即时越权或宿主 CLI 自省结果，符合 issue 对语义边界的要求。
