### PR TITLE
enhance: use weak session lock registry

### DIFF
--- a/src/opencode_a2a/execution/session_manager.py
+++ b/src/opencode_a2a/execution/session_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import weakref
 
 from ..invocation import call_with_supported_kwargs
 from ..server.state_store import MemorySessionStateRepository, SessionStateRepository
@@ -24,7 +25,9 @@ class SessionManager:
         )
         self._lock = asyncio.Lock()
         self._inflight_session_creates: dict[tuple[str, str], asyncio.Task[str]] = {}
-        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._session_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
+            weakref.WeakValueDictionary()
+        )
 
     async def get_or_create_session(
         self,

--- a/tests/execution/test_session_lock_lifecycle.py
+++ b/tests/execution/test_session_lock_lifecycle.py
@@ -1,0 +1,33 @@
+import gc
+import weakref
+from unittest.mock import AsyncMock
+
+import pytest
+
+from opencode_a2a.execution.session_manager import SessionManager
+from opencode_a2a.opencode_upstream_client import OpencodeUpstreamClient
+
+
+@pytest.mark.asyncio
+async def test_session_manager_reuses_live_lock_for_same_session() -> None:
+    manager = SessionManager(client=AsyncMock(spec=OpencodeUpstreamClient))
+
+    lock1 = await manager.get_session_lock("session-1")
+    lock2 = await manager.get_session_lock("session-1")
+
+    assert lock1 is lock2
+
+
+@pytest.mark.asyncio
+async def test_session_manager_does_not_strongly_retain_idle_locks() -> None:
+    manager = SessionManager(client=AsyncMock(spec=OpencodeUpstreamClient))
+
+    lock = await manager.get_session_lock("session-1")
+    lock_ref = weakref.ref(lock)
+    assert "session-1" in manager._session_locks
+
+    del lock
+    gc.collect()
+
+    assert lock_ref() is None
+    assert "session-1" not in manager._session_locks


### PR DESCRIPTION
## 概要
- 实现 `#326`，收敛 `SessionManager` 空闲 session lock 的生命周期
- 避免 manager 对空闲 `asyncio.Lock` 长期强持有

## 关联 Issues
- Closes #326

## 按模块说明
### 1. Session Lock 生命周期
- 将 `SessionManager._session_locks` 从普通 `dict` 改为 `weakref.WeakValueDictionary[str, asyncio.Lock]`
- 保持 `get_session_lock()` 对同一 `session_id` 的活跃 lock 复用语义不变
- 当 lock 不再被执行路径持有时，允许其自动回收，避免长生命周期进程中 lock 字典持续累计

### 2. 回归测试
- 新增 `tests/execution/test_session_lock_lifecycle.py`
- 覆盖：
  - 同一 `session_id` 的 live lock 仍复用
  - 空闲 lock 在无外部强引用后会被自动回收
- 同时通过既有 cancellation / session ownership 路径，确认没有破坏串行语义

## 回归验证
- `./scripts/doctor.sh`
- 结果：`439` 个测试通过，coverage `91.48%`

## 设计说明
- 不新增新的 TTL/LRU 配置，也不引入 sweep 任务
- 采用弱引用是更小、更稳妥的对象生命周期收敛方式，符合 `#326` 的“最小机制”目标
