### PR TITLE
ci: harden publish release recovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
       publish_to_pypi:
         description: Publish artifacts to PyPI before syncing the GitHub Release
         required: true
-        default: true
+        default: false
         type: boolean
       sync_github_release:
         description: Create or repair the GitHub Release and release assets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,8 @@ uv run mypy src/opencode_a2a
 
 - Tag pushes still perform the full release flow: regression checks, artifact builds, PyPI publish, and GitHub Release sync.
 - Manual `workflow_dispatch` runs require a `release_tag` input so the workflow checks out and rebuilds the exact tagged revision instead of the current branch tip.
-- Use `publish_to_pypi=false` when PyPI already contains the release and you only need to create or repair the GitHub Release.
+- Manual `workflow_dispatch` runs default `publish_to_pypi=false` so the safest recovery path is to repair the GitHub Release without attempting a duplicate PyPI publish.
+- Set `publish_to_pypi=true` only when a maintainer intentionally needs the manual dispatch to publish artifacts to PyPI before syncing the GitHub Release.
 - GitHub Release sync is idempotent for the tagged release: it creates the release when missing and uploads only missing wheel/sdist assets.
 
 If a release run publishes to PyPI successfully but fails while creating or uploading the GitHub Release, recover with a manual dispatch against the same tag and set `publish_to_pypi=false`.


### PR DESCRIPTION
## Summary

### Workflow
- 为 `Publish` 的 `workflow_dispatch` 增加显式输入：`release_tag`、`publish_to_pypi`、`sync_github_release`
- 手工触发时强制检出指定 tag，避免误用当前分支头部代码参与发布或补偿
- 将 `workflow_dispatch.publish_to_pypi` 默认值设为 `false`，让手工补偿默认走“只修复 GitHub Release、不重复发布 PyPI”的安全路径
- 将 GitHub Release 阶段改为可重试、可补建 release、只补缺失 wheel/sdist 资产的幂等同步流程
- 为同一 tag 增加 workflow 并发收敛，降低重复补偿相互干扰的风险

### Docs
- 在 `CONTRIBUTING.md` 增补 maintainer 侧恢复说明
- 明确手工 dispatch 默认不重发 PyPI，只有维护者明确需要时才设置 `publish_to_pypi=true`

### Commits
- `1ba8280` `ci: harden publish release recovery (#359)`
- `3d72556` `docs: unwrap release recovery markdown lines`
- `3b91a6f` `ci: default manual release repair away from pypi`

### Validation
- `./scripts/doctor.sh`

### Issue
- Closes #359
