### PR TITLE
fix: configure interrupt retention and tombstones

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -60,9 +60,14 @@ Key variables to understand protocol behavior:
   return HTTP `413`.
 - `A2A_SESSION_CACHE_TTL_SECONDS` / `A2A_SESSION_CACHE_MAXSIZE`: session cache
   behavior for `(identity, contextId) -> session_id`.
-- `A2A_INTERRUPT_REQUEST_TTL_SECONDS`: retention window for the in-memory
-  interrupt request binding cache used by `a2a.interrupt.*` callback methods.
-  Default: `3600` seconds (`60` minutes).
+- `A2A_INTERRUPT_REQUEST_TTL_SECONDS`: active retention window for the
+  in-memory interrupt request binding cache used by `a2a.interrupt.*`
+  callback methods. Default: `10800` seconds (`180` minutes).
+- `A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS`: retention window for expired
+  interrupt tombstones after active TTL has elapsed. During this window,
+  repeated replies keep returning `INTERRUPT_REQUEST_EXPIRED` instead of
+  falling through to `INTERRUPT_REQUEST_NOT_FOUND`. Default: `600` seconds
+  (`10` minutes).
 - `A2A_CANCEL_ABORT_TIMEOUT_SECONDS`: best-effort timeout for upstream
   `session.abort` in cancel flow.
 - `OPENCODE_TIMEOUT` / `OPENCODE_TIMEOUT_STREAM`: upstream request timeout and
@@ -764,9 +769,14 @@ Notes:
   (`metadata.shared.interrupt.request_id`).
 - The server keeps an in-memory interrupt binding cache; callbacks with unknown
   or expired `request_id` are rejected.
-- The cache retention window is controlled by
-  `A2A_INTERRUPT_REQUEST_TTL_SECONDS` (default: `3600` seconds / `60`
-  minutes). This is a deployment/runtime setting and is intentionally not part
+- The cache retention windows are controlled by
+  `A2A_INTERRUPT_REQUEST_TTL_SECONDS` (default: `10800` seconds / `180`
+  minutes) and `A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS` (default: `600`
+  seconds / `10` minutes). After the active TTL elapses, the server keeps a
+  short-lived tombstone so repeated replies continue to return
+  `INTERRUPT_REQUEST_EXPIRED` before eventually aging out to
+  `INTERRUPT_REQUEST_NOT_FOUND`.
+- These values are deployment/runtime settings and are intentionally not part
   of the shared extension method contract.
 - Callback requests are validated against interrupt type and caller identity.
 - Callback context variables use the shared method contract plus

--- a/src/opencode_a2a_server/config.py
+++ b/src/opencode_a2a_server/config.py
@@ -140,9 +140,14 @@ class Settings(BaseSettings):
     a2a_session_cache_ttl_seconds: int = Field(default=3600, alias="A2A_SESSION_CACHE_TTL_SECONDS")
     a2a_session_cache_maxsize: int = Field(default=10_000, alias="A2A_SESSION_CACHE_MAXSIZE")
     a2a_interrupt_request_ttl_seconds: float = Field(
-        default=3600.0,
+        default=10_800.0,
         ge=0.0,
         alias="A2A_INTERRUPT_REQUEST_TTL_SECONDS",
+    )
+    a2a_interrupt_request_tombstone_ttl_seconds: float = Field(
+        default=600.0,
+        ge=0.0,
+        alias="A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS",
     )
     a2a_cancel_abort_timeout_seconds: float = Field(
         default=2.0,

--- a/src/opencode_a2a_server/opencode_upstream_client.py
+++ b/src/opencode_a2a_server/opencode_upstream_client.py
@@ -40,6 +40,12 @@ class InterruptRequestBinding:
     expires_at: float
 
 
+@dataclass(frozen=True)
+class InterruptRequestTombstone:
+    request_id: str
+    expires_at: float
+
+
 class OpencodeUpstreamClient:
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
@@ -51,8 +57,12 @@ class OpencodeUpstreamClient:
         self._stream_timeout = settings.opencode_timeout_stream
         self._log_payloads = settings.a2a_log_payloads
         self._interrupt_request_ttl_seconds = float(settings.a2a_interrupt_request_ttl_seconds)
+        self._interrupt_request_tombstone_ttl_seconds = float(
+            settings.a2a_interrupt_request_tombstone_ttl_seconds
+        )
         self._interrupt_request_clock = time.monotonic
         self._interrupt_requests: dict[str, InterruptRequestBinding] = {}
+        self._interrupt_request_tombstones: dict[str, InterruptRequestTombstone] = {}
         self._client = self._build_http_client(self._base_url)
 
     def _build_http_client(self, base_url: str) -> httpx.AsyncClient:
@@ -155,6 +165,26 @@ class OpencodeUpstreamClient:
         ]
         for request_id in expired:
             self._interrupt_requests.pop(request_id, None)
+            self._remember_interrupt_request_tombstone(request_id, now=now)
+
+    def _prune_interrupt_request_tombstones(self, *, now: float) -> None:
+        expired = [
+            request_id
+            for request_id, tombstone in self._interrupt_request_tombstones.items()
+            if tombstone.expires_at <= now
+        ]
+        for request_id in expired:
+            self._interrupt_request_tombstones.pop(request_id, None)
+
+    def _remember_interrupt_request_tombstone(self, request_id: str, *, now: float) -> None:
+        ttl = self._interrupt_request_tombstone_ttl_seconds
+        if ttl <= 0:
+            self._interrupt_request_tombstones.pop(request_id, None)
+            return
+        self._interrupt_request_tombstones[request_id] = InterruptRequestTombstone(
+            request_id=request_id,
+            expires_at=now + ttl,
+        )
 
     def remember_interrupt_request(
         self,
@@ -174,6 +204,7 @@ class OpencodeUpstreamClient:
             return
         now = self._interrupt_request_clock()
         self._prune_interrupt_requests(now=now)
+        self._prune_interrupt_request_tombstones(now=now)
         ttl = self._interrupt_request_ttl_seconds if ttl_seconds is None else ttl_seconds
         expires_at = now + max(0.0, float(ttl))
         self._interrupt_requests[request] = InterruptRequestBinding(
@@ -187,6 +218,7 @@ class OpencodeUpstreamClient:
             ),
             expires_at=expires_at,
         )
+        self._interrupt_request_tombstones.pop(request, None)
 
     def resolve_interrupt_request(
         self,
@@ -196,12 +228,16 @@ class OpencodeUpstreamClient:
         if not request:
             return "missing", None
         now = self._interrupt_request_clock()
+        self._prune_interrupt_request_tombstones(now=now)
         binding = self._interrupt_requests.get(request)
         if binding is None:
+            if request in self._interrupt_request_tombstones:
+                return "expired", None
             return "missing", None
         if binding.expires_at <= now:
             self._interrupt_requests.pop(request, None)
             self._prune_interrupt_requests(now=now)
+            self._remember_interrupt_request_tombstone(request, now=now)
             return "expired", None
         self._prune_interrupt_requests(now=now)
         return "active", binding
@@ -217,6 +253,7 @@ class OpencodeUpstreamClient:
         if not request:
             return
         self._interrupt_requests.pop(request, None)
+        self._interrupt_request_tombstones.pop(request, None)
 
     @property
     def stream_timeout(self) -> float | None:

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -25,6 +25,8 @@ def test_settings_valid():
         "OPENCODE_WORKSPACE_ROOT": "/srv/workspaces/alpha",
         "A2A_STREAM_SSE_PING_SECONDS": "20",
         "A2A_MAX_REQUEST_BODY_BYTES": "2048",
+        "A2A_INTERRUPT_REQUEST_TTL_SECONDS": "7200",
+        "A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS": "120",
         "A2A_CANCEL_ABORT_TIMEOUT_SECONDS": "0.75",
         "A2A_ENABLE_SESSION_SHELL": "true",
         "A2A_SANDBOX_MODE": "danger-full-access",
@@ -44,6 +46,8 @@ def test_settings_valid():
         assert settings.opencode_workspace_root == "/srv/workspaces/alpha"
         assert settings.a2a_stream_sse_ping_seconds == 20
         assert settings.a2a_max_request_body_bytes == 2048
+        assert settings.a2a_interrupt_request_ttl_seconds == 7200.0
+        assert settings.a2a_interrupt_request_tombstone_ttl_seconds == 120.0
         assert settings.a2a_cancel_abort_timeout_seconds == 0.75
         assert settings.a2a_enable_session_shell is True
         assert settings.a2a_sandbox_mode == "danger-full-access"

--- a/tests/upstream/test_opencode_upstream_client_params.py
+++ b/tests/upstream/test_opencode_upstream_client_params.py
@@ -512,6 +512,7 @@ async def test_interrupt_request_binding_expires_after_ttl() -> None:
             opencode_timeout=1.0,
             a2a_log_level="DEBUG",
             a2a_log_payloads=False,
+            a2a_interrupt_request_tombstone_ttl_seconds=2.0,
         )
     )
 
@@ -538,12 +539,56 @@ async def test_interrupt_request_binding_expires_after_ttl() -> None:
     assert status == "expired"
     assert binding is None
     assert client.resolve_interrupt_session("perm-1") is None
+    assert client.resolve_interrupt_request("perm-1") == ("expired", None)
+
+    now = 1009.0
+    status, binding = client.resolve_interrupt_request("perm-1")
+    assert status == "missing"
+    assert binding is None
 
     await client.close()
 
 
 @pytest.mark.asyncio
-async def test_interrupt_request_ttl_defaults_to_one_hour_and_is_configurable() -> None:
+async def test_interrupt_request_prune_keeps_expired_tombstone() -> None:
+    client = OpencodeUpstreamClient(
+        make_settings(
+            a2a_bearer_token="t-1",
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+            a2a_interrupt_request_tombstone_ttl_seconds=5.0,
+        )
+    )
+
+    now = 100.0
+    client._interrupt_request_clock = lambda: now  # type: ignore[method-assign]
+    client.remember_interrupt_request(
+        request_id="perm-1",
+        session_id="ses-1",
+        interrupt_type="permission",
+        ttl_seconds=2.0,
+    )
+
+    now = 103.0
+    client.remember_interrupt_request(
+        request_id="perm-2",
+        session_id="ses-2",
+        interrupt_type="permission",
+        ttl_seconds=10.0,
+    )
+
+    assert client.resolve_interrupt_request("perm-1") == ("expired", None)
+    assert client.resolve_interrupt_request("perm-2")[0] == "active"
+
+    now = 109.0
+    assert client.resolve_interrupt_request("perm-1") == ("missing", None)
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_request_ttl_defaults_to_three_hours_and_is_configurable() -> None:
     default_client = OpencodeUpstreamClient(
         make_settings(
             a2a_bearer_token="t-1",
@@ -552,7 +597,8 @@ async def test_interrupt_request_ttl_defaults_to_one_hour_and_is_configurable() 
             a2a_log_payloads=False,
         )
     )
-    assert default_client._interrupt_request_ttl_seconds == 3600.0
+    assert default_client._interrupt_request_ttl_seconds == 10_800.0
+    assert default_client._interrupt_request_tombstone_ttl_seconds == 600.0
     await default_client.close()
 
     configured_client = OpencodeUpstreamClient(
@@ -562,9 +608,11 @@ async def test_interrupt_request_ttl_defaults_to_one_hour_and_is_configurable() 
             a2a_log_level="DEBUG",
             a2a_log_payloads=False,
             a2a_interrupt_request_ttl_seconds=90.0,
+            a2a_interrupt_request_tombstone_ttl_seconds=15.0,
         )
     )
     assert configured_client._interrupt_request_ttl_seconds == 90.0
+    assert configured_client._interrupt_request_tombstone_ttl_seconds == 15.0
     await configured_client.close()
 
 


### PR DESCRIPTION
## 概要
本 PR 基于 `#265` 的诊断结果，继续实现 `#266`：
- 将 interrupt request active TTL 改为服务配置，默认值调整为 `180` 分钟
- 新增 expired tombstone TTL 配置，默认值为 `10` 分钟
- 在 expired 后短时间内稳定返回 `INTERRUPT_REQUEST_EXPIRED`，避免立即退化为 `INTERRUPT_REQUEST_NOT_FOUND`

## 按模块说明
### 配置层
- 新增 `A2A_INTERRUPT_REQUEST_TTL_SECONDS`，默认 `10800` 秒（180 分钟）
- 新增 `A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS`，默认 `600` 秒（10 分钟）

### Upstream Client / 状态管理
- `OpencodeUpstreamClient` 改为从 `Settings` 读取 interrupt active TTL 与 tombstone TTL
- interrupt request 过期后不再立即彻底删除，而是转入短期 tombstone 状态
- 在 tombstone 存续期内，同一 `request_id` 的重复 reply 继续返回 `INTERRUPT_REQUEST_EXPIRED`
- tombstone 过期后，才最终退化为 `INTERRUPT_REQUEST_NOT_FOUND`
- 后台 prune 路径也会把已过期 request 转成 tombstone，避免绕过该语义

### 测试
- 更新配置解析测试，覆盖两个新/变更的 TTL 配置项
- 更新 upstream client 测试，覆盖：
  - 默认 active/tombstone TTL
  - 自定义配置生效
  - 过期后 tombstone 保留与最终 aging out
  - prune 路径下 tombstone 语义保持一致

### 文档
- 更新 `docs/guide.md` 的运行时配置说明
- 更新 interrupt callback 章节，明确 active TTL、tombstone TTL 及其行为
- 明确这些值属于 deployment/runtime setting，不属于 shared extension method contract

## 相关提交
- `fix: configure interrupt request TTL (#266)`
- `fix: add interrupt tombstone retention (#266)`

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`

## 关联 Issue
- Closes #266
- Closes #265

## 关系说明
- `#265` 记录了 `interrupt_request_expired -> interrupt_request_not_found` 的根因诊断
- 本 PR 通过引入可配置 active TTL 与 tombstone TTL，直接修复了该问题对应的状态退化与交互时效缺陷，因此一并关闭 `#265`
- `#266` 记录本次实现工作本身，继续保持 `Closes #266`

## 说明
- 本 PR 仍未将 TTL 暴露到 extension contract / Agent Card 字段中
- 当前判断该值属于部署策略而非协议稳定语义，放在服务配置与 guide 层公开更合适
