### PR TITLE
refactor(execution): split session, policy, and stream runtime

### DIFF
--- a/src/opencode_a2a/execution/event_helpers.py
+++ b/src/opencode_a2a/execution/event_helpers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from a2a.server.events.event_queue import EventQueue
+from a2a.types import Artifact, Part, TaskArtifactUpdateEvent
+
+
+async def _enqueue_artifact_update(
+    *,
+    event_queue: EventQueue,
+    task_id: str,
+    context_id: str,
+    artifact_id: str,
+    part: Part,
+    append: bool | None,
+    last_chunk: bool | None,
+    artifact_metadata: Mapping[str, Any] | None = None,
+    event_metadata: Mapping[str, Any] | None = None,
+) -> None:
+    normalized_last_chunk = True if last_chunk is True else None
+    artifact = Artifact(
+        artifact_id=artifact_id,
+        parts=[part],
+        metadata=dict(artifact_metadata) if artifact_metadata else None,
+    )
+    await event_queue.enqueue_event(
+        TaskArtifactUpdateEvent(
+            task_id=task_id,
+            context_id=context_id,
+            artifact=artifact,
+            append=append,
+            last_chunk=normalized_last_chunk,
+            metadata=dict(event_metadata) if event_metadata else None,
+        )
+    )

--- a/src/opencode_a2a/execution/executor.py
+++ b/src/opencode_a2a/execution/executor.py
@@ -21,7 +21,6 @@ from a2a.types import (
     Part,
     Role,
     Task,
-    TaskArtifactUpdateEvent,
     TaskState,
     TaskStatus,
     TaskStatusUpdateEvent,
@@ -35,6 +34,7 @@ from ..parts.mapping import (
     map_a2a_parts_to_opencode_parts,
     summarize_a2a_parts,
 )
+from .event_helpers import _enqueue_artifact_update
 from .policy import PolicyEnforcer
 from .request_context import (
     _build_history,
@@ -566,11 +566,6 @@ class OpencodeAgentExecutor(AgentExecutor):
             emit_metric=self._emit_metric,
             sleep=asyncio.sleep,
         )
-        self._sessions = self._session_manager._sessions
-        self._session_owners = self._session_manager._session_owners
-        self._pending_session_claims = self._session_manager._pending_session_claims
-        self._inflight_session_creates = self._session_manager._inflight_session_creates
-        self._session_locks = self._session_manager._session_locks
         self._lock = asyncio.Lock()
         self._running_requests: dict[tuple[str, str], asyncio.Task[Any]] = {}
         self._running_stop_events: dict[tuple[str, str], asyncio.Event] = {}
@@ -1113,34 +1108,4 @@ def _build_assistant_message(
         parts=[Part(root=TextPart(text=text))],
         task_id=task_id,
         context_id=context_id,
-    )
-
-
-async def _enqueue_artifact_update(
-    *,
-    event_queue: EventQueue,
-    task_id: str,
-    context_id: str,
-    artifact_id: str,
-    part: Part,
-    append: bool | None,
-    last_chunk: bool | None,
-    artifact_metadata: Mapping[str, Any] | None = None,
-    event_metadata: Mapping[str, Any] | None = None,
-) -> None:
-    normalized_last_chunk = True if last_chunk is True else None
-    artifact = Artifact(
-        artifact_id=artifact_id,
-        parts=[part],
-        metadata=dict(artifact_metadata) if artifact_metadata else None,
-    )
-    await event_queue.enqueue_event(
-        TaskArtifactUpdateEvent(
-            task_id=task_id,
-            context_id=context_id,
-            artifact=artifact,
-            append=append,
-            last_chunk=normalized_last_chunk,
-            metadata=dict(event_metadata) if event_metadata else None,
-        )
     )

--- a/src/opencode_a2a/execution/policy.py
+++ b/src/opencode_a2a/execution/policy.py
@@ -42,4 +42,3 @@ class PolicyEnforcer:
 
     def resolve_directory_for_control(self, requested: str | None) -> str | None:
         return self.resolve_directory(requested)
-

--- a/src/opencode_a2a/execution/session_manager.py
+++ b/src/opencode_a2a/execution/session_manager.py
@@ -138,4 +138,3 @@ class SessionManager:
         async with self._lock:
             self._sessions.pop((identity, context_id))
             return self._inflight_session_creates.pop((identity, context_id), None)
-

--- a/src/opencode_a2a/execution/stream_runtime.py
+++ b/src/opencode_a2a/execution/stream_runtime.py
@@ -9,16 +9,15 @@ from typing import Any
 
 from a2a.server.events.event_queue import EventQueue
 from a2a.types import (
-    Artifact,
     DataPart,
     Part,
-    TaskArtifactUpdateEvent,
     TaskState,
     TaskStatus,
     TaskStatusUpdateEvent,
     TextPart,
 )
 
+from .event_helpers import _enqueue_artifact_update
 from .stream_events import (
     BlockType,
     _build_progress_identity,
@@ -49,36 +48,6 @@ from .stream_state import (
 from .upstream_errors import _StreamTerminalSignal
 
 logger = logging.getLogger("opencode_a2a.execution.executor")
-
-
-async def _enqueue_artifact_update(
-    *,
-    event_queue: EventQueue,
-    task_id: str,
-    context_id: str,
-    artifact_id: str,
-    part: Part,
-    append: bool | None,
-    last_chunk: bool | None,
-    artifact_metadata: Mapping[str, Any] | None = None,
-    event_metadata: Mapping[str, Any] | None = None,
-) -> None:
-    normalized_last_chunk = True if last_chunk is True else None
-    artifact = Artifact(
-        artifact_id=artifact_id,
-        parts=[part],
-        metadata=dict(artifact_metadata) if artifact_metadata else None,
-    )
-    await event_queue.enqueue_event(
-        TaskArtifactUpdateEvent(
-            task_id=task_id,
-            context_id=context_id,
-            artifact=artifact,
-            append=append,
-            last_chunk=normalized_last_chunk,
-            metadata=dict(event_metadata) if event_metadata else None,
-        )
-    )
 
 
 class StreamRuntime:

--- a/tests/execution/test_cancellation.py
+++ b/tests/execution/test_cancellation.py
@@ -86,7 +86,7 @@ async def test_cancel_interrupts_running_execute_and_keeps_queue_open(caplog):
         "metric=a2a_cancel_abort_success_total" in record.message for record in caplog.records
     )
     assert any("metric=a2a_cancel_duration_ms" in record.message for record in caplog.records)
-    assert executor._sessions.get(("user-1", "context-A")) is None
+    assert executor._session_manager._sessions.get(("user-1", "context-A")) is None
     assert ("task-1", "context-A") not in executor._running_requests
     assert ("task-1", "context-A") not in executor._running_stop_events
     assert ("task-1", "context-A") not in executor._running_identities
@@ -261,7 +261,7 @@ async def test_cancel_waiting_for_session_lock_does_not_abort_other_generation()
     executor = OpencodeAgentExecutor(client, streaming_enabled=False)
     prelocked_session_lock = asyncio.Lock()
     await prelocked_session_lock.acquire()
-    executor._session_locks["session-4"] = prelocked_session_lock
+    executor._session_manager._session_locks["session-4"] = prelocked_session_lock
 
     execute_context = make_request_context_mock(
         task_id="task-4",
@@ -274,7 +274,7 @@ async def test_cancel_waiting_for_session_lock_does_not_abort_other_generation()
 
     try:
         for _ in range(20):
-            if executor._sessions.get(("user-4", "context-D")) == "session-4":
+            if executor._session_manager._sessions.get(("user-4", "context-D")) == "session-4":
                 break
             await asyncio.sleep(0.01)
 

--- a/tests/execution/test_session_ownership.py
+++ b/tests/execution/test_session_ownership.py
@@ -49,7 +49,7 @@ async def test_identity_isolation(mock_client):
 
     await executor.execute(context1, event_queue)
     mock_client.create_session.assert_called_once()
-    assert executor._sessions.get(("user-1", "context-A")) == "session-1"
+    assert executor._session_manager._sessions.get(("user-1", "context-A")) == "session-1"
 
     # User 2, Context A (Same context ID, different user)
     context2 = make_request_context_mock(
@@ -62,9 +62,9 @@ async def test_identity_isolation(mock_client):
     await executor.execute(context2, event_queue)
     # Should create a NEW session for user-2
     assert mock_client.create_session.call_count == 2
-    assert executor._sessions.get(("user-2", "context-A")) == "session-2"
+    assert executor._session_manager._sessions.get(("user-2", "context-A")) == "session-2"
     # User 1's session should still be there
-    assert executor._sessions.get(("user-1", "context-A")) == "session-1"
+    assert executor._session_manager._sessions.get(("user-1", "context-A")) == "session-1"
 
 
 @pytest.mark.asyncio
@@ -81,7 +81,7 @@ async def test_session_hijack_prevention(mock_client):
     )
 
     await executor.execute(context1, event_queue)
-    assert executor._session_owners.get("session-1") == "user-1"
+    assert executor._session_manager._session_owners.get("session-1") == "user-1"
 
     # User 2 tries to bind to session-1 via metadata
     context2 = make_request_context_mock(
@@ -168,8 +168,8 @@ async def test_concurrent_session_create_isolated_by_identity():
     )
 
     assert client.create_session.call_count == 2
-    assert executor._sessions.get(("user-1", "context-A")) == "session-1"
-    assert executor._sessions.get(("user-2", "context-A")) == "session-2"
+    assert executor._session_manager._sessions.get(("user-1", "context-A")) == "session-1"
+    assert executor._session_manager._sessions.get(("user-2", "context-A")) == "session-2"
 
 
 def test_session_owner_cache_is_bounded():
@@ -180,12 +180,12 @@ def test_session_owner_cache_is_bounded():
         session_cache_maxsize=2,
     )
 
-    executor._session_owners.set("session-1", "user-1")
-    executor._session_owners.set("session-2", "user-2")
-    executor._session_owners.set("session-3", "user-3")
+    executor._session_manager._session_owners.set("session-1", "user-1")
+    executor._session_manager._session_owners.set("session-2", "user-2")
+    executor._session_manager._session_owners.set("session-3", "user-3")
 
     # Cache is bounded by maxsize and should not grow unbounded.
-    assert len(executor._session_owners._store) <= 2
+    assert len(executor._session_manager._session_owners._store) <= 2
 
 
 def test_owner_cache_refresh_on_get_extends_ttl():
@@ -257,8 +257,8 @@ async def test_preferred_session_claim_is_released_on_upstream_failure():
 
     await executor.execute(context, event_queue)
 
-    assert executor._session_owners.get("session-X") is None
-    assert executor._pending_session_claims.get("session-X") is None
+    assert executor._session_manager._session_owners.get("session-X") is None
+    assert executor._session_manager._pending_session_claims.get("session-X") is None
 
 
 @pytest.mark.asyncio
@@ -292,8 +292,8 @@ async def test_preferred_session_claim_is_released_on_upstream_cancellation():
     with pytest.raises(asyncio.CancelledError):
         await executor.execute(context, event_queue)
 
-    assert executor._session_owners.get("session-X") is None
-    assert executor._pending_session_claims.get("session-X") is None
+    assert executor._session_manager._session_owners.get("session-X") is None
+    assert executor._session_manager._pending_session_claims.get("session-X") is None
 
 
 @pytest.mark.asyncio

--- a/tests/jsonrpc/test_opencode_session_extension_commands.py
+++ b/tests/jsonrpc/test_opencode_session_extension_commands.py
@@ -380,7 +380,9 @@ async def test_session_shell_extension_rejects_owner_mismatch(monkeypatch):
             **_BASE_SETTINGS,
         )
     )
-    app.state.opencode_agent_executor._session_owners.set("s-1", "bearer:other")  # noqa: SLF001
+    app.state.opencode_agent_executor._session_manager._session_owners.set(  # noqa: SLF001
+        "s-1", "bearer:other"
+    )
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/jsonrpc/test_opencode_session_extension_prompt_async.py
+++ b/tests/jsonrpc/test_opencode_session_extension_prompt_async.py
@@ -173,7 +173,9 @@ async def test_session_prompt_async_extension_rejects_owner_mismatch(monkeypatch
     app = app_module.create_app(
         make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
     )
-    app.state.opencode_agent_executor._session_owners.set("s-1", "bearer:other")  # noqa: SLF001
+    app.state.opencode_agent_executor._session_manager._session_owners.set(  # noqa: SLF001
+        "s-1", "bearer:other"
+    )
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## 概要
本 PR 完成 `#273` 的执行层重构，将原先集中在 `executor.py` 中的会话管理、目录策略、流式运行时逻辑拆分为独立模块，并将 `executor` 收缩为更薄的编排层。

## 模块变更
### `execution/session_manager.py`
- 抽离 session cache、owner claim、pending claim、inflight create、session lock
- 保持原有 `(identity, context_id) -> session` 绑定行为不变
- 保持 control 面 claim/finalize/release 复用能力

### `execution/policy.py`
- 抽离 directory normalize / validate 逻辑
- 保持 workspace boundary 与 override policy 行为不变
- 为后续 `#278` 的策略增强预留独立边界

### `execution/stream_runtime.py`
- 抽离 `_consume_opencode_stream` 主循环
- 统一流式 chunk、progress、interrupt、terminal signal 的消费与事件发射
- 复用既有 `stream_events.py`、`stream_state.py`、`upstream_errors.py`

### `execution/event_helpers.py`
- 抽离共享 artifact update helper
- 消除 `executor.py` 与 `stream_runtime.py` 的重复实现

### `execution/executor.py`
- 收缩为 facade / orchestrator
- 保留 execute / cancel / upstream tool dispatch / error 出口
- 移除对 `session_manager` 内部状态的兼容别名，避免继续保留临时耦合层

### 测试调整
- 将依赖旧兼容别名的测试切换为直接访问 `session_manager` 内部状态
- 保持行为断言与覆盖范围不变

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`

## 关联 Issues
- Closes #273
- Relates to #278
- Relates to #276
- Relates to #274
- Relates to #279

## 当前状态
- 先前审查中提到的两个非阻塞风险已完成清理：
  - 已移除 `executor` 对 `session_manager` 内部状态的兼容别名
  - 已抽出共享 `artifact update` helper，消除重复实现
