### PR TITLE
docs: clarify chat output mode contract

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -172,6 +172,9 @@ If one deployment works while another fails against the same upstream provider, 
 - The service forwards A2A `message:send` to OpenCode session/message calls.
 - Main chat requests may override the upstream model for one request through `metadata.shared.model`.
 - Provider/model catalog discovery is available through `opencode.providers.list` and `opencode.models.list`.
+- Main chat requests that explicitly send `configuration.acceptedOutputModes` must stay compatible with the declared chat output modes.
+- Current main chat requests must continue accepting `text/plain`; requests that only accept `application/json` or other incompatible modes are rejected before execution starts.
+- `application/json` is additive structured-output support for incremental `tool_call` payloads. It does not guarantee that ordinary assistant prose can always be losslessly represented as JSON, so consumers that expect normal chat text should keep accepting `text/plain`.
 - Main chat input supports structured A2A `parts` passthrough:
   - `TextPart` is forwarded as an OpenCode text part.
   - `FilePart(FileWithBytes)` is forwarded as a `file` part with a `data:` URL.

--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -383,7 +383,9 @@ def _build_agent_skills(
                 name="OpenCode Chat",
                 description=(
                     "Handle core A2A chat turns with shared session binding and optional "
-                    "request-scoped model selection."
+                    "request-scoped model selection. Chat clients should continue accepting "
+                    "text/plain responses; application/json is additive structured-output "
+                    "support."
                 ),
                 input_modes=list(_CHAT_INPUT_MODES),
                 output_modes=list(_CHAT_OUTPUT_MODES),
@@ -453,7 +455,9 @@ def _build_agent_skills(
             description=(
                 "Handle core A2A message/send and message/stream requests by routing "
                 "TextPart and FilePart inputs to OpenCode sessions with shared session "
-                "binding and optional request-scoped model selection."
+                "binding and optional request-scoped model selection. Chat clients "
+                "should continue accepting text/plain responses; application/json is "
+                "additive structured-output support."
             ),
             input_modes=list(_CHAT_INPUT_MODES),
             output_modes=list(_CHAT_OUTPUT_MODES),

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -652,6 +652,7 @@ def test_agent_card_chat_examples_include_project_hint_when_configured() -> None
     chat_skill = next(skill for skill in card.skills if skill.id == "opencode.chat")
     assert chat_skill.examples is None
     assert "shared session binding" in chat_skill.description
+    assert "text/plain responses" in chat_skill.description
     assert "core-a2a" in chat_skill.tags
     assert "portable" in chat_skill.tags
 

--- a/tests/server/test_app_behaviors.py
+++ b/tests/server/test_app_behaviors.py
@@ -734,6 +734,40 @@ async def test_on_message_send_rejects_output_modes_without_text_plain() -> None
 
     assert isinstance(exc_info.value.error, UnsupportedOperationError)
     assert "require text/plain" in exc_info.value.error.message
+    assert exc_info.value.error.data == {
+        "accepted_output_modes": ["application/json"],
+        "required_output_modes": ["text/plain"],
+        "supported_output_modes": ["text/plain", "application/json"],
+    }
+    assert handler.setup_called is False
+
+
+@pytest.mark.asyncio
+async def test_on_message_send_stream_rejects_incompatible_output_modes_before_execution() -> None:
+    class _Handler(OpencodeRequestHandler):
+        def __init__(self) -> None:
+            super().__init__(agent_executor=MagicMock(), task_store=MagicMock())
+            self.setup_called = False
+
+        async def _setup_message_execution(self, params, context=None):  # noqa: ANN001
+            del params, context
+            self.setup_called = True
+            raise AssertionError("_setup_message_execution should not be called")
+
+    handler = _Handler()
+    params = types.SimpleNamespace(
+        configuration=types.SimpleNamespace(accepted_output_modes=["image/png"])
+    )
+
+    with pytest.raises(ServerError) as exc_info:
+        await handler.on_message_send_stream(params).__anext__()
+
+    assert isinstance(exc_info.value.error, UnsupportedOperationError)
+    assert "not compatible" in exc_info.value.error.message
+    assert exc_info.value.error.data == {
+        "accepted_output_modes": ["image/png"],
+        "supported_output_modes": ["text/plain", "application/json"],
+    }
     assert handler.setup_called is False
 
 


### PR DESCRIPTION
## 背景

本 PR 聚焦 `#379`，把现有的 chat `acceptedOutputModes` fail-fast 校验提升为更明确的公开契约表达。

当前主逻辑已经会在入口和 executor 层拒绝不接受 `text/plain` 的 chat 请求，但文档与 Agent Card skill 描述此前还没有把这层边界直接说透，客户端容易把 `default_output_modes = [text/plain, application/json]` 误解成“只接受 `application/json` 也总能工作”。

## Guide 契约说明

- 在 `docs/guide.md` 的 Core Behavior 段落补充 chat output modes consumer guidance。
- 明确说明：
  - 显式 `configuration.acceptedOutputModes` 必须与 chat 声明能力兼容。
  - 当前 main chat 请求必须继续接受 `text/plain`。
  - `application/json` 是增量结构化输出支持，不承诺普通 assistant prose 都能无损表示为 JSON。

## Agent Card 技能说明

- 在 `src/opencode_a2a/server/agent_card.py` 的 `opencode.chat` skill description 中补充同样的边界说明。
- 保持现有 skill/output modes 声明不变，不额外引入新的 extension 字段或 metadata 面。

## Tests

- 在 `tests/server/test_app_behaviors.py` 补充更聚焦的入口契约测试：
  - `acceptedOutputModes=["application/json"]` 时在入口拒绝，并稳定断言错误 `data` 字段。
  - `acceptedOutputModes=["image/png"]` 时在入口拒绝，并稳定断言错误 `data` 字段。
- 在 `tests/server/test_agent_card.py` 增加 chat skill 文案断言，防止 Agent Card 说明回退。

## 验证

- `uv run pytest --no-cov tests/server/test_app_behaviors.py tests/server/test_agent_card.py -q`
- `./scripts/doctor.sh`

## Issue 关联

Closes #379
