### PR TITLE
chore: pin build backend below setuptools-scm 10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "setuptools-scm[toml]>=8"]
+requires = ["setuptools>=80", "setuptools-scm[toml]>=8,<10"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/package/test_typing_contract.py
+++ b/tests/package/test_typing_contract.py
@@ -11,3 +11,7 @@ def test_package_declares_py_typed_marker() -> None:
 
 def test_package_declares_runtime_protobuf_dependency() -> None:
     assert '"protobuf>=6.33.5,<7.0"' in PYPROJECT_TEXT
+
+
+def test_build_backend_pins_setuptools_scm_below_warninging_major_version() -> None:
+    assert 'requires = ["setuptools>=80", "setuptools-scm[toml]>=8,<10"]' in PYPROJECT_TEXT


### PR DESCRIPTION
## 摘要
- 将 build backend 依赖从 `setuptools-scm>=8` 收紧为 `setuptools-scm[toml]>=8,<10`。
- 将 `setuptools` 下限对齐到 `>=80`，与上游当前推荐范围保持一致。
- 新增针对 `pyproject.toml` 的轻量测试，防止后续漂移回会产生日志 warning 的版本线。

## 背景
- 在最新 `main` 上，`uv build --no-sources` 和 `./scripts/doctor.sh` 的 build release artifacts 阶段仍会稳定出现 `vcs_versioning` 的 `GlobalOverrides` warning。
- 复测后确认 `setuptools-scm 8.3.1` 与 `9.2.2` 构建输出干净，而 `10.0.5` 会引入该 warning。
- 因此当前更低风险的修复方案是避开 10.x 版本线，而不是继续升级到最新版本。

## 验证
- `uv build --no-sources`
- `./scripts/doctor.sh`

Closes #421
