### PR TITLE
fix(ci): format test_client_facade.py for ruff

### DIFF
--- a/tests/client/test_client_facade.py
+++ b/tests/client/test_client_facade.py
@@ -219,10 +219,7 @@ async def test_send_message_adds_bearer_token_from_settings(
     _, _, kwargs = fake_client.send_message_inputs[0]
     assert kwargs["request_metadata"] is None
     assert kwargs["context"] is not None
-    assert (
-        kwargs["context"].state["headers"]["Authorization"]
-        == "Bearer peer-token"
-    )
+    assert kwargs["context"].state["headers"]["Authorization"] == "Bearer peer-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更说明
本次仅修复 release 发布流程里 `Run regression baseline` 失败的真实原因：`ruff format` 在 CI 中会自动重写测试文件，导致步骤以非零状态结束，进而阻塞发布。

## 变更内容
### 1) 回归测试文件格式修正
- 文件：`tests/client/test_client_facade.py`
- 处理 `ruff format` 自动调整的长行断行
- 将断行恢复为 ruff 格式化输出的单行表达式，保证与 CI 工具版本一致

## 影响范围
- 仅变更文档行为无业务逻辑影响，仅影响代码风格一致性。
- 该修复依赖 `ruff format` 的规范化输出，解决当前发布失败（非缓存问题）。

## 关联信息
- 关联提交：`35345fb`
- Relates to: #289
