### PR TITLE
fix: reduce log noise and debug exposure

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1247,7 +1247,8 @@ If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscr
 - Idempotency contract: repeated `tasks/cancel` on an already `canceled` task returns the current terminal task state without error.
 - Terminal subscribe contract: calling `subscribe` on a terminal task replays one terminal `Task` snapshot and then closes the stream.
 - These two semantics are also declared as machine-readable `service_behaviors` in the compatibility profile and wire contract extensions.
-- The service emits lightweight metric log records (`logger=opencode_a2a.execution.executor`):
+- At `A2A_LOG_LEVEL=DEBUG`, the service emits lightweight metric log records
+  (`logger=opencode_a2a.execution.executor`):
   - `a2a_stream_requests_total`
   - `a2a_stream_active` (`value=1` when a stream starts, `value=-1` when it closes)
   - `opencode_stream_retries_total`

--- a/src/opencode_a2a/execution/coordinator.py
+++ b/src/opencode_a2a/execution/coordinator.py
@@ -220,7 +220,7 @@ class ExecutionCoordinator:
                 streaming_request=self._prepared.streaming_request,
             )
         except UpstreamConcurrencyLimitError as exc:
-            logger.warning("OpenCode request rejected by concurrency budget: %s", exc)
+            logger.debug("OpenCode request rejected by concurrency budget: %s", exc)
             await self._executor._emit_error(
                 self._event_queue,
                 task_id=self._task_id,
@@ -312,11 +312,11 @@ class ExecutionCoordinator:
         )
 
         logger.debug(
-            "OpenCode response task_id=%s session_id=%s message_id=%s text=%s",
+            "OpenCode response task_id=%s session_id=%s message_id=%s text_len=%s",
             self._task_id,
             response.session_id,
             resolved_message_id,
-            response_text,
+            len(response_text),
         )
 
         if response_error is not None:

--- a/src/opencode_a2a/execution/coordinator.py
+++ b/src/opencode_a2a/execution/coordinator.py
@@ -174,7 +174,11 @@ class ExecutionCoordinator:
                 break
 
         except httpx.HTTPStatusError as exc:
-            logger.exception("OpenCode request failed with HTTP error")
+            logger.warning(
+                "OpenCode request failed with HTTP status=%s",
+                exc.response.status_code,
+                exc_info=logger.isEnabledFor(logging.DEBUG),
+            )
             error_type, state, message = _format_upstream_error(
                 exc,
                 request="send_message",
@@ -190,7 +194,11 @@ class ExecutionCoordinator:
                 streaming_request=self._prepared.streaming_request,
             )
         except httpx.TimeoutException as exc:
-            logger.exception("OpenCode request timed out")
+            logger.warning(
+                "OpenCode request timed out: %s",
+                exc,
+                exc_info=logger.isEnabledFor(logging.DEBUG),
+            )
             await self._executor._emit_error(
                 self._event_queue,
                 task_id=self._task_id,

--- a/src/opencode_a2a/execution/executor.py
+++ b/src/opencode_a2a/execution/executor.py
@@ -310,7 +310,7 @@ class OpencodeAgentExecutor(AgentExecutor):
             (
                 "Received message identity=%s credential_id=%s auth_scheme=%s trace_id=%s "
                 "task_id=%s context_id=%s "
-                "streaming=%s text=%s part_count=%s"
+                "streaming=%s text_len=%s part_count=%s"
             ),
             identity,
             credential_id,
@@ -319,7 +319,7 @@ class OpencodeAgentExecutor(AgentExecutor):
             task_id,
             context_id,
             streaming_request,
-            user_text,
+            len(user_text),
             len(request_parts),
         )
         prepared = PreparedExecution(

--- a/src/opencode_a2a/execution/stream_runtime.py
+++ b/src/opencode_a2a/execution/stream_runtime.py
@@ -138,14 +138,14 @@ class StreamRuntime:
                 )
                 logger.debug(
                     "Stream chunk task_id=%s session_id=%s block_type=%s append=%s "
-                    "shared_source=%s internal_source=%s text=%s",
+                    "shared_source=%s internal_source=%s content_len=%s",
                     task_id,
                     session_id,
                     chunk.block_type,
                     effective_append,
                     chunk.shared_source,
                     chunk.internal_source,
-                    chunk.content_key,
+                    len(chunk.content_key),
                 )
                 if chunk.block_type == BlockType.TOOL_CALL:
                     self._emit_metric("tool_call_chunks_emitted_total")

--- a/src/opencode_a2a/execution/stream_runtime.py
+++ b/src/opencode_a2a/execution/stream_runtime.py
@@ -343,7 +343,7 @@ class StreamRuntime:
                     )
                 ]
             state.buffer = snapshot
-            logger.warning(
+            logger.debug(
                 "Suppressing non-prefix snapshot rewrite "
                 "task_id=%s session_id=%s part_id=%s block_type=%s had_delta=%s",
                 task_id,
@@ -593,7 +593,7 @@ class StreamRuntime:
                     if stop_event.is_set():
                         break
                     self._emit_metric("opencode_stream_retries_total")
-                    logger.exception("OpenCode event stream failed; retrying")
+                    logger.debug("OpenCode event stream failed; retrying", exc_info=True)
                     await self._sleep(backoff)
                     backoff = min(backoff * 2, max_backoff)
         except Exception:

--- a/src/opencode_a2a/opencode_upstream_client.py
+++ b/src/opencode_a2a/opencode_upstream_client.py
@@ -72,7 +72,7 @@ class _FastFailConcurrencyBudget:
         async with self._lock:
             inflight = self._inflight
             if inflight >= self._limit:
-                logger.warning(
+                logger.debug(
                     "OpenCode upstream concurrency limit exceeded "
                     "category=%s operation=%s limit=%s inflight=%s",
                     self._category,

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -430,7 +430,7 @@ class OpencodeRequestHandler(DefaultRequestHandler):
             ):
                 yield event
         except (asyncio.CancelledError, GeneratorExit):
-            logger.warning("Client disconnected. Cancelling producer task %s", task_id)
+            logger.debug("Client disconnected. Cancelling producer task %s", task_id)
             producer_task.cancel()
             await queue.close(immediate=True)
             raise
@@ -504,7 +504,7 @@ class OpencodeRequestHandler(DefaultRequestHandler):
                 try:
                     current_task = asyncio.current_task()
                     if current_task is not None and current_task.cancelled():
-                        logger.warning(
+                        logger.debug(
                             "Client disconnected from message request. Cancelling task %s", task_id
                         )
                         producer_task.cancel()

--- a/tests/execution/test_agent_errors.py
+++ b/tests/execution/test_agent_errors.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -173,7 +174,7 @@ async def test_execute_http_error_maps_to_task_error_type_and_state(
 
 
 @pytest.mark.asyncio
-async def test_streaming_execute_http_error_emits_status_update_with_metadata() -> None:
+async def test_streaming_execute_http_error_emits_status_update_with_metadata(caplog) -> None:
     request = httpx.Request("POST", "http://127.0.0.1:4096/message")
     response = httpx.Response(
         status_code=429,
@@ -204,7 +205,8 @@ async def test_streaming_execute_http_error_emits_status_update_with_metadata() 
     )
     event_queue = AsyncMock(spec=EventQueue)
 
-    await executor.execute(context, event_queue)
+    with caplog.at_level(logging.INFO, logger="opencode_a2a.execution.coordinator"):
+        await executor.execute(context, event_queue)
 
     status = None
     for call in event_queue.enqueue_event.call_args_list:
@@ -223,6 +225,14 @@ async def test_streaming_execute_http_error_emits_status_update_with_metadata() 
     assert status.status.state == TaskState.failed
     assert status.metadata["opencode"]["error"]["type"] == "UPSTREAM_QUOTA_EXCEEDED"
     assert status.metadata["opencode"]["error"]["upstream_status"] == 429
+    http_logs = [
+        record
+        for record in caplog.records
+        if "OpenCode request failed with HTTP status=429" in record.message
+    ]
+    assert len(http_logs) == 1
+    assert http_logs[0].levelno == logging.WARNING
+    assert not http_logs[0].exc_info
 
 
 @pytest.mark.asyncio

--- a/tests/execution/test_agent_errors.py
+++ b/tests/execution/test_agent_errors.py
@@ -236,7 +236,9 @@ async def test_streaming_execute_http_error_emits_status_update_with_metadata(ca
 
 
 @pytest.mark.asyncio
-async def test_streaming_execute_upstream_backpressure_emits_status_update_with_metadata() -> None:
+async def test_streaming_execute_upstream_backpressure_emits_status_update_with_metadata(
+    caplog,
+) -> None:
     client = AsyncMock()
 
     async def create_session(title: str | None = None, *, directory: str | None = None) -> str:
@@ -265,7 +267,8 @@ async def test_streaming_execute_upstream_backpressure_emits_status_update_with_
     )
     event_queue = AsyncMock(spec=EventQueue)
 
-    await executor.execute(context, event_queue)
+    with caplog.at_level(logging.DEBUG, logger="opencode_a2a.execution.coordinator"):
+        await executor.execute(context, event_queue)
 
     status = None
     for call in event_queue.enqueue_event.call_args_list:
@@ -283,6 +286,13 @@ async def test_streaming_execute_upstream_backpressure_emits_status_update_with_
     assert status is not None
     assert status.status.state == TaskState.failed
     assert status.metadata["opencode"]["error"]["type"] == "UPSTREAM_BACKPRESSURE"
+    backpressure_logs = [
+        record
+        for record in caplog.records
+        if "OpenCode request rejected by concurrency budget" in record.message
+    ]
+    assert len(backpressure_logs) == 1
+    assert backpressure_logs[0].levelno == logging.DEBUG
 
 
 @pytest.mark.asyncio

--- a/tests/execution/test_metrics.py
+++ b/tests/execution/test_metrics.py
@@ -202,3 +202,10 @@ async def test_streaming_retry_metric_increments_once_per_retry(monkeypatch, cap
 
     messages = [record.message for record in caplog.records]
     assert sum("metric=opencode_stream_retries_total" in message for message in messages) == 1
+    retry_logs = [
+        record
+        for record in caplog.records
+        if "OpenCode event stream failed; retrying" in record.message
+    ]
+    assert len(retry_logs) == 1
+    assert retry_logs[0].levelno == logging.DEBUG

--- a/tests/execution/test_streaming_output_contract_logging.py
+++ b/tests/execution/test_streaming_output_contract_logging.py
@@ -19,6 +19,50 @@ from tests.support.streaming_output import (
 
 
 @pytest.mark.asyncio
+async def test_execute_debug_log_records_text_length_without_raw_user_text(caplog) -> None:
+    raw_text = "do not write this prompt to logs"
+    response_text = "do not write this response to logs"
+    client = DummyStreamingClient(
+        stream_events_payload=[],
+        response_text=response_text,
+    )
+    client.settings = make_settings(
+        test_bearer_token="test",
+        opencode_base_url="http://localhost",
+        a2a_log_body_limit=64,
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    with caplog.at_level(logging.DEBUG, logger="opencode_a2a.execution"):
+        await executor.execute(
+            make_request_context(
+                task_id="task-debug-input",
+                context_id="ctx-debug-input",
+                text=raw_text,
+            ),
+            queue,
+        )
+
+    received_messages = [
+        record.message for record in caplog.records if record.message.startswith("Received message")
+    ]
+    assert len(received_messages) == 1
+    assert f"text_len={len(raw_text)}" in received_messages[0]
+    opencode_response_messages = [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("OpenCode response")
+    ]
+    assert len(opencode_response_messages) == 1
+    assert f"text_len={len(response_text)}" in opencode_response_messages[0]
+    all_messages = "\n".join(record.message for record in caplog.records)
+    assert raw_text not in all_messages
+    assert response_text not in all_messages
+
+
+@pytest.mark.asyncio
 async def test_streaming_logs_raw_upstream_events_at_debug(caplog) -> None:
     client = DummyStreamingClient(
         stream_events_payload=[

--- a/tests/upstream/test_opencode_upstream_client_params.py
+++ b/tests/upstream/test_opencode_upstream_client_params.py
@@ -1,5 +1,6 @@
 import asyncio
 import json as json_module
+import logging
 
 import httpx
 import pytest
@@ -593,6 +594,7 @@ async def test_send_message_raises_upstream_contract_error_for_non_json_response
 @pytest.mark.asyncio
 async def test_send_message_raises_concurrency_limit_error_when_request_budget_exhausted(
     monkeypatch,
+    caplog,
 ):
     client = OpencodeUpstreamClient(
         make_settings(
@@ -618,11 +620,20 @@ async def test_send_message_raises_concurrency_limit_error_when_request_budget_e
     first_request = asyncio.create_task(client.send_message("ses-1", "hello"))
     await started.wait()
 
-    with pytest.raises(
-        UpstreamConcurrencyLimitError,
-        match="request concurrency limit exceeded",
-    ):
-        await client.send_message("ses-2", "blocked")
+    with caplog.at_level(logging.DEBUG, logger="opencode_a2a.opencode_upstream_client"):
+        with pytest.raises(
+            UpstreamConcurrencyLimitError,
+            match="request concurrency limit exceeded",
+        ):
+            await client.send_message("ses-2", "blocked")
+
+    budget_logs = [
+        record
+        for record in caplog.records
+        if "OpenCode upstream concurrency limit exceeded" in record.message
+    ]
+    assert len(budget_logs) == 1
+    assert budget_logs[0].levelno == logging.DEBUG
 
     release.set()
     await first_request


### PR DESCRIPTION
## 关联 issue

Closes #415

## 变更说明

### 执行链路

- 将 unary OpenCode HTTP status 错误从默认 `ERROR` 堆栈调整为 `WARNING`，并仅在 `DEBUG` 级别附带堆栈信息。
- 将 unary OpenCode timeout 错误从默认 `ERROR` 堆栈调整为 `WARNING`，并仅在 `DEBUG` 级别附带堆栈信息。
- 将 upstream concurrency backpressure 的本地预算命中日志下调为 `DEBUG`，避免限流期间按请求刷默认 `WARNING`。
- 将 OpenCode response debug 日志中的响应正文替换为 `text_len`。
- 保留未知异常路径的 `exception` 记录，避免隐藏真正的运行时故障。

### 流式输出

- 将可恢复的 OpenCode event stream retry 日志下调为 `DEBUG`，避免默认 `WARNING` 运行时输出重试堆栈噪音。
- 将非前缀 snapshot rewrite 抑制日志下调为 `DEBUG`，保留调试可见性但不污染默认日志。
- 将 stream chunk debug 日志中的内容文本替换为 `content_len`。

### 服务请求处理

- 将客户端断开连接导致的 producer task 取消日志从 `WARNING` 下调为 `DEBUG`，按正常控制流处理。
- 将 executor request debug 日志中的用户输入正文替换为 `text_len`。

### 文档与测试

- 更新英文文档，明确 lightweight metric log records 需要 `A2A_LOG_LEVEL=DEBUG`。
- 补充日志级别相关测试，覆盖 stream retry、OpenCode HTTP status 错误、concurrency backpressure 以及 debug 日志不直接输出用户输入/响应正文。

## 验证

- `uv run pytest --no-cov tests/execution/test_metrics.py::test_streaming_retry_metric_increments_once_per_retry tests/execution/test_agent_errors.py::test_streaming_execute_http_error_emits_status_update_with_metadata tests/server/test_app_behaviors.py::test_normalize_log_level_configure_logging_and_main tests/server/test_transport_contract.py::test_normalize_log_level_falls_back_to_warning_for_invalid_value`
- `uv run pytest --no-cov tests/execution/test_streaming_output_contract_logging.py::test_execute_debug_log_records_text_length_without_raw_user_text tests/execution/test_agent_errors.py::test_streaming_execute_upstream_backpressure_emits_status_update_with_metadata tests/upstream/test_opencode_upstream_client_params.py::test_send_message_raises_concurrency_limit_error_when_request_budget_exhausted`
- `uv run ruff check src/opencode_a2a/execution/executor.py src/opencode_a2a/execution/coordinator.py src/opencode_a2a/execution/stream_runtime.py src/opencode_a2a/opencode_upstream_client.py tests/execution/test_streaming_output_contract_logging.py tests/execution/test_agent_errors.py tests/upstream/test_opencode_upstream_client_params.py`
- `uv run ruff format --check src/opencode_a2a/execution/executor.py src/opencode_a2a/execution/coordinator.py src/opencode_a2a/execution/stream_runtime.py src/opencode_a2a/opencode_upstream_client.py tests/execution/test_streaming_output_contract_logging.py tests/execution/test_agent_errors.py tests/upstream/test_opencode_upstream_client_params.py`
- `./scripts/doctor.sh`，571 项测试通过，覆盖率 91.65%。
