### PR TITLE
fix(ci): split runtime and dev dependency audits (#313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,13 @@ jobs:
       - name: Enforce coverage policy
         run: uv run python ./scripts/check_coverage.py
 
-      - name: Run dependency vulnerability audit
-        run: uv run pip-audit
+      - name: Export runtime requirements for vulnerability audit
+        run: >
+          uv export --format requirements.txt --no-dev --locked --no-emit-project
+          --output-file /tmp/runtime-requirements.txt >/dev/null
+
+      - name: Run runtime dependency vulnerability audit
+        run: uv run pip-audit --requirement /tmp/runtime-requirements.txt
 
       - name: Clean previous build artifacts
         run: rm -rf build dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,13 @@ jobs:
       - name: Run regression baseline
         run: bash ./scripts/doctor.sh
 
-      - name: Run dependency vulnerability audit
-        run: uv run pip-audit
+      - name: Export runtime requirements for vulnerability audit
+        run: >
+          uv export --format requirements.txt --no-dev --locked --no-emit-project
+          --output-file /tmp/runtime-requirements.txt >/dev/null
+
+      - name: Run runtime dependency vulnerability audit
+        run: uv run pip-audit --requirement /tmp/runtime-requirements.txt
 
       - name: Clean previous build artifacts
         run: rm -rf build dist

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ remaining repository-maintenance helpers.
 ## Other Scripts
 
 - [`doctor.sh`](./doctor.sh): primary local development regression entrypoint (uv sync + lint + tests + coverage)
-- [`dependency_health.sh`](./dependency_health.sh): dependency review entrypoint (`sync`/`pip check` + outdated + audit)
+- [`dependency_health.sh`](./dependency_health.sh): development dependency review entrypoint (`sync`/`pip check` + outdated + dev audit), while blocking CI/publish audits focus on runtime dependencies
 - [`check_coverage.py`](./check_coverage.py): enforces the overall coverage floor and per-file minimums for critical modules
 - [`lint.sh`](./lint.sh): lint helper
 - [`smoke_test_built_cli.sh`](./smoke_test_built_cli.sh): built-artifact smoke test for the released CLI runtime; defaults to the only local wheel, supports explicit wheel/sdist paths, and rejects ambiguous local artifact selection

--- a/scripts/dependency_health.sh
+++ b/scripts/dependency_health.sh
@@ -9,5 +9,11 @@ run_shared_repo_health_prerequisites "dependency-health"
 echo "[dependency-health] list outdated packages"
 uv pip list --outdated
 
-echo "[dependency-health] run vulnerability audit"
-uv run pip-audit
+dev_requirements="$(mktemp)"
+trap 'rm -f "${dev_requirements}"' EXIT
+
+echo "[dependency-health] export dev extra requirements"
+uv export --format requirements.txt --extra dev --no-dev --locked --no-emit-project --output-file "${dev_requirements}" >/dev/null
+
+echo "[dependency-health] run dev dependency vulnerability audit"
+uv run pip-audit --requirement "${dev_requirements}"


### PR DESCRIPTION
## 变更说明
本 PR 将阻塞型依赖审计限制为 runtime 依赖，并把 dev 工具链依赖的漏洞检查留在现有 `dependency-health` 通道中。

### 具体调整
- `CI` workflow 改为基于 `uv.lock` 导出的 runtime requirements 执行阻塞型 `pip-audit`
- `Publish` workflow 同样只对 runtime requirements 执行阻塞型 `pip-audit`
- `scripts/dependency_health.sh` 改为导出 `dev` extra 依赖图并执行 dev dependency audit
- `scripts/README.md` 补充 runtime blocking / dev visibility 的脚本说明

## 背景与原因
当前仓库与另一仓库存在同类问题：`CI` / `Publish` 在安装 `--all-extras` 后直接执行 `uv run pip-audit`，导致 `pytest -> pygments`、`pip-audit -> rich -> pygments` 这类 dev 工具链依赖的漏洞也会阻塞主线 CI 和发版流程。

当前已复现 `pygments 2.19.2 / CVE-2026-4539`。它不是 runtime 依赖，因此更合理的策略是：
- runtime 依赖继续阻塞
- dev 依赖继续可见，但不阻塞无关业务提交和发版

## 验证记录
- `bash -n scripts/dependency_health.sh`
  - 结果：通过
- `git diff --check`
  - 结果：通过
- `bash ./scripts/doctor.sh`
  - 结果：通过，`364 passed`
- `uv export --format requirements.txt --no-dev --locked --no-emit-project --output-file /tmp/opencode-runtime-req-final.txt >/dev/null && uv run pip-audit --requirement /tmp/opencode-runtime-req-final.txt`
  - 结果：`No known vulnerabilities found`
- `bash ./scripts/dependency_health.sh`
  - 结果：仍报 `pygments 2.19.2 / CVE-2026-4539`，符合“保留 dev 依赖风险可见性”的预期

## 关联 Issue
- Closes #313
