### PR TITLE
refactor(cli): remove redundant serve subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ OPENCODE_WORKSPACE_ROOT=/abs/path/to/workspace \
 opencode-a2a
 ```
 
-`opencode-a2a serve` remains available as a backward-compatible alias.
-
 Verify that the service is up:
 
 ```bash

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -157,8 +157,6 @@ OPENCODE_WORKSPACE_ROOT=/abs/path/to/workspace \
 opencode-a2a
 ```
 
-`opencode-a2a serve` remains available as a backward-compatible alias.
-
 ## Troubleshooting Provider Auth State
 
 If one deployment works while another fails against the same upstream provider,

--- a/src/opencode_a2a/cli.py
+++ b/src/opencode_a2a/cli.py
@@ -56,10 +56,6 @@ def build_parser() -> argparse.ArgumentParser:
             "OpenCode A2A runtime. Run without a subcommand to start the service."
             " Deployment supervision is intentionally left to the operator."
         ),
-        epilog=(
-            "Running `opencode-a2a` with no subcommand starts the runtime."
-            " `serve` is kept as a backward-compatible alias."
-        ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -69,14 +65,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     subparsers = parser.add_subparsers(dest="command")
-    subparsers.add_parser(
-        "serve",
-        help="Backward-compatible alias for starting the OpenCode A2A runtime.",
-        description=(
-            "Backward-compatible alias for starting the OpenCode A2A runtime"
-            " using environment-based settings."
-        ),
-    )
 
     call_parser = subparsers.add_parser(
         "call",
@@ -103,10 +91,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     namespace = parser.parse_args(args)
-    if namespace.command == "serve":
-        serve_main()
-        return 0
-
     if namespace.command == "call":
         return asyncio.run(run_call(namespace.agent_url, namespace.text, namespace.token))
 

--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -14,24 +14,20 @@ def test_cli_help_does_not_require_runtime_settings(capsys: pytest.CaptureFixtur
 
     assert excinfo.value.code == 0
     help_text = capsys.readouterr().out
-    assert "serve" in help_text
     assert "Run without a subcommand to start the service." in help_text
-    assert "backward-compatible alias" in help_text
+    assert "{call}" in help_text
+    assert "serve" not in help_text
     assert "deploy-release" not in help_text
     assert "init-release-system" not in help_text
     assert "uninstall-instance" not in help_text
     serve_mock.assert_not_called()
 
 
-def test_cli_serve_help_exposes_runtime_contract(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
+def test_cli_serve_subcommand_is_rejected() -> None:
     with pytest.raises(SystemExit) as excinfo:
-        cli.main(["serve", "--help"])
+        cli.main(["serve"])
 
-    assert excinfo.value.code == 0
-    help_text = capsys.readouterr().out
-    assert "Backward-compatible alias for starting the OpenCode A2A runtime" in help_text
+    assert excinfo.value.code == 2
 
 
 def test_cli_version_does_not_require_runtime_settings(
@@ -49,13 +45,6 @@ def test_cli_version_does_not_require_runtime_settings(
 def test_cli_defaults_to_serve_when_no_subcommand() -> None:
     with mock.patch("opencode_a2a.cli.serve_main") as serve_mock:
         assert cli.main([]) == 0
-
-    serve_mock.assert_called_once_with()
-
-
-def test_cli_serve_subcommand_invokes_runtime() -> None:
-    with mock.patch("opencode_a2a.cli.serve_main") as serve_mock:
-        assert cli.main(["serve"]) == 0
 
     serve_mock.assert_called_once_with()
 


### PR DESCRIPTION
## 概要
本 PR 聚焦 `#295`，收敛 CLI 启动入口并移除冗余的 `serve` 子命令。

当前 `opencode-a2a` 无子命令时即可直接启动服务，因此 `serve` 不再保留为兼容入口。本次实现将 canonical 启动方式统一为根命令 `opencode-a2a`，并同步收敛文档与测试。

## 模块变更
### `src/opencode_a2a/cli.py`
- 保留无子命令直接启动服务的默认行为。
- 移除 `serve` 子命令及其相关 help 文案。
- CLI 仅保留根命令启动服务与 `call` 子命令两种入口。

### `README.md`
- Quick Start 统一改为使用 `opencode-a2a` 启动服务。
- 删除 `serve` 兼容说明，避免继续强化旧入口。

### `docs/guide.md`
- 与 README 保持一致，只保留 `opencode-a2a` 作为服务启动命令。
- 删除 `serve` 相关兼容说明。

### `tests/server/test_cli.py`
- 断言 root help 只体现根命令默认启动语义。
- 新增断言：`serve` 会被 argparse 拒绝。
- 删除旧的 `serve` help / runtime 调用测试。

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
- 结果：`340 passed`

## 关联
Closes #295
