### PR TITLE
chore: add Dependabot baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    groups:
+      uv-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,4 +21,5 @@ Executable scripts live in this directory. This file is the entry index for the 
 ## Notes
 
 - `doctor.sh` and `dependency_health.sh` intentionally remain separate entrypoints and share common prerequisites through [`health_common.sh`](./health_common.sh).
+- [`.github/dependabot.yml`](../.github/dependabot.yml) enables weekly Dependabot version updates for `uv` and GitHub Actions with grouped low-risk updates, while `dependency_health.sh` remains the explicit review/audit entrypoint.
 - External conformance experiments remain intentionally separate from the default regression path. See [`../docs/conformance.md`](../docs/conformance.md).

--- a/tests/scripts/test_script_health_contract.py
+++ b/tests/scripts/test_script_health_contract.py
@@ -8,6 +8,7 @@ SMOKE_TEST_TEXT = Path("scripts/smoke_test_built_cli.sh").read_text()
 COVERAGE_GATE_TEXT = Path("scripts/check_coverage.py").read_text()
 SCRIPTS_INDEX_TEXT = Path("scripts/README.md").read_text()
 PYPROJECT_TEXT = Path("pyproject.toml").read_text()
+DEPENDABOT_TEXT = Path(".github/dependabot.yml").read_text()
 
 
 def test_shared_repo_health_prerequisites_live_in_common_helper() -> None:
@@ -45,6 +46,15 @@ def test_scripts_index_documents_split_health_entrypoints() -> None:
     assert "external A2A conformance experiment entrypoint" in SCRIPTS_INDEX_TEXT
     assert "dependency review entrypoint" in SCRIPTS_INDEX_TEXT
     assert "health_common.sh" in SCRIPTS_INDEX_TEXT
+    assert "weekly Dependabot version updates" in SCRIPTS_INDEX_TEXT
+
+
+def test_dependabot_configuration_covers_uv_and_github_actions() -> None:
+    assert 'package-ecosystem: "uv"' in DEPENDABOT_TEXT
+    assert 'package-ecosystem: "github-actions"' in DEPENDABOT_TEXT
+    assert "open-pull-requests-limit: 5" in DEPENDABOT_TEXT
+    assert "open-pull-requests-limit: 3" in DEPENDABOT_TEXT
+    assert "uv-minor-and-patch" in DEPENDABOT_TEXT
 
 
 def test_conformance_script_keeps_external_experiment_scope() -> None:


### PR DESCRIPTION
## 概要

为仓库引入首期 Dependabot 自动依赖更新基线，覆盖 `uv` 与 `github-actions`，并保持现有依赖审计脚本与 CI 门禁分工不变。

## 变更

### `.github`

- 新增 `.github/dependabot.yml`
- 为 `uv` 配置每周检查、分组 minor/patch 更新、限制并发 PR 为 5
- 为 `github-actions` 配置每周检查、分组更新、限制并发 PR 为 3
- 统一使用 `deps` commit 前缀与 `dependencies` 标签

### `scripts`

- 更新 `scripts/README.md`
- 说明 Dependabot 负责自动版本更新 PR
- 说明 `dependency_health.sh` 继续负责显式依赖审计与巡检

### `tests`

- 更新 `tests/scripts/test_script_health_contract.py`
- 增加 Dependabot 配置存在性与覆盖范围的契约断言
- 增加脚本索引文档说明的契约断言，防止后续文档漂移

## 验证

- `./scripts/doctor.sh`

## 关联

- Closes #401
