### PR TITLE
fix: enable SDK polling for fallback

### DIFF
--- a/src/opencode_a2a/client/client.py
+++ b/src/opencode_a2a/client/client.py
@@ -295,7 +295,7 @@ class A2AClient:
         card = await self.get_agent_card()
         config = ClientConfig(
             streaming=True,
-            polling=False,
+            polling=self._polling_fallback_policy.enabled,
             httpx_client=await self._get_httpx_client(),
             supported_transports=list(self._settings.supported_transports),
             use_client_preference=self._settings.use_client_preference,

--- a/tests/client/test_client_facade.py
+++ b/tests/client/test_client_facade.py
@@ -155,6 +155,46 @@ async def test_build_client_uses_settings_and_transport_config(
 
 
 @pytest.mark.asyncio
+async def test_build_client_enables_sdk_polling_when_polling_fallback_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = A2AClient(
+        "http://agent.example.com",
+        settings=A2AClientSettings(polling_fallback_enabled=True),
+    )
+    fake_sdk_client = _FakeClient()
+    factory_calls: dict[str, object] = {}
+
+    class _FakeFactory:
+        def __init__(self, config: ClientConfig, consumers: list[object] | None = None):
+            factory_calls["config"] = config
+            factory_calls["consumers"] = consumers
+
+        def create(
+            self,
+            _card: object,
+            consumers: list[object] | None = None,
+            interceptors: list[object] | None = None,
+            extensions: list[str] | None = None,
+        ) -> _FakeClient:
+            return fake_sdk_client
+
+    monkeypatch.setattr(client_module, "ClientFactory", _FakeFactory)
+    monkeypatch.setattr(
+        client_module,
+        "build_agent_card_resolver",
+        lambda *_args: _FakeCardResolver("agent-card"),
+    )
+
+    actual = await client._build_client()
+
+    config = factory_calls["config"]
+    assert isinstance(config, ClientConfig)
+    assert config.polling is True
+    assert actual is fake_sdk_client
+
+
+@pytest.mark.asyncio
 async def test_send_returns_last_event(monkeypatch: pytest.MonkeyPatch) -> None:
     client = A2AClient("http://agent.example.com")
     fake_client = _FakeClient(events=["a", "b", "last"])


### PR DESCRIPTION
## 概要

### Client

- 在 A2A client polling fallback 启用时，同步设置 SDK `ClientConfig.polling=True`。
- 保持默认行为不变：fallback 未启用时仍使用 SDK 默认 blocking send 配置。

### Tests

- 补充 client facade 测试，覆盖 polling fallback 会传递到 SDK `ClientConfig`。
- 继续保留既有默认配置测试，确认 `polling=False` 默认值未漂移。

## 关联

- Closes #413
- 相关 commit：`b91df40 fix: enable SDK polling for fallback`

## 验证

- `uv run pytest tests/client/test_client_facade.py --no-cov`
- `./scripts/doctor.sh`
