### PR TITLE
fix: backfill legacy sqlite interrupt request details column

### DIFF
--- a/src/opencode_a2a/server/state_store.py
+++ b/src/opencode_a2a/server/state_store.py
@@ -15,7 +15,9 @@ from sqlalchemy import (
     and_,
     delete,
     insert,
+    inspect,
     select,
+    text,
     update,
 )
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -25,6 +27,7 @@ from ..execution.stream_state import _TTLCache
 from ..runtime_state import InterruptRequestBinding, InterruptRequestTombstone
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
     from sqlalchemy.ext.asyncio import AsyncEngine
 
 _STATE_METADATA = MetaData()
@@ -68,6 +71,34 @@ _INTERRUPT_REQUESTS = Table(
 
 _MEMORY_SESSION_BINDING_TTL_SECONDS = 3600
 _MEMORY_SESSION_BINDING_MAXSIZE = 10_000
+
+
+def _add_missing_sqlite_column(
+    connection: Connection,
+    *,
+    table: Table,
+    column_name: str,
+) -> None:
+    if connection.dialect.name != "sqlite":
+        return
+    existing_columns = {column["name"] for column in inspect(connection).get_columns(table.name)}
+    if column_name in existing_columns:
+        return
+    column = table.c[column_name]
+    if column.primary_key or not column.nullable:
+        raise RuntimeError(
+            f"Unsupported SQLite state-store migration for {table.name}.{column_name}"
+        )
+    column_type = column.type.compile(dialect=connection.dialect)
+    connection.execute(text(f'ALTER TABLE "{table.name}" ADD COLUMN "{column_name}" {column_type}'))
+
+
+def _ensure_state_store_schema(connection: Connection) -> None:
+    _add_missing_sqlite_column(
+        connection,
+        table=_INTERRUPT_REQUESTS,
+        column_name="details_json",
+    )
 
 
 class SessionStateRepository(ABC):
@@ -220,6 +251,7 @@ class DatabaseSessionStateRepository(SessionStateRepository):
             return
         async with self.engine.begin() as conn:
             await conn.run_sync(_STATE_METADATA.create_all)
+            await conn.run_sync(_ensure_state_store_schema)
         self._initialized = True
 
     async def _ensure_initialized(self) -> None:
@@ -541,6 +573,7 @@ class DatabaseInterruptRequestRepository(InterruptRequestRepository):
             return
         async with self.engine.begin() as conn:
             await conn.run_sync(_STATE_METADATA.create_all)
+            await conn.run_sync(_ensure_state_store_schema)
         self._initialized = True
 
     async def _ensure_initialized(self) -> None:

--- a/tests/server/test_state_store.py
+++ b/tests/server/test_state_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy import text
 
 from opencode_a2a.server.state_store import (
     DatabaseSessionStateRepository,
@@ -221,5 +222,75 @@ async def test_interrupt_request_repository_lists_pending_items_by_identity_and_
     assert permission_items[0].details == {"permission": "read"}
     assert [item.request_id for item in question_items] == ["q-1"]
     assert question_items[0].details == {"questions": [{"question": "Proceed?"}]}
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_database_interrupt_request_repository_upgrades_legacy_interrupt_table(
+    tmp_path: Path,
+) -> None:
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'legacy-interrupt.db'}"
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_task_store_database_url=database_url,
+    )
+    engine = build_database_engine(settings)
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                """
+                CREATE TABLE a2a_interrupt_requests (
+                    request_id VARCHAR NOT NULL PRIMARY KEY,
+                    session_id VARCHAR,
+                    interrupt_type VARCHAR,
+                    identity VARCHAR,
+                    task_id VARCHAR,
+                    context_id VARCHAR,
+                    expires_at FLOAT,
+                    tombstone_expires_at FLOAT
+                )
+                """
+            )
+        )
+        await conn.execute(
+            text(
+                """
+                INSERT INTO a2a_interrupt_requests (
+                    request_id,
+                    session_id,
+                    interrupt_type,
+                    identity,
+                    task_id,
+                    context_id,
+                    expires_at,
+                    tombstone_expires_at
+                ) VALUES (
+                    'perm-legacy',
+                    'ses-legacy',
+                    'permission',
+                    'user-1',
+                    'task-legacy',
+                    'ctx-legacy',
+                    4102444800.0,
+                    NULL
+                )
+                """
+            )
+        )
+
+    repository = build_interrupt_request_repository(settings, engine=engine)
+    await initialize_state_repository(repository)
+
+    status, binding = await repository.resolve(request_id="perm-legacy")
+    pending = await repository.list_pending(identity="user-1", interrupt_type="permission")
+
+    assert status == "active"
+    assert binding is not None
+    assert binding.session_id == "ses-legacy"
+    assert binding.details is None
+    assert [item.request_id for item in pending] == ["perm-legacy"]
+    assert pending[0].details is None
 
     await engine.dispose()


### PR DESCRIPTION
## 变更概述
- 修复旧版 SQLite runtime state 数据库升级到新代码后，`a2a_interrupt_requests` 缺少 `details_json` 列导致的查询失败。
- 保持当前轻量持久化方案，不引入完整 Alembic/versioned migration 体系，仅补充受控的启动期兼容升级。

## 按模块说明
### `server/state_store`
- 在数据库初始化后补充 SQLite 旧表结构校验。
- 对已存在但缺少 `details_json` 的 `a2a_interrupt_requests` 表执行安全的可空列补齐。
- 兼容逻辑仍限制在初始化路径，不改变正常读写流程。

### `tests/server`
- 新增旧版中断请求表结构的回归测试。
- 覆盖“历史表缺列但升级后仍可正常查询”的场景。

## 验证
- `uv run pytest --no-cov tests/server/test_state_store.py`
- `./scripts/doctor.sh`

## 关联 Issue
- Closes #357
