### PR TITLE
fix: align sdk task-store and stream artifact flows

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -58,6 +58,7 @@ Key variables to understand protocol behavior:
 - `A2A_CLIENT_SUPPORTED_TRANSPORTS`: ordered outbound transport preference list.
 - `A2A_TASK_STORE_BACKEND`: unified lightweight persistence backend for SDK task rows plus adapter-managed session / interrupt state. Supported values: `database`, `memory`. Default: `database`.
 - `A2A_TASK_STORE_DATABASE_URL`: database URL used by the unified durable backend when `A2A_TASK_STORE_BACKEND=database`. Default: `sqlite+aiosqlite:///./opencode-a2a.db`.
+- On startup, the runtime applies compatible in-place schema upgrades for the durable task/state store tables before serving requests.
 - Runtime authentication is configured only through the static credential registry declared by `A2A_STATIC_AUTH_CREDENTIALS`.
 - The runtime maps authenticated requests to stable principals rather than credential-derived identities.
 - With `A2A_STATIC_AUTH_CREDENTIALS`, every bearer credential must declare an explicit `principal`; Basic credentials always derive their runtime principal from `username`.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -225,16 +225,23 @@ If one deployment works while another fails against the same upstream provider, 
 - Streaming is always enabled in this server profile; `message:stream` is part of the stable runtime baseline.
 - Streaming (`/v1/message:stream`) emits incremental `TaskArtifactUpdateEvent` and then `TaskStatusUpdateEvent(final=true)`.
 - Stream artifacts carry `artifact.metadata.shared.stream.block_type` with values `text` / `reasoning` / `tool_call`.
-- All chunks share one stream artifact ID and preserve original timeline via `artifact.metadata.shared.stream.event_id`.
+- Stream artifacts are scoped to logical output lanes rather than one shared catch-all artifact:
+  - text chunks use a stable text artifact ID
+  - reasoning chunks use a stable reasoning artifact ID
+  - tool-call updates use a stable per-tool-part artifact ID when the upstream part is identifiable
+- `artifact.metadata.shared.stream.event_id` preserves the original cross-artifact stream timeline, even when different logical lanes use different artifact IDs.
+- `artifact.metadata.shared.stream.part_id` is best-effort metadata for the upstream part identity that drove the chunk.
 - `artifact.metadata.shared.stream.message_id` remains best-effort metadata: when upstream omits `message_id`, the service falls back to a stable request-scoped message identity.
 - `artifact.metadata.shared.stream.sequence` carries the canonical per-request stream sequence.
-- A final snapshot is emitted only when streaming chunks did not already produce the same final text.
+- A final complete text snapshot is emitted only when streaming chunks did not already produce the same final text.
+- That final complete text snapshot uses `append=false` on the text artifact so clients and the task store can treat it as the canonical replace-on-finish version rather than another fragment.
 - Stream routing is schema-first: the service classifies chunks primarily by OpenCode `part.type` and `part_id` state rather than inline text markers.
 - `message.part.delta` and `message.part.updated` are merged per `part_id`; out-of-order deltas are buffered and replayed when the corresponding `part.updated` arrives.
 - Structured `tool` parts are emitted as `tool_call` blocks using structured v1 part payloads, while `text` and `reasoning` continue to use text parts.
 - `tool_call` block payloads are normalized structured objects that may expose fields such as `call_id`, `tool`, `status`, `title`, `subtitle`, `input`, `output`, and `error`.
 - If `application/json` is not accepted but `text/plain` is still accepted, those `tool_call` blocks are downgraded to stable compact JSON text so text-only clients retain the same observable state transitions.
 - When a request restricts `acceptedOutputModes`, the stream applies the same output filtering before persistence so later task snapshots do not re-expose filtered structured blocks.
+- Persistence is canonicalized separately from transport: stream subscribers still receive incremental artifact updates, while task-store persistence rewrites those updates into compact per-artifact snapshots so `GetTask` and terminal replay do not accumulate token-level fragments.
 - Final status event metadata may include normalized token usage at `metadata.shared.usage` with fields such as `input_tokens`, `output_tokens`, `total_tokens`, optional `reasoning_tokens`, optional `cache_tokens.read_tokens` / `cache_tokens.write_tokens`, and optional `cost`.
 - Usage is extracted from documented info payloads and supported usage parts such as `step-finish`; non-usage parts with similar fields are ignored.
 - Interrupt events (`permission.asked` / `question.asked`) are mapped to `TaskStatusUpdateEvent(final=false, state=input-required)` with details at `metadata.shared.interrupt`, including `request_id`, interrupt `type`, `phase=asked`, and a normalized minimal callback payload.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -182,7 +182,7 @@ Database-backed task persistence also keeps the existing first-terminal-state-wi
 
 At startup, the runtime logs a concise persistence summary covering the active backend, the redacted database URL when applicable, the shared persistence scope, and whether the SQLite local durability profile is active.
 
-The A2A SDK task table remains managed by the SDK's own `DatabaseTaskStore` initialization path. The internal migration runner only owns the additional `opencode-a2a` state tables listed above, but both layers still share the same configured lightweight persistence backend.
+For the SDK task table, the runtime first applies a compatibility migration for legacy local schemas and then delegates steady-state table initialization back to the SDK's own `DatabaseTaskStore` path. The internal migration runner therefore owns the adapter-local state tables listed above plus backward-compatible task-table upgrades, while the SDK continues to own the primary task ORM lifecycle on the shared lightweight persistence backend.
 
 In-flight asyncio locks, outbound A2A client caches, and stream-local aggregation buffers remain process-local runtime state.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -58,7 +58,7 @@ Key variables to understand protocol behavior:
 - `A2A_CLIENT_SUPPORTED_TRANSPORTS`: ordered outbound transport preference list.
 - `A2A_TASK_STORE_BACKEND`: unified lightweight persistence backend for SDK task rows plus adapter-managed session / interrupt state. Supported values: `database`, `memory`. Default: `database`.
 - `A2A_TASK_STORE_DATABASE_URL`: database URL used by the unified durable backend when `A2A_TASK_STORE_BACKEND=database`. Default: `sqlite+aiosqlite:///./opencode-a2a.db`.
-- On startup, the runtime applies compatible in-place schema upgrades for the durable task/state store tables before serving requests.
+- On startup, the runtime only auto-migrates adapter-owned state tables; existing SDK-owned task tables must be upgraded explicitly with upstream `a2a-db`.
 - Runtime authentication is configured only through the static credential registry declared by `A2A_STATIC_AUTH_CREDENTIALS`.
 - The runtime maps authenticated requests to stable principals rather than credential-derived identities.
 - With `A2A_STATIC_AUTH_CREDENTIALS`, every bearer credential must declare an explicit `principal`; Basic credentials always derive their runtime principal from `username`.
@@ -182,7 +182,7 @@ Database-backed task persistence also keeps the existing first-terminal-state-wi
 
 At startup, the runtime logs a concise persistence summary covering the active backend, the redacted database URL when applicable, the shared persistence scope, and whether the SQLite local durability profile is active.
 
-For the SDK task table, the runtime first applies a compatibility migration for legacy local schemas and then delegates steady-state table initialization back to the SDK's own `DatabaseTaskStore` path. The internal migration runner therefore owns the adapter-local state tables listed above plus backward-compatible task-table upgrades, while the SDK continues to own the primary task ORM lifecycle on the shared lightweight persistence backend.
+The adapter-owned state tables listed above remain managed by the internal migration runner. The SDK-owned `tasks` table does not use runtime auto-migration here; upgrade existing SDK task schemas explicitly with upstream `a2a-db` before starting the service after an SDK schema change. If `a2a-db` is unavailable in your environment, install the `a2a-sdk[db-cli]` extra first.
 
 In-flight asyncio locks, outbound A2A client caches, and stream-local aggregation buffers remain process-local runtime state.
 

--- a/src/opencode_a2a/cli.py
+++ b/src/opencode_a2a/cli.py
@@ -171,6 +171,7 @@ def should_show_call_help(args: Sequence[str]) -> bool:
 async def run_call(agent_url: str, text: str) -> int:
     settings = load_settings(os.environ)
     client = A2AClient(agent_url, settings=settings)
+    rendered_artifacts: dict[str, str] = {}
 
     try:
         async for event in client.send_message(text):
@@ -182,9 +183,24 @@ async def run_call(agent_url: str, text: str) -> int:
             elif event.HasField("artifact_update"):
                 artifact = event.artifact_update.artifact
                 if artifact and artifact.parts:
+                    artifact_id = artifact.artifact_id or ""
                     for part in artifact.parts:
                         text_val = part.text if part.HasField("text") else None
                         if isinstance(text_val, str):
+                            if event.artifact_update.append:
+                                rendered_artifacts[artifact_id] = (
+                                    f"{rendered_artifacts.get(artifact_id, '')}{text_val}"
+                                )
+                                print(text_val, end="", flush=True)
+                                continue
+
+                            previous = rendered_artifacts.get(artifact_id, "")
+                            rendered_artifacts[artifact_id] = text_val
+                            if text_val == previous:
+                                continue
+                            if previous and text_val.startswith(previous):
+                                print(text_val[len(previous) :], end="", flush=True)
+                                continue
                             print(text_val, end="", flush=True)
             elif (
                 event.HasField("status_update")

--- a/src/opencode_a2a/execution/coordinator.py
+++ b/src/opencode_a2a/execution/coordinator.py
@@ -93,11 +93,12 @@ class ExecutionCoordinator:
         self._task_id = task_id
         self._context_id = context_id
         self._prepared = prepared
-        self._stream_artifact_id = f"{task_id}:stream"
+        self._stream_artifact_base_id = f"{task_id}:stream"
+        self._stream_text_artifact_id = f"{self._stream_artifact_base_id}:text"
         self._stream_state = _StreamOutputState(
             user_text=prepared.user_text,
             stable_message_id=f"{task_id}:{context_id}:assistant",
-            event_id_namespace=f"{task_id}:{context_id}:{self._stream_artifact_id}",
+            event_id_namespace=f"{task_id}:{context_id}:{self._stream_artifact_base_id}",
         )
         self._stream_terminal_signal: asyncio.Future[_StreamTerminalSignal] | None = None
         self._stop_event = asyncio.Event()
@@ -287,7 +288,7 @@ class ExecutionCoordinator:
                     identity=self._prepared.identity,
                     task_id=self._task_id,
                     context_id=self._context_id,
-                    artifact_id=self._stream_artifact_id,
+                    artifact_id=self._stream_artifact_base_id,
                     stream_state=self._stream_state,
                     event_queue=self._event_queue,
                     stop_event=self._stop_event,
@@ -391,19 +392,26 @@ class ExecutionCoordinator:
             )
             return
 
-        if self._stream_state.should_emit_final_snapshot(response_text):
+        final_text_artifact_id = self._stream_state.resolve_text_artifact_id(
+            self._stream_text_artifact_id
+        )
+        if self._stream_state.should_emit_final_snapshot(
+            artifact_id=final_text_artifact_id,
+            text=response_text,
+        ):
             sequence = self._stream_state.next_sequence()
             await _enqueue_artifact_update(
                 event_queue=self._event_queue,
                 task_id=self._task_id,
                 context_id=self._context_id,
-                artifact_id=self._stream_artifact_id,
+                artifact_id=final_text_artifact_id,
                 part=Part(text=response_text),
-                append=self._stream_state.emitted_stream_chunk,
+                append=False,
                 last_chunk=True,
                 artifact_metadata=_build_stream_artifact_metadata(
                     block_type=BlockType.TEXT,
                     shared_source="final_snapshot",
+                    part_id=None,
                     message_id=resolved_message_id,
                     event_id=self._stream_state.build_event_id(sequence),
                     sequence=sequence,

--- a/src/opencode_a2a/execution/stream_runtime.py
+++ b/src/opencode_a2a/execution/stream_runtime.py
@@ -96,25 +96,28 @@ class StreamRuntime:
                 ):
                     continue
                 should_emit, effective_append = stream_state.register_chunk(
-                    block_type=chunk.block_type,
+                    artifact_id=chunk.artifact_id,
                     content_key=chunk.content_key,
                     append=chunk.append,
                     accumulate_content=chunk.accumulate_content,
                 )
                 if not should_emit:
                     continue
+                if chunk.block_type == BlockType.TEXT:
+                    stream_state.remember_text_artifact_id(chunk.artifact_id)
                 sequence = stream_state.next_sequence()
                 await _enqueue_artifact_update(
                     event_queue=event_queue,
                     task_id=task_id,
                     context_id=context_id,
-                    artifact_id=artifact_id,
+                    artifact_id=chunk.artifact_id,
                     part=chunk.part,
                     append=effective_append,
                     last_chunk=False,
                     artifact_metadata=_build_stream_artifact_metadata(
                         block_type=chunk.block_type,
                         shared_source=chunk.shared_source,
+                        part_id=chunk.part_id,
                         message_id=resolved_message_id,
                         role=chunk.role,
                         event_id=stream_state.build_event_id(sequence),
@@ -181,15 +184,18 @@ class StreamRuntime:
 
         def _new_text_chunk(
             *,
+            artifact_id: str,
             text: str,
             append: bool,
             block_type: BlockType,
             internal_source: str,
             shared_source: str,
+            part_id: str | None,
             message_id: str | None,
             role: str | None,
         ) -> _NormalizedStreamChunk:
             return _NormalizedStreamChunk(
+                artifact_id=artifact_id,
                 part=Part(text=text),
                 content_key=text,
                 accumulate_content=True,
@@ -197,18 +203,21 @@ class StreamRuntime:
                 block_type=block_type,
                 internal_source=internal_source,
                 shared_source=shared_source,
+                part_id=part_id,
                 message_id=message_id,
                 role=role,
             )
 
         def _new_data_chunk(
             *,
+            artifact_id: str,
             data: Mapping[str, Any],
             content_key: str,
             append: bool,
             block_type: BlockType,
             internal_source: str,
             shared_source: str,
+            part_id: str | None,
             message_id: str | None,
             role: str | None,
         ) -> _NormalizedStreamChunk:
@@ -223,6 +232,7 @@ class StreamRuntime:
                 part = Part(text=fallback_text)
                 content_key = fallback_text
             return _NormalizedStreamChunk(
+                artifact_id=artifact_id,
                 part=part,
                 content_key=content_key,
                 accumulate_content=False,
@@ -230,9 +240,24 @@ class StreamRuntime:
                 block_type=block_type,
                 internal_source=internal_source,
                 shared_source=shared_source,
+                part_id=part_id,
                 message_id=message_id,
                 role=role,
             )
+
+        def _resolve_stream_artifact_id(
+            *,
+            block_type: BlockType,
+            part_id: str | None,
+        ) -> str:
+            if block_type == BlockType.TEXT:
+                return f"{artifact_id}:text"
+            if block_type == BlockType.REASONING:
+                return f"{artifact_id}:reasoning"
+            normalized_part_id = (part_id or "").strip()
+            if normalized_part_id:
+                return f"{artifact_id}:tool:{normalized_part_id}"
+            return f"{artifact_id}:tool"
 
         def _upsert_part_state(
             *,
@@ -248,13 +273,23 @@ class StreamRuntime:
             state = part_states.get(part_id)
             if state is None:
                 state = _StreamPartState(
+                    artifact_id=_resolve_stream_artifact_id(
+                        block_type=block_type,
+                        part_id=part_id,
+                    ),
                     block_type=block_type,
+                    part_id=part_id,
                     message_id=message_id,
                     role=role,
                 )
                 part_states[part_id] = state
                 return state
+            state.artifact_id = _resolve_stream_artifact_id(
+                block_type=block_type,
+                part_id=part_id,
+            )
             state.block_type = block_type
+            state.part_id = part_id
             if role is not None:
                 state.role = role
             if message_id:
@@ -276,11 +311,13 @@ class StreamRuntime:
             state.saw_delta = True
             return [
                 _new_text_chunk(
+                    artifact_id=state.artifact_id,
                     text=delta_text,
                     append=True,
                     block_type=state.block_type,
                     internal_source=internal_source,
                     shared_source="stream",
+                    part_id=state.part_id,
                     message_id=state.message_id,
                     role=state.role,
                 )
@@ -305,11 +342,13 @@ class StreamRuntime:
                     return []
                 return [
                     _new_text_chunk(
+                        artifact_id=state.artifact_id,
                         text=delta_text,
                         append=True,
                         block_type=state.block_type,
                         internal_source="part_text_diff",
                         shared_source="stream",
+                        part_id=state.part_id,
                         message_id=state.message_id,
                         role=state.role,
                     )
@@ -349,12 +388,14 @@ class StreamRuntime:
             state.buffer = content_key
             return [
                 _new_data_chunk(
+                    artifact_id=state.artifact_id,
                     data=tool_payload,
                     content_key=content_key,
                     append=bool(previous),
                     block_type=state.block_type,
                     internal_source="tool_part_update",
                     shared_source="tool_part_update",
+                    part_id=state.part_id,
                     message_id=state.message_id,
                     role=state.role,
                 )

--- a/src/opencode_a2a/execution/stream_state.py
+++ b/src/opencode_a2a/execution/stream_state.py
@@ -15,6 +15,7 @@ class BlockType(StrEnum):
 
 @dataclass(frozen=True)
 class _NormalizedStreamChunk:
+    artifact_id: str
     part: Any
     content_key: str
     accumulate_content: bool
@@ -22,6 +23,7 @@ class _NormalizedStreamChunk:
     block_type: BlockType
     internal_source: str
     shared_source: str
+    part_id: str | None
     message_id: str | None
     role: str | None
 
@@ -35,7 +37,9 @@ class _PendingDelta:
 
 @dataclass
 class _StreamPartState:
+    artifact_id: str
     block_type: BlockType
+    part_id: str | None
     message_id: str | None
     role: str | None
     buffer: str = ""
@@ -69,13 +73,14 @@ class _StreamOutputState:
     user_text: str
     stable_message_id: str
     event_id_namespace: str
-    content_buffers: dict[BlockType, str] = field(default_factory=dict)
+    artifact_content_buffers: dict[str, str] = field(default_factory=dict)
     progress_buffers: dict[str, str] = field(default_factory=dict)
     token_usage: dict[str, Any] | None = None
     upstream_error: Any | None = None
     pending_interrupt_request_ids: set[str] = field(default_factory=set)
+    emitted_artifact_ids: set[str] = field(default_factory=set)
+    text_artifact_id: str | None = None
     saw_any_chunk: bool = False
-    emitted_stream_chunk: bool = False
     sequence: int = 0
 
     def should_drop_initial_user_echo(
@@ -97,19 +102,19 @@ class _StreamOutputState:
     def register_chunk(
         self,
         *,
-        block_type: BlockType,
+        artifact_id: str,
         content_key: str,
         append: bool,
         accumulate_content: bool = True,
     ) -> tuple[bool, bool]:
-        previous = self.content_buffers.get(block_type, "")
+        previous = self.artifact_content_buffers.get(artifact_id, "")
         next_value = f"{previous}{content_key}" if append and accumulate_content else content_key
         if next_value == previous:
             return False, False
-        self.content_buffers[block_type] = next_value
+        self.artifact_content_buffers[artifact_id] = next_value
         self.saw_any_chunk = True
-        effective_append = self.emitted_stream_chunk
-        self.emitted_stream_chunk = True
+        effective_append = artifact_id in self.emitted_artifact_ids
+        self.emitted_artifact_ids.add(artifact_id)
         return True, effective_append
 
     def register_progress(self, *, identity: str, content_key: str) -> bool:
@@ -119,13 +124,24 @@ class _StreamOutputState:
         self.progress_buffers[identity] = content_key
         return True
 
-    def should_emit_final_snapshot(self, text: str) -> bool:
+    def remember_text_artifact_id(self, artifact_id: str | None) -> None:
+        if isinstance(artifact_id, str):
+            normalized = artifact_id.strip()
+            if normalized:
+                self.text_artifact_id = normalized
+
+    def resolve_text_artifact_id(self, default_artifact_id: str) -> str:
+        if isinstance(self.text_artifact_id, str) and self.text_artifact_id.strip():
+            return self.text_artifact_id.strip()
+        return default_artifact_id
+
+    def should_emit_final_snapshot(self, *, artifact_id: str, text: str) -> bool:
         if not text.strip():
             return False
-        existing = self.content_buffers.get(BlockType.TEXT, "")
+        existing = self.artifact_content_buffers.get(artifact_id, "")
         if existing.strip() == text.strip():
             return False
-        self.content_buffers[BlockType.TEXT] = text
+        self.artifact_content_buffers[artifact_id] = text
         self.saw_any_chunk = True
         return True
 
@@ -226,6 +242,7 @@ def _build_stream_artifact_metadata(
     *,
     block_type: BlockType,
     shared_source: str,
+    part_id: str | None = None,
     message_id: str | None = None,
     role: str | None = None,
     event_id: str | None = None,
@@ -238,6 +255,8 @@ def _build_stream_artifact_metadata(
         "block_type": block_type.value,
         "source": shared_source,
     }
+    if part_id:
+        stream_meta["part_id"] = part_id
     if message_id:
         stream_meta["message_id"] = message_id
     if role:

--- a/src/opencode_a2a/output_modes.py
+++ b/src/opencode_a2a/output_modes.py
@@ -32,6 +32,9 @@ OUTPUT_NEGOTIATION_ACCEPTED_OUTPUT_MODES_FIELD = "accepted_output_modes"
 _OPENCODE_METADATA_KEY = "opencode"
 _APPLICATION_JSON_MEDIA_TYPE = "application/json"
 _TEXT_PLAIN_MEDIA_TYPE = "text/plain"
+_STREAM_METADATA_SHARED_KEY = "shared"
+_STREAM_METADATA_STREAM_KEY = "stream"
+_STREAM_METADATA_BLOCK_TYPE_KEY = "block_type"
 
 
 def _accepted_output_modes_source(source: Any) -> Iterable[str] | None:
@@ -208,6 +211,55 @@ def apply_accepted_output_modes(
     return payload
 
 
+def _extract_artifact_stream_block_type(artifact: Artifact | None) -> str | None:
+    if artifact is None:
+        return None
+    metadata = _normalize_metadata_mapping(artifact.metadata)
+    if not metadata:
+        return None
+    shared = metadata.get(_STREAM_METADATA_SHARED_KEY)
+    if not isinstance(shared, dict):
+        return None
+    stream = shared.get(_STREAM_METADATA_STREAM_KEY)
+    if not isinstance(stream, dict):
+        return None
+    block_type = stream.get(_STREAM_METADATA_BLOCK_TYPE_KEY)
+    return block_type.strip() if isinstance(block_type, str) and block_type.strip() else None
+
+
+def _canonicalize_artifact_event(
+    event: TaskArtifactUpdateEvent,
+    text_buffers: dict[str, str],
+) -> TaskArtifactUpdateEvent:
+    artifact = event.artifact
+    if artifact is None or not artifact.parts:
+        return event
+
+    block_type = _extract_artifact_stream_block_type(artifact)
+    if block_type is None:
+        return event
+
+    updated = clone_proto(event)
+    updated.append = False
+
+    part = artifact.parts[0]
+    artifact_id = artifact.artifact_id
+    if block_type in {"text", "reasoning"} and part.HasField("text"):
+        previous = text_buffers.get(artifact_id, "")
+        full_text = part.text if not event.append else f"{previous}{part.text}"
+        text_buffers[artifact_id] = full_text
+        canonical_part = clone_proto(part)
+        canonical_part.text = full_text
+        updated.artifact.CopyFrom(replace_artifact_parts(artifact, [canonical_part]))
+        return updated
+
+    if block_type == "tool_call":
+        updated.artifact.CopyFrom(replace_artifact_parts(artifact, [clone_proto(part)]))
+        return updated
+
+    return event
+
+
 class NegotiatingResultAggregator(ResultAggregator):
     def __init__(
         self,
@@ -216,12 +268,18 @@ class NegotiatingResultAggregator(ResultAggregator):
     ) -> None:
         super().__init__(task_manager)
         self._accepted_output_modes = normalize_accepted_output_modes(accepted_output_modes)
+        self._canonical_text_buffers: dict[str, str] = {}
 
     def _transform_event(self, event: Any) -> Any | None:
         negotiated_event = apply_accepted_output_modes(event, self._accepted_output_modes)
         if negotiated_event is None:
             return None
         return annotate_output_negotiation_metadata(negotiated_event, self._accepted_output_modes)
+
+    def _transform_persisted_event(self, event: Any) -> Any:
+        if not isinstance(event, TaskArtifactUpdateEvent):
+            return event
+        return _canonicalize_artifact_event(event, self._canonical_text_buffers)
 
     async def _persist_output_negotiation_metadata(self, event: Any) -> None:
         if not isinstance(event, TaskArtifactUpdateEvent):
@@ -243,8 +301,9 @@ class NegotiatingResultAggregator(ResultAggregator):
             transformed_event = self._transform_event(event)
             if transformed_event is None:
                 continue
-            await self._persist_output_negotiation_metadata(transformed_event)
-            await self.task_manager.process(transformed_event)
+            persisted_event = self._transform_persisted_event(transformed_event)
+            await self._persist_output_negotiation_metadata(persisted_event)
+            await self.task_manager.process(persisted_event)
             yield transformed_event
 
     async def consume_all(self, consumer: EventConsumer) -> Task | Message | None:
@@ -255,8 +314,9 @@ class NegotiatingResultAggregator(ResultAggregator):
             if isinstance(transformed_event, Message):
                 self._message = transformed_event
                 return transformed_event
-            await self._persist_output_negotiation_metadata(transformed_event)
-            await self.task_manager.process(transformed_event)
+            persisted_event = self._transform_persisted_event(transformed_event)
+            await self._persist_output_negotiation_metadata(persisted_event)
+            await self.task_manager.process(persisted_event)
         return await self.task_manager.get_task()
 
     async def consume_and_break_on_interrupt(
@@ -275,8 +335,9 @@ class NegotiatingResultAggregator(ResultAggregator):
             if isinstance(transformed_event, Message):
                 self._message = transformed_event
                 return transformed_event, False, None
-            await self._persist_output_negotiation_metadata(transformed_event)
-            await self.task_manager.process(transformed_event)
+            persisted_event = self._transform_persisted_event(transformed_event)
+            await self._persist_output_negotiation_metadata(persisted_event)
+            await self.task_manager.process(persisted_event)
 
             should_interrupt = False
             is_auth_required = (
@@ -304,8 +365,9 @@ class NegotiatingResultAggregator(ResultAggregator):
             transformed_event = self._transform_event(event)
             if transformed_event is None:
                 continue
-            await self._persist_output_negotiation_metadata(transformed_event)
-            await self.task_manager.process(transformed_event)
+            persisted_event = self._transform_persisted_event(transformed_event)
+            await self._persist_output_negotiation_metadata(persisted_event)
+            await self.task_manager.process(persisted_event)
             if event_callback:
                 await event_callback()
 

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -7,6 +7,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import uvicorn
+from a2a.auth.user import User
 from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventConsumer, EventQueueLegacy
 from a2a.server.request_handlers.default_request_handler import (
@@ -119,6 +120,19 @@ from .task_store import (
 logger = logging.getLogger(__name__)
 TASK_STORE_ERROR_TYPE = "TASK_STORE_UNAVAILABLE"
 PUSH_NOTIFICATIONS_UNSUPPORTED_MESSAGE = "Push notifications are not supported by the agent"
+
+
+class AuthenticatedIdentityUser(User):
+    def __init__(self, identity: str) -> None:
+        self._identity = identity
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+    @property
+    def user_name(self) -> str:
+        return self._identity
 
 
 def _rest_error_response(
@@ -758,6 +772,7 @@ class IdentityAwareCallContextBuilder(DefaultServerCallContextBuilder):
         identity = getattr(request.state, "user_identity", None)
         if identity:
             context.state["identity"] = identity
+            context.user = AuthenticatedIdentityUser(identity)
         auth_scheme = getattr(request.state, "user_auth_scheme", None)
         if auth_scheme:
             context.state["auth_scheme"] = auth_scheme
@@ -966,6 +981,7 @@ def create_app(settings: Settings) -> FastAPI:
         "/v1/tasks",
         build_list_tasks_route(
             task_store=task_store,
+            context_builder=context_builder.build,
         ),
         methods=["GET"],
     )

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -7,7 +7,6 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import uvicorn
-from a2a.auth.user import User
 from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventConsumer, EventQueueLegacy
 from a2a.server.request_handlers.default_request_handler import (
@@ -93,6 +92,7 @@ from .agent_card import (
     build_agent_card,
 )
 from .client_manager import A2AClientManager
+from .context_helpers import AuthenticatedIdentityUser
 from .lifespan import build_lifespan
 from .middleware import (
     build_agent_card_etag,
@@ -120,19 +120,6 @@ from .task_store import (
 logger = logging.getLogger(__name__)
 TASK_STORE_ERROR_TYPE = "TASK_STORE_UNAVAILABLE"
 PUSH_NOTIFICATIONS_UNSUPPORTED_MESSAGE = "Push notifications are not supported by the agent"
-
-
-class AuthenticatedIdentityUser(User):
-    def __init__(self, identity: str) -> None:
-        self._identity = identity
-
-    @property
-    def is_authenticated(self) -> bool:
-        return True
-
-    @property
-    def user_name(self) -> str:
-        return self._identity
 
 
 def _rest_error_response(

--- a/src/opencode_a2a/server/context_helpers.py
+++ b/src/opencode_a2a/server/context_helpers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+from a2a.auth.user import UnauthenticatedUser, User
+from a2a.server.context import ServerCallContext
+
+
+class AuthenticatedIdentityUser(User):
+    def __init__(self, identity: str) -> None:
+        self._identity = identity
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+    @property
+    def user_name(self) -> str:
+        return self._identity
+
+
+def normalize_server_call_context(context: ServerCallContext | None) -> ServerCallContext:
+    if context is None:
+        return ServerCallContext()
+
+    raw_state = _read_context_attribute(context, "state", default=None)
+    raw_requested_extensions = _read_context_attribute(
+        context,
+        "requested_extensions",
+        default=None,
+    )
+    raw_tenant = _read_context_attribute(context, "tenant", default="")
+    raw_user = _read_context_attribute(context, "user", default=None)
+
+    state = _normalize_context_state(raw_state)
+    requested_extensions = _normalize_requested_extensions(raw_requested_extensions)
+    tenant = _normalize_tenant(raw_tenant)
+    identity = state.get("identity")
+    user = _normalize_user(raw_user, identity=identity if isinstance(identity, str) else None)
+
+    if (
+        isinstance(context, ServerCallContext)
+        and raw_state is state
+        and raw_user is user
+        and raw_tenant == tenant
+        and raw_requested_extensions == requested_extensions
+    ):
+        return context
+
+    return ServerCallContext(
+        state=state,
+        user=user,
+        tenant=tenant,
+        requested_extensions=requested_extensions,
+    )
+
+
+def _read_context_attribute(context: Any, name: str, *, default: Any) -> Any:
+    try:
+        return getattr(context, name)
+    except AttributeError:
+        return default
+
+
+def _normalize_context_state(raw_state: Any) -> MutableMapping[str, Any]:
+    if isinstance(raw_state, MutableMapping):
+        return raw_state
+    if isinstance(raw_state, Mapping):
+        return dict(raw_state)
+    return {}
+
+
+def _normalize_requested_extensions(raw_extensions: Any) -> set[str]:
+    if raw_extensions is None:
+        return set()
+    if isinstance(raw_extensions, set):
+        return raw_extensions
+    if isinstance(raw_extensions, str):
+        return {raw_extensions}
+    try:
+        return {str(value) for value in raw_extensions}
+    except TypeError:
+        return set()
+
+
+def _normalize_tenant(raw_tenant: Any) -> str:
+    return raw_tenant if isinstance(raw_tenant, str) else ""
+
+
+def _normalize_user(raw_user: Any, *, identity: str | None) -> User:
+    if identity:
+        if not isinstance(raw_user, User) or isinstance(raw_user, UnauthenticatedUser):
+            return AuthenticatedIdentityUser(identity)
+    if isinstance(raw_user, User):
+        return raw_user
+    return UnauthenticatedUser()

--- a/src/opencode_a2a/server/migrations.py
+++ b/src/opencode_a2a/server/migrations.py
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
 
 STATE_STORE_SCHEMA_NAME = "state_store"
 CURRENT_STATE_STORE_SCHEMA_VERSION = 5
-TASK_STORE_SCHEMA_NAME = "task_store"
-CURRENT_TASK_STORE_SCHEMA_VERSION = 3
 
 _SCHEMA_VERSION_METADATA = MetaData()
 
@@ -136,41 +134,6 @@ def _migration_5_drop_legacy_pending_claim_rows(
             pending_session_claims_table.c.expires_at.is_(None)
         )
     )
-
-
-def _migration_1_add_task_store_sdk_columns(
-    connection: Connection,
-    *,
-    task_table: Table,
-) -> None:
-    for column_name in ("owner", "last_updated", "protocol_version"):
-        _add_missing_nullable_column(
-            connection,
-            table=task_table,
-            column_name=column_name,
-        )
-
-
-def _migration_2_backfill_task_store_sdk_defaults(
-    connection: Connection,
-    *,
-    task_table: Table,
-) -> None:
-    connection.execute(task_table.update().where(task_table.c.owner.is_(None)).values(owner=""))
-    connection.execute(
-        task_table.update()
-        .where(task_table.c.protocol_version.is_(None))
-        .values(protocol_version="1.0")
-    )
-
-
-def _migration_3_add_task_store_indexes(
-    connection: Connection,
-    *,
-    task_table: Table,
-) -> None:
-    for index in sorted(task_table.indexes, key=lambda item: item.name or ""):
-        _create_missing_index(connection, index=index)
 
 
 def _read_schema_version(
@@ -288,38 +251,6 @@ def migrate_state_store_schema(
         connection,
         version_table=_SCHEMA_VERSIONS,
         scope=STATE_STORE_SCHEMA_NAME,
-        current_version=current_version,
-        migrations=migrations,
-    )
-
-
-def migrate_task_store_schema(
-    connection: Connection,
-    *,
-    task_table: Table,
-    current_version: int = CURRENT_TASK_STORE_SCHEMA_VERSION,
-) -> int:
-    _SCHEMA_VERSION_METADATA.create_all(connection)
-    task_table.metadata.create_all(connection, tables=[task_table])
-
-    migrations: dict[int, Callable[[Connection], None]] = {
-        1: lambda conn: _migration_1_add_task_store_sdk_columns(
-            conn,
-            task_table=task_table,
-        ),
-        2: lambda conn: _migration_2_backfill_task_store_sdk_defaults(
-            conn,
-            task_table=task_table,
-        ),
-        3: lambda conn: _migration_3_add_task_store_indexes(
-            conn,
-            task_table=task_table,
-        ),
-    }
-    return _apply_schema_migrations(
-        connection,
-        version_table=_SCHEMA_VERSIONS,
-        scope=TASK_STORE_SCHEMA_NAME,
         current_version=current_version,
         migrations=migrations,
     )

--- a/src/opencode_a2a/server/migrations.py
+++ b/src/opencode_a2a/server/migrations.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 
 STATE_STORE_SCHEMA_NAME = "state_store"
 CURRENT_STATE_STORE_SCHEMA_VERSION = 5
+TASK_STORE_SCHEMA_NAME = "task_store"
+CURRENT_TASK_STORE_SCHEMA_VERSION = 3
 
 _SCHEMA_VERSION_METADATA = MetaData()
 
@@ -134,6 +136,41 @@ def _migration_5_drop_legacy_pending_claim_rows(
             pending_session_claims_table.c.expires_at.is_(None)
         )
     )
+
+
+def _migration_1_add_task_store_sdk_columns(
+    connection: Connection,
+    *,
+    task_table: Table,
+) -> None:
+    for column_name in ("owner", "last_updated", "protocol_version"):
+        _add_missing_nullable_column(
+            connection,
+            table=task_table,
+            column_name=column_name,
+        )
+
+
+def _migration_2_backfill_task_store_sdk_defaults(
+    connection: Connection,
+    *,
+    task_table: Table,
+) -> None:
+    connection.execute(task_table.update().where(task_table.c.owner.is_(None)).values(owner=""))
+    connection.execute(
+        task_table.update()
+        .where(task_table.c.protocol_version.is_(None))
+        .values(protocol_version="1.0")
+    )
+
+
+def _migration_3_add_task_store_indexes(
+    connection: Connection,
+    *,
+    task_table: Table,
+) -> None:
+    for index in sorted(task_table.indexes, key=lambda item: item.name or ""):
+        _create_missing_index(connection, index=index)
 
 
 def _read_schema_version(
@@ -251,6 +288,38 @@ def migrate_state_store_schema(
         connection,
         version_table=_SCHEMA_VERSIONS,
         scope=STATE_STORE_SCHEMA_NAME,
+        current_version=current_version,
+        migrations=migrations,
+    )
+
+
+def migrate_task_store_schema(
+    connection: Connection,
+    *,
+    task_table: Table,
+    current_version: int = CURRENT_TASK_STORE_SCHEMA_VERSION,
+) -> int:
+    _SCHEMA_VERSION_METADATA.create_all(connection)
+    task_table.metadata.create_all(connection, tables=[task_table])
+
+    migrations: dict[int, Callable[[Connection], None]] = {
+        1: lambda conn: _migration_1_add_task_store_sdk_columns(
+            conn,
+            task_table=task_table,
+        ),
+        2: lambda conn: _migration_2_backfill_task_store_sdk_defaults(
+            conn,
+            task_table=task_table,
+        ),
+        3: lambda conn: _migration_3_add_task_store_indexes(
+            conn,
+            task_table=task_table,
+        ),
+    }
+    return _apply_schema_migrations(
+        connection,
+        version_table=_SCHEMA_VERSIONS,
+        scope=TASK_STORE_SCHEMA_NAME,
         current_version=current_version,
         migrations=migrations,
     )

--- a/src/opencode_a2a/server/rest_tasks.py
+++ b/src/opencode_a2a/server/rest_tasks.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
 
 from a2a.extensions.common import HTTP_EXTENSION_HEADER, get_requested_extensions
+from a2a.server.context import ServerCallContext
 from a2a.server.tasks.task_store import TaskStore
-from a2a.types import Task, TaskState
+from a2a.types import ListTasksRequest, Task, TaskState
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from google.protobuf.json_format import MessageToDict
@@ -31,12 +33,13 @@ from ..parsing import (
 from ..parsing import (
     parse_timestamp_field as parse_shared_timestamp_field,
 )
-from .task_store import TaskStoreOperationError, list_stored_tasks
+from .task_store import TaskStoreOperationError
 
 logger = logging.getLogger(__name__)
 _DEFAULT_LIST_TASKS_PAGE_SIZE = 50
 _MAX_LIST_TASKS_PAGE_SIZE = 100
 _MIN_LIST_TASKS_PAGE_SIZE = 1
+_LIST_TASKS_SCAN_BATCH_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -56,6 +59,13 @@ class _ListTasksQuery:
     status_timestamp_after: datetime | None
 
 
+@dataclass(frozen=True)
+class _ListTasksPage:
+    tasks: list[Task]
+    next_page_token: str
+    total_size: int
+
+
 class _ListTasksValidationError(ValueError):
     def __init__(self, *, field: str, message: str) -> None:
         super().__init__(message)
@@ -66,11 +76,16 @@ class _ListTasksValidationError(ValueError):
 def build_list_tasks_route(
     *,
     task_store: TaskStore,
+    context_builder: Callable[[Request], ServerCallContext],
 ):
     async def list_tasks_route(request: Request) -> JSONResponse:
         try:
             query = _parse_list_tasks_query(request)
-            tasks = await list_stored_tasks(task_store)
+            page = await _list_tasks_page(
+                task_store,
+                query=query,
+                context=context_builder(request),
+            )
         except _ListTasksValidationError as error:
             return JSONResponse(
                 build_http_error_body(
@@ -94,14 +109,6 @@ def build_list_tasks_route(
                 status_code=500,
             )
 
-        filtered_tasks = _filter_tasks(tasks, query=query)
-        total_size = len(filtered_tasks)
-        paged_tasks = _apply_cursor(filtered_tasks, cursor=query.cursor)
-        page_tasks = paged_tasks[: query.requested_page_size]
-        next_page_token = ""
-        if len(paged_tasks) > len(page_tasks) and page_tasks:
-            next_page_token = _encode_page_token(page_tasks[-1])
-
         return JSONResponse(
             {
                 "tasks": [
@@ -113,42 +120,78 @@ def build_list_tasks_route(
                             get_requested_extensions(request.headers.getlist(HTTP_EXTENSION_HEADER))
                         ),
                     )
-                    for task in page_tasks
+                    for task in page.tasks
                 ],
-                "nextPageToken": next_page_token,
-                "pageSize": len(page_tasks),
-                "totalSize": total_size,
+                "nextPageToken": page.next_page_token,
+                "pageSize": len(page.tasks),
+                "totalSize": page.total_size,
             }
         )
 
     return list_tasks_route
 
 
-def _filter_tasks(tasks: list[Task], *, query: _ListTasksQuery) -> list[Task]:
-    filtered = tasks
+async def _list_tasks_page(
+    task_store: TaskStore,
+    *,
+    query: _ListTasksQuery,
+    context: ServerCallContext,
+) -> _ListTasksPage:
+    page_tasks: list[Task] = []
+    total_size: int | None = None
+    backend_page_token = ""
+    has_more = False
 
-    if query.context_id is not None:
-        filtered = [task for task in filtered if task.context_id == query.context_id]
+    while True:
+        response = await task_store.list(
+            _build_list_tasks_request(
+                query,
+                page_size=max(query.requested_page_size, _LIST_TASKS_SCAN_BATCH_SIZE),
+                page_token=backend_page_token,
+            ),
+            context,
+        )
+        if total_size is None:
+            total_size = int(response.total_size)
 
-    if query.status is not None:
-        filtered = [task for task in filtered if task.status.state == query.status]
+        for task in response.tasks:
+            if query.cursor is not None and _task_sort_key(task) >= _cursor_sort_key(query.cursor):
+                continue
+            page_tasks.append(task)
+            if len(page_tasks) > query.requested_page_size:
+                has_more = True
+                break
 
-    if query.status_timestamp_after is not None:
-        filtered = [
-            task for task in filtered if _task_sort_key(task)[0] >= query.status_timestamp_after
-        ]
+        if has_more or not response.next_page_token:
+            break
+        backend_page_token = response.next_page_token
 
-    return sorted(
-        filtered,
-        key=_task_sort_key,
-        reverse=True,
+    tasks = page_tasks[: query.requested_page_size]
+    next_page_token = _encode_page_token(tasks[-1]) if has_more and tasks else ""
+    return _ListTasksPage(
+        tasks=tasks,
+        next_page_token=next_page_token,
+        total_size=0 if total_size is None else total_size,
     )
 
 
-def _apply_cursor(tasks: list[Task], *, cursor: _TaskCursor | None) -> list[Task]:
-    if cursor is None:
-        return tasks
-    return [task for task in tasks if _task_sort_key(task) < _cursor_sort_key(cursor)]
+def _build_list_tasks_request(
+    query: _ListTasksQuery,
+    *,
+    page_size: int,
+    page_token: str,
+) -> ListTasksRequest:
+    request = ListTasksRequest(
+        context_id=query.context_id or "",
+        include_artifacts=True,
+        page_size=page_size,
+        page_token=page_token,
+    )
+    if query.status is not None:
+        request.status = query.status
+    if query.status_timestamp_after is not None:
+        request.status_timestamp_after = query.status_timestamp_after
+    return request
 
 
 def _serialize_task(

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -13,7 +13,7 @@ from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_store import TaskStore
 from a2a.types import ListTasksRequest, ListTasksResponse, Task, TaskState
 from google.protobuf.json_format import MessageToDict
-from sqlalchemy import event, or_, select
+from sqlalchemy import Table, event, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine import make_url
@@ -21,6 +21,7 @@ from sqlalchemy.engine import make_url
 from ..a2a_utils import proto_equals
 from ..config import Settings
 from ..task_states import TERMINAL_TASK_STATES
+from .migrations import migrate_task_store_schema
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
@@ -472,6 +473,20 @@ def _task_row_values(task: Task, *, owner: str | None) -> dict[str, Any]:
 
 
 async def initialize_task_store(task_store: TaskStore) -> None:
+    raw_task_store = unwrap_task_store(task_store)
+    if isinstance(raw_task_store, DatabaseTaskStore):
+        if raw_task_store._initialized:
+            return
+        task_table = cast(Table, raw_task_store.task_model.__table__)
+        async with raw_task_store.engine.begin() as conn:
+            await conn.run_sync(
+                lambda sync_conn: migrate_task_store_schema(
+                    sync_conn,
+                    task_table=task_table,
+                )
+            )
+        raw_task_store._initialized = True
+        return
     initialize = getattr(task_store, "initialize", None)
     if callable(initialize):
         await initialize()

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -485,7 +485,7 @@ async def initialize_task_store(task_store: TaskStore) -> None:
                     task_table=task_table,
                 )
             )
-        raw_task_store._initialized = True
+        await raw_task_store.initialize()
         return
     initialize = getattr(task_store, "initialize", None)
     if callable(initialize):

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -33,7 +33,6 @@ _ATOMIC_TERMINAL_GUARD_DIALECTS = frozenset({"postgresql", "sqlite"})
 _SQLITE_JOURNAL_MODE = "WAL"
 _SQLITE_BUSY_TIMEOUT_MS = 30_000
 _SQLITE_SYNCHRONOUS_MODE = "NORMAL"
-_LIST_TASKS_BATCH_SIZE = 100
 
 
 class TaskStoreOperationError(RuntimeError):
@@ -378,28 +377,6 @@ def unwrap_task_store(task_store: TaskStore) -> TaskStore:
     if isinstance(inner, TaskStore):
         return unwrap_task_store(inner)
     return task_store
-
-
-async def list_stored_tasks(
-    task_store: TaskStore,
-    context: ServerCallContext | None = None,
-) -> list[Task]:
-    normalized_context = _normalize_task_store_context(context)
-    tasks: list[Task] = []
-    next_page_token = ""
-
-    while True:
-        response = await task_store.list(
-            ListTasksRequest(
-                page_size=_LIST_TASKS_BATCH_SIZE,
-                page_token=next_page_token,
-            ),
-            normalized_context,
-        )
-        tasks.extend(response.tasks)
-        if not response.next_page_token:
-            return tasks
-        next_page_token = response.next_page_token
 
 
 def _normalize_task_store_context(

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -13,7 +13,7 @@ from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_store import TaskStore
 from a2a.types import ListTasksRequest, ListTasksResponse, Task, TaskState
 from google.protobuf.json_format import MessageToDict
-from sqlalchemy import Table, event, or_, select
+from sqlalchemy import event, inspect, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine import make_url
@@ -21,7 +21,6 @@ from sqlalchemy.engine import make_url
 from ..a2a_utils import proto_equals
 from ..config import Settings
 from ..task_states import TERMINAL_TASK_STATES
-from .migrations import migrate_task_store_schema
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
@@ -33,6 +32,9 @@ _ATOMIC_TERMINAL_GUARD_DIALECTS = frozenset({"postgresql", "sqlite"})
 _SQLITE_JOURNAL_MODE = "WAL"
 _SQLITE_BUSY_TIMEOUT_MS = 30_000
 _SQLITE_SYNCHRONOUS_MODE = "NORMAL"
+_SDK_TASKS_TABLE_NAME = "tasks"
+_SDK_TASKS_REQUIRED_COLUMNS = frozenset({"owner", "last_updated", "protocol_version"})
+_SDK_TASKS_REQUIRED_INDEXES = frozenset({"idx_tasks_owner_last_updated"})
 
 
 class TaskStoreOperationError(RuntimeError):
@@ -47,6 +49,10 @@ class TaskStoreOperationError(RuntimeError):
 class TaskPersistenceDecision:
     persist: bool
     reason: str | None = None
+
+
+class TaskStoreSchemaCompatibilityError(RuntimeError):
+    pass
 
 
 class TaskWritePolicy(ABC):
@@ -452,18 +458,50 @@ def _task_row_values(task: Task, *, owner: str | None) -> dict[str, Any]:
 async def initialize_task_store(task_store: TaskStore) -> None:
     raw_task_store = unwrap_task_store(task_store)
     if isinstance(raw_task_store, DatabaseTaskStore):
-        if raw_task_store._initialized:
-            return
-        task_table = cast(Table, raw_task_store.task_model.__table__)
-        async with raw_task_store.engine.begin() as conn:
-            await conn.run_sync(
-                lambda sync_conn: migrate_task_store_schema(
-                    sync_conn,
-                    task_table=task_table,
-                )
-            )
+        await _ensure_sdk_task_store_schema_compatible(raw_task_store)
         await raw_task_store.initialize()
         return
     initialize = getattr(task_store, "initialize", None)
     if callable(initialize):
         await initialize()
+
+
+async def _ensure_sdk_task_store_schema_compatible(task_store: DatabaseTaskStore) -> None:
+    database_url = task_store.engine.url.render_as_string(hide_password=True)
+    async with task_store.engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: _validate_sdk_task_table_schema(
+                sync_conn,
+                database_url=database_url,
+            )
+        )
+
+
+def _validate_sdk_task_table_schema(
+    connection: Any,
+    *,
+    database_url: str,
+) -> None:
+    inspector = inspect(connection)
+    if _SDK_TASKS_TABLE_NAME not in inspector.get_table_names():
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns(_SDK_TASKS_TABLE_NAME)}
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_SDK_TASKS_TABLE_NAME)}
+    missing_columns = sorted(_SDK_TASKS_REQUIRED_COLUMNS - existing_columns)
+    missing_indexes = sorted(_SDK_TASKS_REQUIRED_INDEXES - existing_indexes)
+    if not missing_columns and not missing_indexes:
+        return
+
+    details: list[str] = []
+    if missing_columns:
+        details.append(f"missing columns: {', '.join(missing_columns)}")
+    if missing_indexes:
+        details.append(f"missing indexes: {', '.join(missing_indexes)}")
+
+    raise TaskStoreSchemaCompatibilityError(
+        "Legacy SDK task table schema detected for 'tasks' "
+        f"({'; '.join(details)}). Run "
+        f"`a2a-db --database-url {database_url}` before starting the service. "
+        "If `a2a-db` is unavailable, install the `a2a-sdk[db-cli]` extra first."
+    )

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -21,6 +21,7 @@ from sqlalchemy.engine import make_url
 from ..a2a_utils import proto_equals
 from ..config import Settings
 from ..task_states import TERMINAL_TASK_STATES
+from .context_helpers import normalize_server_call_context
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
@@ -388,9 +389,7 @@ def unwrap_task_store(task_store: TaskStore) -> TaskStore:
 def _normalize_task_store_context(
     context: ServerCallContext | None,
 ) -> ServerCallContext:
-    if context is not None:
-        return context
-    return ServerCallContext()
+    return normalize_server_call_context(context)
 
 
 def _configure_sqlite_connection(dbapi_connection: Any, _connection_record: Any) -> None:

--- a/tests/execution/test_agent_helpers.py
+++ b/tests/execution/test_agent_helpers.py
@@ -62,21 +62,28 @@ def test_stream_output_state_covers_echo_progress_and_interrupt_edges() -> None:
     )
 
     changed, append = state.register_chunk(
-        block_type=BlockType.TEXT,
+        artifact_id="task:stream:text",
         content_key="draft",
         append=False,
     )
     assert (changed, append) == (True, False)
     assert state.register_chunk(
-        block_type=BlockType.TEXT,
+        artifact_id="task:stream:text",
         content_key="draft",
         append=False,
     ) == (False, False)
     assert state.register_progress(identity="step:1", content_key="running") is True
     assert state.register_progress(identity="step:1", content_key="running") is False
-    assert state.should_emit_final_snapshot(" ") is False
-    assert state.should_emit_final_snapshot("draft") is False
-    assert state.should_emit_final_snapshot("final answer") is True
+    state.remember_text_artifact_id("task:stream:text")
+    assert state.should_emit_final_snapshot(artifact_id="task:stream:text", text=" ") is False
+    assert state.should_emit_final_snapshot(artifact_id="task:stream:text", text="draft") is False
+    assert (
+        state.should_emit_final_snapshot(
+            artifact_id="task:stream:text",
+            text="final answer",
+        )
+        is True
+    )
     assert state.resolve_message_id("  msg-1  ") == "msg-1"
     assert state.resolve_message_id("   ") == "msg-stable"
     assert state.build_event_id(state.next_sequence()) == "evt-ns:1"

--- a/tests/execution/test_streaming_output_contract_blocks.py
+++ b/tests/execution/test_streaming_output_contract_blocks.py
@@ -233,7 +233,14 @@ async def test_streaming_never_resets_single_artifact_after_first_chunk() -> Non
     updates = _artifact_updates(queue)
     assert len(updates) >= 2
     assert updates[0].append is False
-    assert all(ev.append is True for ev in updates[1:])
+    stream_updates = [ev for ev in updates if _artifact_stream_meta(ev)["source"] == "stream"]
+    assert stream_updates[0].append is False
+    assert all(ev.append is True for ev in stream_updates[1:])
+    final_snapshots = [
+        ev for ev in updates if _artifact_stream_meta(ev)["source"] == "final_snapshot"
+    ]
+    assert final_snapshots
+    assert all(ev.append is False for ev in final_snapshots)
 
 
 @pytest.mark.asyncio

--- a/tests/execution/test_streaming_output_contract_core.py
+++ b/tests/execution/test_streaming_output_contract_core.py
@@ -11,7 +11,7 @@ from a2a.types import (
 
 from opencode_a2a.execution.executor import OpencodeAgentExecutor
 from opencode_a2a.execution.stream_events import _extract_token_usage, _extract_tool_part_payload
-from opencode_a2a.execution.stream_state import BlockType, _StreamOutputState
+from opencode_a2a.execution.stream_state import _StreamOutputState
 from opencode_a2a.task_states import TERMINAL_TASK_STATES
 from tests.support.helpers import (
     DummyEventQueue,
@@ -76,19 +76,19 @@ def test_stream_output_state_deduplicates_non_accumulating_tool_chunks() -> None
     )
 
     assert state.register_chunk(
-        block_type=BlockType.TOOL_CALL,
+        artifact_id="task:stream:tool:call-1",
         content_key='{"status":"pending"}',
         append=False,
         accumulate_content=False,
     ) == (True, False)
     assert state.register_chunk(
-        block_type=BlockType.TOOL_CALL,
+        artifact_id="task:stream:tool:call-1",
         content_key='{"status":"pending"}',
         append=True,
         accumulate_content=False,
     ) == (False, False)
     assert state.register_chunk(
-        block_type=BlockType.TOOL_CALL,
+        artifact_id="task:stream:tool:call-1",
         content_key='{"status":"running"}',
         append=True,
         accumulate_content=False,
@@ -170,7 +170,11 @@ async def test_streaming_filters_user_echo_and_emits_single_artifact_block_types
     block_types = [_artifact_stream_meta(event)["block_type"] for event in updates]
     assert _unique(block_types) == ["reasoning", "tool_call", "text"]
     artifact_ids = [event.artifact.artifact_id for event in updates]
-    assert len(set(artifact_ids)) == 1
+    assert artifact_ids == [
+        "task-1:stream:reasoning",
+        "task-1:stream:tool:prt-msg-1-tool",
+        "task-1:stream:text",
+    ]
     event_ids = [_artifact_stream_meta(event)["event_id"] for event in updates]
     assert event_ids == [f"task-1:ctx-1:task-1:stream:{seq}" for seq in range(1, len(updates) + 1)]
 
@@ -348,7 +352,7 @@ async def test_streaming_emits_final_snapshot_only_when_stream_has_no_final_answ
     final_event = final_updates[0]
     assert _part_text(final_event) == "final answer from send_message"
     assert _artifact_stream_meta(final_event)["source"] == "final_snapshot"
-    assert final_event.append is True
+    assert final_event.append is False
     assert final_event.last_chunk is True
 
 
@@ -503,7 +507,7 @@ async def test_streaming_emits_snapshot_when_message_id_missing_and_stream_is_pa
     assert _artifact_stream_meta(first)["sequence"] == 1
 
     assert _part_text(second) == "partial final answer"
-    assert second.append is True
+    assert second.append is False
     assert second.last_chunk is True
     assert _artifact_stream_meta(second)["source"] == "final_snapshot"
     assert _artifact_stream_meta(second)["message_id"] == "task-6b:ctx-6b:assistant"

--- a/tests/server/test_call_context_builder.py
+++ b/tests/server/test_call_context_builder.py
@@ -32,6 +32,8 @@ def test_builder_sets_identity_for_non_stream_request():
     builder = IdentityAwareCallContextBuilder()
     context = builder.build(_request("/"))
     assert context.state.get("identity") == "opaque:test-id"
+    assert context.user.is_authenticated is True
+    assert context.user.user_name == "opaque:test-id"
     assert context.state.get("auth_scheme") == "bearer"
     assert context.state.get("credential_id") == "cred-123"
     assert context.state.get("traceparent") == (
@@ -46,6 +48,8 @@ def test_builder_marks_rest_stream_request():
     builder = IdentityAwareCallContextBuilder()
     context = builder.build(_request("/v1/message:stream"))
     assert context.state.get("identity") == "opaque:test-id"
+    assert context.user.is_authenticated is True
+    assert context.user.user_name == "opaque:test-id"
     assert context.state.get("auth_scheme") == "bearer"
     assert context.state.get("credential_id") == "cred-123"
     assert context.state.get("traceparent") == (
@@ -60,6 +64,8 @@ def test_builder_marks_encoded_stream_request():
     builder = IdentityAwareCallContextBuilder()
     context = builder.build(_request("/v1/message%3Astream", raw_path=b"/v1/message%3Astream"))
     assert context.state.get("identity") == "opaque:test-id"
+    assert context.user.is_authenticated is True
+    assert context.user.user_name == "opaque:test-id"
     assert context.state.get("auth_scheme") == "bearer"
     assert context.state.get("credential_id") == "cred-123"
     assert context.state.get("traceparent") == (

--- a/tests/server/test_output_negotiation.py
+++ b/tests/server/test_output_negotiation.py
@@ -216,6 +216,77 @@ async def test_negotiating_result_aggregator_persists_metadata_for_artifact_firs
 
 
 @pytest.mark.asyncio
+async def test_negotiating_result_aggregator_compacts_stream_artifacts_for_persistence() -> None:
+    store = _store()
+    task_manager = TaskManager(
+        context=ServerCallContext(),
+        task_id="task-stream-compact",
+        context_id="ctx-stream-compact",
+        task_store=store,
+        initial_message=None,
+    )
+    aggregator = NegotiatingResultAggregator(task_manager, None)
+    queue = EventQueue()
+    stream_metadata = {
+        "shared": {
+            "stream": {
+                "block_type": "text",
+                "source": "stream",
+                "message_id": "msg-stream-1",
+            }
+        }
+    }
+
+    await queue.enqueue_event(
+        TaskArtifactUpdateEvent(
+            task_id="task-stream-compact",
+            context_id="ctx-stream-compact",
+            artifact=Artifact(
+                artifact_id="task-stream-compact:stream:text",
+                parts=[Part(text="hello ")],
+                metadata=stream_metadata,
+            ),
+            append=False,
+            last_chunk=False,
+        )
+    )
+    await queue.enqueue_event(
+        TaskArtifactUpdateEvent(
+            task_id="task-stream-compact",
+            context_id="ctx-stream-compact",
+            artifact=Artifact(
+                artifact_id="task-stream-compact:stream:text",
+                parts=[Part(text="world")],
+                metadata=stream_metadata,
+            ),
+            append=True,
+            last_chunk=False,
+        )
+    )
+    await queue.enqueue_event(
+        TaskStatusUpdateEvent(
+            task_id="task-stream-compact",
+            context_id="ctx-stream-compact",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+        )
+    )
+
+    result = await aggregator.consume_all(EventConsumer(queue))
+
+    assert isinstance(result, Task)
+    assert result.artifacts is not None
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0].artifact_id == "task-stream-compact:stream:text"
+    assert result.artifacts[0].parts[0].text == "hello world"
+
+    stored = await store.get("task-stream-compact", ServerCallContext())
+    assert stored is not None
+    assert len(stored.artifacts) == 1
+    assert stored.artifacts[0].artifact_id == "task-stream-compact:stream:text"
+    assert stored.artifacts[0].parts[0].text == "hello world"
+
+
+@pytest.mark.asyncio
 async def test_on_get_task_applies_persisted_output_negotiation() -> None:
     store = _store()
     task = _task_with_negotiated_outputs(task_id="task-get", context_id="ctx-get")

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -8,9 +8,8 @@ from unittest.mock import AsyncMock
 import pytest
 from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.types import Task, TaskState, TaskStatus
-from sqlalchemy import inspect, text
+from sqlalchemy import text
 
-from opencode_a2a.server.migrations import CURRENT_TASK_STORE_SCHEMA_VERSION
 from opencode_a2a.server.task_store import (
     FirstTerminalStateWinsPolicy,
     GuardedTaskStore,
@@ -45,24 +44,6 @@ def _set_metadata(task: Task, metadata: dict) -> Task:
     task.ClearField("metadata")
     task.metadata.update(metadata)
     return task
-
-
-async def _read_task_store_schema_version(engine) -> int | None:  # noqa: ANN001
-    async with engine.begin() as conn:
-        result = await conn.execute(
-            text("SELECT version FROM a2a_schema_version WHERE name = 'task_store'")
-        )
-        value = result.scalar_one_or_none()
-        return int(value) if value is not None else None
-
-
-async def _read_table_index_names(engine, table_name: str) -> set[str]:  # noqa: ANN001
-    async with engine.begin() as conn:
-        return await conn.run_sync(
-            lambda sync_conn: {
-                index["name"] for index in inspect(sync_conn).get_indexes(table_name)
-            }
-        )
 
 
 def test_build_task_store_defaults_to_database_backend(tmp_path: Path) -> None:
@@ -191,7 +172,7 @@ async def test_build_database_engine_configures_sqlite_pragmas_and_parent_dir(
 
 
 @pytest.mark.asyncio
-async def test_database_task_store_upgrades_legacy_tasks_table_schema(
+async def test_database_task_store_rejects_legacy_tasks_table_schema(
     tmp_path: Path,
 ) -> None:
     database_url = f"sqlite+aiosqlite:///{tmp_path / 'legacy-tasks.db'}"
@@ -242,29 +223,8 @@ async def test_database_task_store_upgrades_legacy_tasks_table_schema(
         )
 
     store = build_task_store(settings, engine=engine)
-    await initialize_task_store(store)
-    restored = await store.get("legacy-task")
-
-    async with engine.begin() as conn:
-        result = await conn.execute(
-            text(
-                """
-                SELECT owner, protocol_version
-                FROM tasks
-                WHERE id = 'legacy-task'
-                """
-            )
-        )
-        migrated_row = result.mappings().one()
-
-    assert restored is not None
-    assert restored.id == "legacy-task"
-    assert restored.context_id == "ctx-1"
-    assert restored.status.state == TaskState.TASK_STATE_WORKING
-    assert migrated_row["owner"] == ""
-    assert migrated_row["protocol_version"] == "1.0"
-    assert await _read_task_store_schema_version(engine) == CURRENT_TASK_STORE_SCHEMA_VERSION
-    assert "idx_tasks_owner_last_updated" in await _read_table_index_names(engine, "tasks")
+    with pytest.raises(RuntimeError, match="a2a-db"):
+        await initialize_task_store(store)
 
     await engine.dispose()
 

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 import warnings
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from a2a.server.context import ServerCallContext
 from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.types import Task, TaskState, TaskStatus
 from sqlalchemy import text
@@ -24,7 +25,7 @@ from opencode_a2a.server.task_store import (
     initialize_task_store,
     unwrap_task_store,
 )
-from tests.support.helpers import make_settings
+from tests.support.helpers import make_request_context_mock, make_settings
 
 
 def _task(task_id: str, *, context_id: str = "ctx-1") -> Task:
@@ -258,6 +259,50 @@ async def test_initialize_task_store_delegates_back_to_sdk_initialize(
         await store.engine.dispose()
 
     assert called is True
+
+
+def test_make_request_context_mock_uses_normalized_call_context() -> None:
+    context = make_request_context_mock(
+        task_id="task-1",
+        context_id="ctx-1",
+        identity="opaque:test-id",
+    )
+
+    assert isinstance(context.call_context, ServerCallContext)
+    assert context.call_context.state["identity"] == "opaque:test-id"
+    assert context.call_context.user.is_authenticated is True
+    assert context.call_context.user.user_name == "opaque:test-id"
+
+
+@pytest.mark.asyncio
+async def test_database_task_store_normalizes_mock_server_call_context_identity_scope(
+    tmp_path: Path,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'mock-context.db'}",
+    )
+    store = build_task_store(settings)
+    await initialize_task_store(store)
+
+    owner_context = MagicMock(spec=ServerCallContext)
+    owner_context.state = {"identity": "opaque:test-id"}
+    owner_context.requested_extensions = set()
+
+    other_context = MagicMock(spec=ServerCallContext)
+    other_context.state = {"identity": "opaque:other-id"}
+    other_context.requested_extensions = set()
+
+    try:
+        await store.save(_task("task-1"), owner_context)
+        restored = await store.get("task-1", owner_context)
+        missing = await store.get("task-1", other_context)
+    finally:
+        await store.engine.dispose()
+
+    assert restored is not None
+    assert restored.id == "task-1"
+    assert missing is None
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -270,6 +270,37 @@ async def test_database_task_store_upgrades_legacy_tasks_table_schema(
 
 
 @pytest.mark.asyncio
+async def test_initialize_task_store_delegates_back_to_sdk_initialize(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'sdk-init.db'}",
+    )
+    store = build_task_store(settings)
+    raw_store = unwrap_task_store(store)
+    assert isinstance(raw_store, DatabaseTaskStore)
+
+    called = False
+    original_initialize = DatabaseTaskStore.initialize
+
+    async def _record_initialize(self) -> None:  # noqa: ANN001
+        nonlocal called
+        called = True
+        await original_initialize(self)
+
+    monkeypatch.setattr(DatabaseTaskStore, "initialize", _record_initialize)
+
+    try:
+        await initialize_task_store(store)
+    finally:
+        await store.engine.dispose()
+
+    assert called is True
+
+
+@pytest.mark.asyncio
 async def test_build_task_store_does_not_dispose_shared_engine(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -8,7 +8,9 @@ from unittest.mock import AsyncMock
 import pytest
 from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.types import Task, TaskState, TaskStatus
+from sqlalchemy import inspect, text
 
+from opencode_a2a.server.migrations import CURRENT_TASK_STORE_SCHEMA_VERSION
 from opencode_a2a.server.task_store import (
     FirstTerminalStateWinsPolicy,
     GuardedTaskStore,
@@ -43,6 +45,24 @@ def _set_metadata(task: Task, metadata: dict) -> Task:
     task.ClearField("metadata")
     task.metadata.update(metadata)
     return task
+
+
+async def _read_task_store_schema_version(engine) -> int | None:  # noqa: ANN001
+    async with engine.begin() as conn:
+        result = await conn.execute(
+            text("SELECT version FROM a2a_schema_version WHERE name = 'task_store'")
+        )
+        value = result.scalar_one_or_none()
+        return int(value) if value is not None else None
+
+
+async def _read_table_index_names(engine, table_name: str) -> set[str]:  # noqa: ANN001
+    async with engine.begin() as conn:
+        return await conn.run_sync(
+            lambda sync_conn: {
+                index["name"] for index in inspect(sync_conn).get_indexes(table_name)
+            }
+        )
 
 
 def test_build_task_store_defaults_to_database_backend(tmp_path: Path) -> None:
@@ -168,6 +188,85 @@ async def test_build_database_engine_configures_sqlite_pragmas_and_parent_dir(
     assert str(journal_mode).lower() == "wal"
     assert int(busy_timeout) == 30_000
     assert int(synchronous) == 1
+
+
+@pytest.mark.asyncio
+async def test_database_task_store_upgrades_legacy_tasks_table_schema(
+    tmp_path: Path,
+) -> None:
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'legacy-tasks.db'}"
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=database_url,
+    )
+    engine = build_database_engine(settings)
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                """
+                CREATE TABLE tasks (
+                    id VARCHAR(36) NOT NULL PRIMARY KEY,
+                    context_id VARCHAR(36) NOT NULL,
+                    kind VARCHAR(16) NOT NULL,
+                    status JSON NOT NULL,
+                    artifacts JSON,
+                    history JSON,
+                    metadata JSON
+                )
+                """
+            )
+        )
+        await conn.execute(
+            text(
+                """
+                INSERT INTO tasks (
+                    id,
+                    context_id,
+                    kind,
+                    status,
+                    artifacts,
+                    history,
+                    metadata
+                ) VALUES (
+                    'legacy-task',
+                    'ctx-1',
+                    'task',
+                    '{"state":"TASK_STATE_WORKING"}',
+                    '[]',
+                    '[]',
+                    '{}'
+                )
+                """
+            )
+        )
+
+    store = build_task_store(settings, engine=engine)
+    await initialize_task_store(store)
+    restored = await store.get("legacy-task")
+
+    async with engine.begin() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT owner, protocol_version
+                FROM tasks
+                WHERE id = 'legacy-task'
+                """
+            )
+        )
+        migrated_row = result.mappings().one()
+
+    assert restored is not None
+    assert restored.id == "legacy-task"
+    assert restored.context_id == "ctx-1"
+    assert restored.status.state == TaskState.TASK_STATE_WORKING
+    assert migrated_row["owner"] == ""
+    assert migrated_row["protocol_version"] == "1.0"
+    assert await _read_task_store_schema_version(engine) == CURRENT_TASK_STORE_SCHEMA_VERSION
+    assert "idx_tasks_owner_last_updated" in await _read_table_index_names(engine, "tasks")
+
+    await engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from a2a.auth.user import User
+from a2a.server.context import ServerCallContext
 from a2a.server.routes.rest_dispatcher import RestDispatcher
 from a2a.types import (
     Artifact,
@@ -91,6 +93,23 @@ def _task_for_listing(
         artifacts=artifacts,
         history=history,
     )
+
+
+class _TestUser(User):
+    def __init__(self, user_name: str) -> None:
+        self._user_name = user_name
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+    @property
+    def user_name(self) -> str:
+        return self._user_name
+
+
+def _authenticated_task_context(user_name: str = "automation") -> ServerCallContext:
+    return ServerCallContext(user=_TestUser(user_name))
 
 
 def test_agent_card_declares_dual_stack_with_http_json_preferred() -> None:
@@ -204,7 +223,8 @@ async def test_list_tasks_route_returns_paginated_results(monkeypatch) -> None:
             timestamp=(now + timedelta(seconds=2)).isoformat(),
             include_artifacts=True,
             history_size=3,
-        )
+        ),
+        _authenticated_task_context(),
     )
     await task_store.save(
         _task_for_listing(
@@ -213,7 +233,8 @@ async def test_list_tasks_route_returns_paginated_results(monkeypatch) -> None:
             timestamp=(now + timedelta(seconds=1)).isoformat(),
             include_artifacts=True,
             history_size=2,
-        )
+        ),
+        _authenticated_task_context(),
     )
     await task_store.save(
         _task_for_listing(
@@ -222,7 +243,8 @@ async def test_list_tasks_route_returns_paginated_results(monkeypatch) -> None:
             state=TaskState.TASK_STATE_WORKING,
             timestamp=now.isoformat(),
             history_size=1,
-        )
+        ),
+        _authenticated_task_context(),
     )
 
     transport = httpx.ASGITransport(app=app)
@@ -262,6 +284,50 @@ async def test_list_tasks_route_returns_paginated_results(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_tasks_route_respects_authenticated_owner_scope(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = app_module.create_app(
+        make_settings(
+            test_bearer_token="test-token",
+            a2a_task_store_backend="memory",
+        )
+    )
+    task_store = app.state.task_store
+    now = datetime.now(UTC)
+    await task_store.save(
+        _task_for_listing(
+            task_id="task-visible",
+            context_id="ctx-owner-scope",
+            timestamp=(now + timedelta(seconds=1)).isoformat(),
+        ),
+        _authenticated_task_context(),
+    )
+    await task_store.save(
+        _task_for_listing(
+            task_id="task-hidden",
+            context_id="ctx-owner-scope",
+            timestamp=now.isoformat(),
+        ),
+        _authenticated_task_context("someone-else"),
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/v1/tasks",
+            headers={"Authorization": "Bearer test-token"},
+            params={"contextId": "ctx-owner-scope"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totalSize"] == 1
+    assert [task["id"] for task in payload["tasks"]] == ["task-visible"]
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_route_cursor_stays_stable_when_newer_task_is_inserted(
     monkeypatch,
 ) -> None:
@@ -281,21 +347,24 @@ async def test_list_tasks_route_cursor_stays_stable_when_newer_task_is_inserted(
             task_id="task-page-1",
             context_id="ctx-cursor",
             timestamp=(now + timedelta(seconds=3)).isoformat(),
-        )
+        ),
+        _authenticated_task_context(),
     )
     await task_store.save(
         _task_for_listing(
             task_id="task-page-2",
             context_id="ctx-cursor",
             timestamp=(now + timedelta(seconds=2)).isoformat(),
-        )
+        ),
+        _authenticated_task_context(),
     )
     await task_store.save(
         _task_for_listing(
             task_id="task-page-3",
             context_id="ctx-cursor",
             timestamp=(now + timedelta(seconds=1)).isoformat(),
-        )
+        ),
+        _authenticated_task_context(),
     )
 
     transport = httpx.ASGITransport(app=app)
@@ -314,7 +383,8 @@ async def test_list_tasks_route_cursor_stays_stable_when_newer_task_is_inserted(
                 task_id="task-inserted-later",
                 context_id="ctx-cursor",
                 timestamp=(now + timedelta(seconds=4)).isoformat(),
-            )
+            ),
+            _authenticated_task_context(),
         )
 
         second_page = await client.get(
@@ -355,7 +425,7 @@ async def test_list_tasks_route_supports_history_artifacts_and_filters(monkeypat
         include_artifacts=True,
         history_size=4,
     )
-    await task_store.save(target_task)
+    await task_store.save(target_task, _authenticated_task_context())
     await task_store.save(
         _task_for_listing(
             task_id="task-excluded-status",
@@ -364,7 +434,8 @@ async def test_list_tasks_route_supports_history_artifacts_and_filters(monkeypat
             timestamp=now.isoformat(),
             include_artifacts=True,
             history_size=2,
-        )
+        ),
+        _authenticated_task_context(),
     )
 
     transport = httpx.ASGITransport(app=app)
@@ -424,7 +495,7 @@ async def test_list_tasks_route_applies_persisted_output_negotiation(monkeypatch
         ],
         metadata=metadata,
     )
-    await task_store.save(task)
+    await task_store.save(task, _authenticated_task_context())
 
     transport = httpx.ASGITransport(app=app)
     headers = {"Authorization": "Bearer test-token"}
@@ -477,7 +548,8 @@ async def test_list_tasks_route_filters_unnegotiated_shared_extension_metadata(m
             context_id="ctx-shared-list",
             status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED, timestamp=datetime.now(UTC)),
             metadata=metadata,
-        )
+        ),
+        _authenticated_task_context(),
     )
 
     transport = httpx.ASGITransport(app=app)
@@ -613,14 +685,16 @@ async def test_list_tasks_route_tolerates_invalid_stored_status_timestamp(monkey
             task_id="task-valid-ts",
             context_id="ctx-invalid-ts",
             timestamp=now.isoformat(),
-        )
+        ),
+        _authenticated_task_context(),
     )
     await task_store.save(
         _task_for_listing(
             task_id="task-invalid-ts",
             context_id="ctx-invalid-ts",
             timestamp="not-a-timestamp",
-        )
+        ),
+        _authenticated_task_context(),
     )
 
     transport = httpx.ASGITransport(app=app)

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -17,6 +17,7 @@ from opencode_a2a.contracts.extensions import (
     STREAMING_EXTENSION_URI,
 )
 from opencode_a2a.opencode_upstream_client import OpencodeMessage, OpencodeMessagePage
+from opencode_a2a.server.context_helpers import normalize_server_call_context
 
 
 def _build_test_static_auth_credentials(**overrides: Any) -> tuple[dict[str, Any], ...]:
@@ -102,10 +103,12 @@ def _default_requested_extensions() -> set[str]:
 
 def _ensure_test_call_context(call_context: Any | None) -> Any:
     if call_context is None:
-        return ServerCallContext(requested_extensions=_default_requested_extensions())
+        return normalize_server_call_context(
+            ServerCallContext(requested_extensions=_default_requested_extensions())
+        )
     if not hasattr(call_context, "requested_extensions"):
         call_context.requested_extensions = _default_requested_extensions()
-    return call_context
+    return normalize_server_call_context(call_context)
 
 
 def make_request_context_mock(
@@ -127,9 +130,12 @@ def make_request_context_mock(
     context.message = message
     context.current_task = current_task
     if call_context_enabled:
-        call_context = MagicMock(spec=ServerCallContext)
-        call_context.state = {"identity": identity} if identity else {}
-        call_context.requested_extensions = _default_requested_extensions()
+        call_context = normalize_server_call_context(
+            ServerCallContext(
+                state={"identity": identity} if identity else {},
+                requested_extensions=_default_requested_extensions(),
+            )
+        )
         context.call_context = call_context
     else:
         context.call_context = None


### PR DESCRIPTION
## 概览
本 PR 收敛两类边界：
- `a2a-sdk` task store / SDK-owned schema 的使用边界
- 流式 artifact 的传输边界与最终持久化边界

## 模块说明
### 服务与持久化
- `src/opencode_a2a/server/rest_tasks.py`
  - `/v1/tasks` 改为优先下推到 `task_store.list()`，不再先全量拉取再在进程内分页。
- `src/opencode_a2a/server/application.py`
  - 统一列表/消息路径的 call context 处理，让 owner scope 真正落到 SDK resolver。
- `src/opencode_a2a/server/context_helpers.py`
  - 收敛 `ServerCallContext` 规范化逻辑，补齐伪 context 的 `user` 兼容。
- `src/opencode_a2a/server/task_store.py`
  - SDK-owned `tasks` 表改为 fail-fast schema 校验后再委托 SDK initialize。
  - 读写前统一规范化 call context。
- `src/opencode_a2a/server/migrations.py`
  - 本地 migration 只继续管理 adapter-owned state tables，不再接管 SDK-owned `tasks` 表。

### 流式输出
- `src/opencode_a2a/execution/stream_state.py`
  - 流式状态从“整条流共用一个 artifact”收敛为“按逻辑 artifact 跟踪”。
- `src/opencode_a2a/execution/stream_runtime.py`
  - text / reasoning / tool_call 改为稳定逻辑 artifact 车道。
- `src/opencode_a2a/execution/coordinator.py`
  - streaming 完成时对 text artifact 补发完整 replace snapshot（`append=false`、`lastChunk=true`）。
- `src/opencode_a2a/output_modes.py`
  - 区分 transport event 与 persistence event；客户端继续收增量，task store 持久化 compact canonical snapshot。
- `src/opencode_a2a/cli.py`
  - 适配 final replace snapshot，避免 CLI 重复打印完整文本。

### 文档与测试
- `docs/guide.md`
  - 更新 SDK-owned schema 升级边界与 streaming contract 说明。
- `tests/execution/*`、`tests/server/*`
  - 补齐 task store schema fail-fast、伪 context 兼容、stream artifact canonical persistence 等回归测试。

## 验证
- `bash ./scripts/doctor.sh`
- `uv run python ./scripts/find_thin_wrappers.py --thin-only src/opencode_a2a`

## 关联 Issue
Closes #441
Closes #442
Closes #447
Closes #448
Refs #445
Refs #446
