### PR TITLE
feat: expose cancel/replay semantics in machine-readable service contracts

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -855,6 +855,7 @@ If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscr
 - Upstream interruption is best-effort: if upstream returns 404, network errors, or other HTTP errors, A2A cancellation still completes with `TaskState.canceled`.
 - Idempotency contract: repeated `tasks/cancel` on an already `canceled` task returns the current terminal task state without error.
 - Terminal subscribe contract: calling `subscribe` on a terminal task replays one terminal `Task` snapshot and then closes the stream.
+- These two semantics are also declared as machine-readable `service_behaviors` in the compatibility profile and wire contract extensions.
 - The service emits lightweight metric log records (`logger=opencode_a2a_server.execution.executor`):
   - `a2a_stream_requests_total`
   - `a2a_stream_active` (`value=1` when a stream starts, `value=-1` when it closes)

--- a/src/opencode_a2a_server/contracts/extensions.py
+++ b/src/opencode_a2a_server/contracts/extensions.py
@@ -22,6 +22,9 @@ PROVIDER_DISCOVERY_EXTENSION_URI = "urn:opencode-a2a:provider-discovery/v1"
 INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
 COMPATIBILITY_PROFILE_EXTENSION_URI = "urn:a2a:compatibility-profile/v1"
 WIRE_CONTRACT_EXTENSION_URI = "urn:a2a:wire-contract/v1"
+SERVICE_BEHAVIOR_CLASSIFICATION = "service-level-semantic-enhancement"
+CANCEL_IDEMPOTENCY_BEHAVIOR = "return_current_terminal_task"
+TERMINAL_RESUBSCRIBE_BEHAVIOR = "replay_terminal_task_once_then_close"
 
 
 @dataclass(frozen=True)
@@ -756,6 +759,7 @@ def build_compatibility_profile_params(
     runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
     capability_snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
+    service_behaviors = build_service_behavior_contract_params()
     method_retention: dict[str, dict[str, Any]] = {
         method: {
             "surface": "core",
@@ -842,6 +846,7 @@ def build_compatibility_profile_params(
             },
         },
         "method_retention": method_retention,
+        "service_behaviors": service_behaviors,
         "consumer_guidance": [
             "Treat core A2A methods as the stable interoperability baseline for generic clients.",
             (
@@ -866,6 +871,10 @@ def build_compatibility_profile_params(
                 "Treat opencode.sessions.shell as deployment-conditional and discover it from "
                 "the declared profile and current wire contract before calling it."
             ),
+            (
+                "Treat declared service behaviors as stable server-level semantic "
+                "enhancements layered on top of the core A2A method baseline."
+            ),
         ],
     }
 
@@ -876,6 +885,7 @@ def build_wire_contract_params(
     runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
     capability_snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
+    service_behaviors = build_service_behavior_contract_params()
 
     return {
         "protocol_version": protocol_version,
@@ -901,9 +911,38 @@ def build_wire_contract_params(
             ],
         },
         "all_jsonrpc_methods": capability_snapshot.supported_jsonrpc_methods(),
+        "service_behaviors": service_behaviors,
         "unsupported_method_error": {
             "code": -32601,
             "type": "METHOD_NOT_SUPPORTED",
             "data_fields": list(WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS),
+        },
+    }
+
+
+def build_service_behavior_contract_params() -> dict[str, Any]:
+    return {
+        "classification": SERVICE_BEHAVIOR_CLASSIFICATION,
+        "methods": {
+            "tasks/cancel": {
+                "baseline": "core",
+                "retention": "stable",
+                "idempotency": {
+                    "already_canceled": {
+                        "behavior": CANCEL_IDEMPOTENCY_BEHAVIOR,
+                        "returns_current_state": "canceled",
+                        "error": None,
+                    }
+                },
+            },
+            "tasks/resubscribe": {
+                "baseline": "core",
+                "retention": "stable",
+                "terminal_state_behavior": {
+                    "behavior": TERMINAL_RESUBSCRIBE_BEHAVIOR,
+                    "delivery": "single_task_snapshot",
+                    "closes_stream": True,
+                },
+            },
         },
     }

--- a/src/opencode_a2a_server/server/agent_card.py
+++ b/src/opencode_a2a_server/server/agent_card.py
@@ -208,7 +208,8 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     required=False,
                     description=(
                         "Expose the A2A compatibility profile defining core baselines, "
-                        "extension retention policies, and deployment-conditional methods."
+                        "extension retention policies, declared service behaviors, and "
+                        "deployment-conditional methods."
                     ),
                     params=compatibility_profile_params,
                 ),
@@ -217,7 +218,8 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     required=False,
                     description=(
                         "Expose the wire-level contract declaring supported JSON-RPC methods, "
-                        "HTTP endpoints, and unified error contracts."
+                        "HTTP endpoints, declared service behaviors, and unified error "
+                        "contracts."
                     ),
                     params=wire_contract_params,
                 ),

--- a/src/opencode_a2a_server/server/application.py
+++ b/src/opencode_a2a_server/server/application.py
@@ -6,7 +6,7 @@ import logging
 import secrets
 from contextlib import asynccontextmanager
 from contextvars import ContextVar, Token
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import uvicorn
 from a2a.server.apps.jsonrpc.fastapi_app import A2AFastAPI

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -1,6 +1,7 @@
 from opencode_a2a_server.contracts.extensions import (
     SESSION_QUERY_DEFAULT_LIMIT,
     SESSION_QUERY_MAX_LIMIT,
+    build_service_behavior_contract_params,
 )
 from opencode_a2a_server.jsonrpc.application import SESSION_CONTEXT_PREFIX
 from opencode_a2a_server.server.application import (
@@ -289,6 +290,7 @@ def test_agent_card_injects_profile_into_extensions() -> None:
         )
 
     compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
+    expected_service_behaviors = build_service_behavior_contract_params()
     assert compatibility.params["extension_retention"][MODEL_SELECTION_EXTENSION_URI] == {
         "surface": "core-runtime-metadata",
         "availability": "always",
@@ -305,18 +307,39 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     assert shell_policy["availability"] == "disabled"
     assert shell_policy["retention"] == "deployment-conditional"
     assert shell_policy["toggle"] == "A2A_ENABLE_SESSION_SHELL"
+    assert compatibility.params["service_behaviors"] == expected_service_behaviors
+    assert compatibility.params["service_behaviors"]["classification"] == (
+        "service-level-semantic-enhancement"
+    )
+    assert compatibility.params["service_behaviors"]["methods"]["tasks/cancel"]["idempotency"] == {
+        "already_canceled": {
+            "behavior": "return_current_terminal_task",
+            "returns_current_state": "canceled",
+            "error": None,
+        }
+    }
+    assert compatibility.params["service_behaviors"]["methods"]["tasks/resubscribe"][
+        "terminal_state_behavior"
+    ] == {
+        "behavior": "replay_terminal_task_once_then_close",
+        "delivery": "single_task_snapshot",
+        "closes_stream": True,
+    }
+    assert compatibility.description.endswith("deployment-conditional methods.")
 
     wire_contract = ext_by_uri[WIRE_CONTRACT_EXTENSION_URI]
     assert wire_contract.params["profile"]["profile_id"] == "opencode-a2a-single-tenant-coding-v1"
     assert MODEL_SELECTION_EXTENSION_URI in wire_contract.params["extensions"]["extension_uris"]
     assert PROVIDER_DISCOVERY_EXTENSION_URI in wire_contract.params["extensions"]["extension_uris"]
     assert "opencode.sessions.shell" not in wire_contract.params["all_jsonrpc_methods"]
+    assert wire_contract.params["service_behaviors"] == expected_service_behaviors
     assert wire_contract.params["extensions"]["conditionally_available_methods"] == {
         "opencode.sessions.shell": {
             "reason": "disabled_by_configuration",
             "toggle": "A2A_ENABLE_SESSION_SHELL",
         }
     }
+    assert wire_contract.description.endswith("unified error contracts.")
 
 
 def test_agent_card_chat_examples_include_project_hint_when_configured() -> None:


### PR DESCRIPTION
## 变更摘要

将 `#264` 中子任务 `#270` 对齐的目标落地为 machine-readable 契约表达：
- 让 `tasks/cancel` 的幂等语义（对已 canceled 的重复 cancel 返回当前终态）可被客户端从契约自动发现；
- 让 `terminal subscribe` 的 `replay-once` 行为（终态任务返回单条快照后关闭流）可被外部系统从契约自动发现；
- 保持原有实现、测试与文档语义不变，仅增强可发现性层。

## 修改内容（按模块）

- [核心契约] `src/opencode_a2a_server/contracts/extensions.py`
  - 新增 service-level 语义声明生成函数：`build_service_behavior_contract_params()`。
  - 在 `build_compatibility_profile_params` 和 `build_wire_contract_params` 中引入 `service_behaviors`。
  - 明确分类字段：`classification = service-level-semantic-enhancement`。
  - 关键字段：
    - `tasks/cancel` 的 `idempotency.already_canceled`。
    - `tasks/resubscribe` 的 `terminal_state_behavior`（`single_task_snapshot` + `closes_stream`）。

- [Agent Card] `src/opencode_a2a_server/server/agent_card.py`
  - 调整兼容性/线路契约扩展描述为明确承载 service behaviors。

- [文档] `docs/guide.md`
  - 补充说明上述两项语义已在 compatibility/wire contract 的 `service_behaviors` 中机读声明。

- [测试] `tests/server/test_agent_card.py`
  - 增补对 `service_behaviors` 的显式断言。

## 验证

- 已运行 `uv run pre-commit run --all-files`
- 已运行 `uv run pytest`

## 关联关系

- Closes #270
- Relates to #264

## 风险与说明

- 当前不改变 `tasks/cancel` 与 `tasks/resubscribe` 的执行实现，仅补充契约表达能力。
- 未覆盖额外的 schema 版本演进策略；如后续引入更多语义字段，请统一扩展 `build_service_behavior_contract_params()`。
