### PR TITLE
chore(ci): switch workflows to Node24 and disable uv cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: read
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   quality-gate:
@@ -25,7 +27,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Sync Dependencies
         run: uv sync --all-extras --frozen
@@ -73,7 +75,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Sync Dependencies
         run: uv sync --all-extras --frozen

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: read
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   dependency-health:
@@ -25,7 +27,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Run dependency health checks
         run: bash ./scripts/dependency_health.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: write
   id-token: write
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   publish:
@@ -28,7 +30,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Run regression baseline
         run: bash ./scripts/doctor.sh


### PR DESCRIPTION
## 变更概述
本次变更仅调整发布链路与 CI 的工作流环境策略，目的是解决发布流程中的缓存恢复异常与 Node.js 运行时弃用风险。

## 变更内容

### 1) CI/CD 流程兼容性（release/publish/health）
- 在 `.github/workflows/publish.yml`、`.github/workflows/ci.yml`、`.github/workflows/dependency-health.yml` 的顶层添加
  `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`。
- 该环境变量用于在当前 GitHub Actions 运行环境中将 JavaScript actions 的运行时行为提升到 Node 24，规避 Node.js 20 即将逐步废弃带来的阻断风险。

### 2) UV 缓存策略收敛
- 将上述三类 workflow 中 `astral-sh/setup-uv@v4` 的 `enable-cache` 从 `true` 调整为 `false`。
- 这是为了规避当前发布场景下 `cache` 恢复接口返回 `400` 导致的流水线失败，优先恢复稳定可发布路径。

## 风险与影响
- 关闭 `setup-uv` 缓存会导致首次拉起时安装速度略有下降（更慢），但可避免 publish/CI 因缓存异常中断。
- 当前不改变依赖声明和代码逻辑，仅调整 workflow 行为，可回滚性高。

## 验收建议
- 触发一次 `tag push`（或 `workflow_dispatch`）的 `Publish`。
- 观察发布日志：不再出现 Node.js 20 弃用导致阻断信息，并确认不再出现 `cache service responded with 400` 的恢复失败。

