### PR TITLE
feat: 为 AgentCard 与 skills 显式声明 inputModes / outputModes

### DIFF
--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -12,6 +12,7 @@ from a2a.types import (
     SecurityScheme,
     TransportProtocol,
 )
+from pydantic import Field
 
 from ..config import Settings
 from ..contracts.extensions import (
@@ -45,6 +46,13 @@ from ..profile.runtime import RuntimeProfile, build_runtime_profile
 _CHAT_INPUT_MODES = ["text/plain", "application/octet-stream"]
 _CHAT_OUTPUT_MODES = ["text/plain", "application/json"]
 _JSON_RPC_MODES = ["application/json"]
+
+
+class OpencodeAgentCard(AgentCard):
+    """Custom AgentCard that explicitly includes top-level inputModes and outputModes."""
+
+    input_modes: list[str] | None = Field(default=None, alias="inputModes")
+    output_modes: list[str] | None = Field(default=None, alias="outputModes")
 
 
 def _select_public_extension_params(
@@ -396,8 +404,8 @@ def _build_agent_skills(
                     "Inspect OpenCode session status, history, and low-risk lifecycle actions "
                     "through provider-private JSON-RPC extensions."
                 ),
-                input_modes=list(_JSON_RPC_MODES),
-                output_modes=list(_JSON_RPC_MODES),
+                input_modes=["application/json", "text/plain", "application/octet-stream"],
+                output_modes=["application/json", "text/plain"],
                 tags=["opencode", "sessions", "history", "provider-private"],
             ),
             AgentSkill(
@@ -467,8 +475,8 @@ def _build_agent_skills(
                 "provider-private OpenCode session/history and session-control surface "
                 "exposed through JSON-RPC extensions."
             ),
-            input_modes=list(_JSON_RPC_MODES),
-            output_modes=list(_JSON_RPC_MODES),
+            input_modes=["application/json", "text/plain", "application/octet-stream"],
+            output_modes=["application/json", "text/plain"],
             tags=["opencode", "sessions", "history", "provider-private"],
             examples=_build_session_query_skill_examples(
                 capability_snapshot=capability_snapshot,
@@ -551,7 +559,7 @@ def _build_agent_card(
     security: list[dict[str, list[str]]] = [{"bearerAuth": []}]
     capability_snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
 
-    return AgentCard(
+    return OpencodeAgentCard(
         name=settings.a2a_title,
         description=_build_agent_card_description(
             settings,
@@ -565,6 +573,8 @@ def _build_agent_card(
         preferred_transport=TransportProtocol.http_json,
         default_input_modes=list(_CHAT_INPUT_MODES),
         default_output_modes=list(_CHAT_OUTPUT_MODES),
+        inputModes=list(_CHAT_INPUT_MODES),
+        outputModes=list(_CHAT_OUTPUT_MODES),
         capabilities=AgentCapabilities(
             streaming=True,
             extensions=_build_agent_extensions(

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -41,8 +41,15 @@ def test_agent_card_description_reflects_actual_transport_capabilities() -> None
     assert card.security == [{"bearerAuth": []}]
     assert skills_by_id["opencode.chat"].input_modes == ["text/plain", "application/octet-stream"]
     assert skills_by_id["opencode.chat"].output_modes == ["text/plain", "application/json"]
-    assert skills_by_id["opencode.sessions.query"].input_modes == ["application/json"]
-    assert skills_by_id["opencode.sessions.query"].output_modes == ["application/json"]
+    assert skills_by_id["opencode.sessions.query"].input_modes == [
+        "application/json",
+        "text/plain",
+        "application/octet-stream",
+    ]
+    assert skills_by_id["opencode.sessions.query"].output_modes == [
+        "application/json",
+        "text/plain",
+    ]
     assert skills_by_id["opencode.interrupt.callback"].input_modes == ["application/json"]
     assert skills_by_id["opencode.interrupt.callback"].output_modes == ["application/json"]
 

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -108,7 +108,13 @@ async def test_agent_card_routes_split_public_and_authenticated_extended_contrac
         assert public_card.headers["cache-control"] == PUBLIC_AGENT_CARD_CACHE_CONTROL
         assert public_card.headers["etag"]
         assert public_card.headers["vary"] == "Accept-Encoding"
-        assert public_card.json()["supportsAuthenticatedExtendedCard"] is True
+
+        card_json = public_card.json()
+        assert card_json["supportsAuthenticatedExtendedCard"] is True
+        assert "inputModes" in card_json
+        assert "outputModes" in card_json
+        assert card_json["inputModes"] == card_json["defaultInputModes"]
+        assert card_json["outputModes"] == card_json["defaultOutputModes"]
 
         public_cached = await client.get(
             "/.well-known/agent-card.json",


### PR DESCRIPTION
## 摘要
本 PR 为 `opencode-a2a` 暴露的 AgentCard 与 skill-level metadata 显式补齐了 `inputModes` 与 `outputModes`。

## 变更详情
1. **AgentCard 顶层支持**:
   - 定义了 `OpencodeAgentCard` 子类，增加了顶层 `inputModes` 与 `outputModes` 字段（原本 `a2a-sdk` 中仅有 `default_` 前缀的版本）。
   - 在 `build_agent_card` 中显式填充这些字段。
2. **Skill-level Metadata 补齐**:
   - 为 `opencode.sessions.query` 技能增加了 `text/plain` 和 `application/octet-stream` 作为输入模式（支持 `prompt_async` 中的 text/file parts）。
   - 为 `opencode.sessions.query` 技能增加了 `text/plain` 作为输出模式（支持获取包含文本部分的会话消息）。
3. **测试覆盖**:
   - 更新了 `tests/server/test_agent_card.py` 以验证技能级别的模式声明。
   - 更新了 `tests/server/test_transport_contract.py` 以验证 JSON 响应中存在顶层 `inputModes` 和 `outputModes`。

## 相关 Issue
Closes #362