### PR TITLE
refactor: introduce database runtimes for persistence

### DIFF
--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -93,6 +93,7 @@ from .agent_card import (
 )
 from .client_manager import A2AClientManager
 from .context_helpers import AuthenticatedIdentityUser
+from .database import build_database_engine
 from .lifespan import build_lifespan
 from .middleware import (
     build_agent_card_etag,
@@ -107,13 +108,11 @@ from .request_parsing import (
 )
 from .rest_tasks import build_list_tasks_route
 from .state_store import (
-    build_interrupt_request_repository,
-    build_session_state_repository,
+    build_runtime_state_runtime,
 )
 from .task_store import (
     TaskStoreOperationError,
-    build_database_engine,
-    build_task_store,
+    build_task_store_runtime,
     describe_lightweight_persistence_backend,
 )
 
@@ -784,14 +783,13 @@ def create_app(settings: Settings) -> FastAPI:
     database_engine = (
         build_database_engine(settings) if settings.a2a_task_store_backend == "database" else None
     )
-    session_state_repository = build_session_state_repository(settings, engine=database_engine)
-    interrupt_request_repository = build_interrupt_request_repository(
+    runtime_state_runtime = build_runtime_state_runtime(
         settings,
         engine=database_engine,
     )
     upstream_client = OpencodeUpstreamClient(
         settings,
-        interrupt_request_repository=interrupt_request_repository,
+        interrupt_request_repository=runtime_state_runtime.interrupt_request_repository,
     )
     client_manager = A2AClientManager(settings)
     agent_card = build_agent_card(settings)
@@ -802,12 +800,13 @@ def create_app(settings: Settings) -> FastAPI:
         cancel_abort_timeout_seconds=settings.a2a_cancel_abort_timeout_seconds,
         pending_session_claim_ttl_seconds=settings.a2a_pending_session_claim_ttl_seconds,
         a2a_client_manager=client_manager,
-        session_state_repository=session_state_repository,
+        session_state_repository=runtime_state_runtime.session_state_repository,
     )
-    task_store = build_task_store(
+    task_store_runtime = build_task_store_runtime(
         settings,
         engine=database_engine,
     )
+    task_store = task_store_runtime.task_store
     handler = OpencodeRequestHandler(
         agent_executor=executor,
         task_store=task_store,
@@ -859,9 +858,8 @@ def create_app(settings: Settings) -> FastAPI:
     persistence_summary = describe_lightweight_persistence_backend(settings)
     lifespan = build_lifespan(
         database_engine=database_engine,
-        task_store=task_store,
-        session_state_repository=session_state_repository,
-        interrupt_request_repository=interrupt_request_repository,
+        task_store_runtime=task_store_runtime,
+        runtime_state_runtime=runtime_state_runtime,
         client_manager=client_manager,
         upstream_client=upstream_client,
         persistence_summary=persistence_summary,

--- a/src/opencode_a2a/server/database.py
+++ b/src/opencode_a2a/server/database.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from sqlalchemy import event
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from ..config import Settings
+
+_SQLITE_JOURNAL_MODE = "WAL"
+_SQLITE_BUSY_TIMEOUT_MS = 30_000
+_SQLITE_SYNCHRONOUS_MODE = "NORMAL"
+
+
+def _configure_sqlite_connection(dbapi_connection: Any, _connection_record: Any) -> None:
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
+        cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+        cursor.execute(f"PRAGMA synchronous={_SQLITE_SYNCHRONOUS_MODE}")
+    finally:
+        cursor.close()
+
+
+def build_database_engine(settings: Settings) -> AsyncEngine:
+    database_url = cast(str, settings.a2a_task_store_database_url)
+    url = make_url(database_url)
+    if url.drivername.startswith("sqlite"):
+        database_path = url.database
+        if database_path and database_path != ":memory:" and not database_path.startswith("file:"):
+            path = Path(database_path)
+            if not path.is_absolute():
+                path = (Path.cwd() / path).resolve()
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+    engine = create_async_engine(
+        database_url,
+        pool_pre_ping=not url.drivername.startswith("sqlite"),
+    )
+    if url.drivername.startswith("sqlite"):
+        event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
+    return engine

--- a/src/opencode_a2a/server/lifespan.py
+++ b/src/opencode_a2a/server/lifespan.py
@@ -4,18 +4,14 @@ import logging
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
 
-from .state_store import initialize_state_repository
-from .task_store import initialize_task_store
-
 logger = logging.getLogger(__name__)
 
 
 def build_lifespan(
     *,
     database_engine,
-    task_store,
-    session_state_repository,
-    interrupt_request_repository,
+    task_store_runtime,
+    runtime_state_runtime,
     client_manager,
     upstream_client,
     persistence_summary: Mapping[str, object] | None = None,
@@ -31,13 +27,22 @@ def build_lifespan(
                 persistence_summary.get("database_url", "n/a"),
                 persistence_summary.get("sqlite_tuning", "not_applicable"),
             )
-        await initialize_task_store(task_store)
-        await initialize_state_repository(session_state_repository)
-        await initialize_state_repository(interrupt_request_repository)
-        yield
-        if database_engine is not None:
-            await database_engine.dispose()
-        await client_manager.close_all()
-        await upstream_client.close()
+        task_store_started = False
+        runtime_state_started = False
+        try:
+            await task_store_runtime.startup()
+            task_store_started = True
+            await runtime_state_runtime.startup()
+            runtime_state_started = True
+            yield
+        finally:
+            await client_manager.close_all()
+            await upstream_client.close()
+            if runtime_state_started:
+                await runtime_state_runtime.shutdown()
+            if task_store_started:
+                await task_store_runtime.shutdown()
+            if database_engine is not None:
+                await database_engine.dispose()
 
     return lifespan

--- a/src/opencode_a2a/server/state_store.py
+++ b/src/opencode_a2a/server/state_store.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import (
@@ -25,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from ..config import Settings
 from ..execution.stream_state import _TTLCache
 from ..runtime_state import InterruptRequestBinding, InterruptRequestTombstone
+from .database import build_database_engine
 from .migrations import migrate_state_store_schema
 
 if TYPE_CHECKING:
@@ -767,6 +769,54 @@ def build_interrupt_request_repository(
     return MemoryInterruptRequestRepository(
         request_ttl_seconds=settings.a2a_interrupt_request_ttl_seconds,
         tombstone_ttl_seconds=settings.a2a_interrupt_request_tombstone_ttl_seconds,
+    )
+
+
+@dataclass(slots=True)
+class RuntimeStateRuntime:
+    session_state_repository: SessionStateRepository
+    interrupt_request_repository: InterruptRequestRepository
+    startup: Callable[[], Awaitable[None]]
+    shutdown: Callable[[], Awaitable[None]]
+
+
+async def _noop() -> None:
+    return None
+
+
+def build_runtime_state_runtime(
+    settings: Settings,
+    *,
+    engine: AsyncEngine | None = None,
+) -> RuntimeStateRuntime:
+    if settings.a2a_task_store_backend != "database":
+        return RuntimeStateRuntime(
+            session_state_repository=build_session_state_repository(settings),
+            interrupt_request_repository=build_interrupt_request_repository(settings),
+            startup=_noop,
+            shutdown=_noop,
+        )
+
+    resolved_engine = engine or build_database_engine(settings)
+    session_state_repository = build_session_state_repository(settings, engine=resolved_engine)
+    interrupt_request_repository = build_interrupt_request_repository(
+        settings,
+        engine=resolved_engine,
+    )
+
+    async def _startup() -> None:
+        await initialize_state_repository(session_state_repository)
+        await initialize_state_repository(interrupt_request_repository)
+
+    async def _shutdown() -> None:
+        if engine is None:
+            await resolved_engine.dispose()
+
+    return RuntimeStateRuntime(
+        session_state_repository=session_state_repository,
+        interrupt_request_repository=interrupt_request_repository,
+        startup=_startup,
+        shutdown=_shutdown,
     )
 
 

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from a2a.server.context import ServerCallContext
@@ -13,7 +13,7 @@ from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_store import TaskStore
 from a2a.types import ListTasksRequest, ListTasksResponse, Task, TaskState
 from google.protobuf.json_format import MessageToDict
-from sqlalchemy import event, inspect, or_, select
+from sqlalchemy import inspect, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine import make_url
@@ -22,6 +22,7 @@ from ..a2a_utils import proto_equals
 from ..config import Settings
 from ..task_states import TERMINAL_TASK_STATES
 from .context_helpers import normalize_server_call_context
+from .database import build_database_engine
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
@@ -30,9 +31,6 @@ logger = logging.getLogger(__name__)
 
 _TERMINAL_TASK_STATE_VALUES = tuple(TaskState.Name(int(state)) for state in TERMINAL_TASK_STATES)
 _ATOMIC_TERMINAL_GUARD_DIALECTS = frozenset({"postgresql", "sqlite"})
-_SQLITE_JOURNAL_MODE = "WAL"
-_SQLITE_BUSY_TIMEOUT_MS = 30_000
-_SQLITE_SYNCHRONOUS_MODE = "NORMAL"
 _SDK_TASKS_TABLE_NAME = "tasks"
 _SDK_TASKS_REQUIRED_COLUMNS = frozenset({"owner", "last_updated", "protocol_version"})
 _SDK_TASKS_REQUIRED_INDEXES = frozenset({"idx_tasks_owner_last_updated"})
@@ -268,7 +266,7 @@ class PolicyAwareTaskStore(TaskStoreDecorator):
         task: Task,
         context: ServerCallContext,
     ) -> bool:
-        await task_store._ensure_initialized()
+        await task_store.initialize()
         statement = _build_atomic_task_save_statement(
             task=task,
             owner=task_store.owner_resolver(context),
@@ -284,7 +282,7 @@ class PolicyAwareTaskStore(TaskStoreDecorator):
         task_store: DatabaseTaskStore,
         task_id: str,
     ) -> Task | None:
-        await task_store._ensure_initialized()
+        await task_store.initialize()
         async with task_store.async_session_maker() as session:
             stmt = select(task_store.task_model).where(task_store.task_model.id == task_id)
             result = await session.execute(stmt)
@@ -326,20 +324,54 @@ class GuardedTaskStore(PolicyAwareTaskStore):
         )
 
 
+@dataclass(slots=True)
+class TaskStoreRuntime:
+    task_store: TaskStore
+    startup: Callable[[], Awaitable[None]]
+    shutdown: Callable[[], Awaitable[None]]
+
+
+async def _noop() -> None:
+    return None
+
+
+def build_task_store_runtime(
+    settings: Settings,
+    *,
+    engine: AsyncEngine | None = None,
+) -> TaskStoreRuntime:
+    if settings.a2a_task_store_backend == "memory":
+        return TaskStoreRuntime(
+            task_store=GuardedTaskStore(InMemoryTaskStore()),
+            startup=_noop,
+            shutdown=_noop,
+        )
+
+    resolved_engine = engine or build_database_engine(settings)
+    raw_task_store = DatabaseTaskStore(engine=resolved_engine)
+    task_store = GuardedTaskStore(raw_task_store)
+
+    async def _startup() -> None:
+        await _ensure_sdk_task_store_schema_compatible(raw_task_store)
+        await raw_task_store.initialize()
+
+    async def _shutdown() -> None:
+        if engine is None:
+            await resolved_engine.dispose()
+
+    return TaskStoreRuntime(
+        task_store=task_store,
+        startup=_startup,
+        shutdown=_shutdown,
+    )
+
+
 def build_task_store(
     settings: Settings,
     *,
     engine: AsyncEngine | None = None,
 ) -> TaskStore:
-    if settings.a2a_task_store_backend == "memory":
-        return GuardedTaskStore(InMemoryTaskStore())
-
-    resolved_engine = engine or build_database_engine(settings)
-    return GuardedTaskStore(
-        DatabaseTaskStore(
-            engine=resolved_engine,
-        )
-    )
+    return build_task_store_runtime(settings, engine=engine).task_store
 
 
 def describe_lightweight_persistence_backend(settings: Settings) -> dict[str, str]:
@@ -357,28 +389,6 @@ def describe_lightweight_persistence_backend(settings: Settings) -> dict[str, st
     return summary
 
 
-def build_database_engine(settings: Settings) -> AsyncEngine:
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    database_url = cast(str, settings.a2a_task_store_database_url)
-    url = make_url(database_url)
-    if url.drivername.startswith("sqlite"):
-        database_path = url.database
-        if database_path and database_path != ":memory:" and not database_path.startswith("file:"):
-            path = Path(database_path)
-            if not path.is_absolute():
-                path = (Path.cwd() / path).resolve()
-            path.parent.mkdir(parents=True, exist_ok=True)
-
-    engine = create_async_engine(
-        database_url,
-        pool_pre_ping=not url.drivername.startswith("sqlite"),
-    )
-    if url.drivername.startswith("sqlite"):
-        event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
-    return engine
-
-
 def unwrap_task_store(task_store: TaskStore) -> TaskStore:
     inner = getattr(task_store, "_inner", None)
     if isinstance(inner, TaskStore):
@@ -390,16 +400,6 @@ def _normalize_task_store_context(
     context: ServerCallContext | None,
 ) -> ServerCallContext:
     return normalize_server_call_context(context)
-
-
-def _configure_sqlite_connection(dbapi_connection: Any, _connection_record: Any) -> None:
-    cursor = dbapi_connection.cursor()
-    try:
-        cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
-        cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
-        cursor.execute(f"PRAGMA synchronous={_SQLITE_SYNCHRONOUS_MODE}")
-    finally:
-        cursor.close()
 
 
 def _build_atomic_task_save_statement(

--- a/tests/execution/test_session_ownership.py
+++ b/tests/execution/test_session_ownership.py
@@ -10,12 +10,12 @@ from opencode_a2a.execution.executor import OpencodeAgentExecutor
 from opencode_a2a.execution.session_manager import SessionManager
 from opencode_a2a.execution.stream_state import _TTLCache
 from opencode_a2a.opencode_upstream_client import OpencodeUpstreamClient
+from opencode_a2a.server.database import build_database_engine
 from opencode_a2a.server.state_store import (
     DatabaseSessionStateRepository,
     MemorySessionStateRepository,
     initialize_state_repository,
 )
-from opencode_a2a.server.task_store import build_database_engine
 from tests.support.helpers import (
     configure_mock_client_runtime,
     make_request_context_mock,

--- a/tests/server/test_state_store.py
+++ b/tests/server/test_state_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import inspect, text
@@ -9,16 +10,17 @@ from sqlalchemy.exc import IntegrityError
 
 import opencode_a2a.server.migrations as migrations_module
 import opencode_a2a.server.state_store as state_store_module
+from opencode_a2a.server.database import build_database_engine
 from opencode_a2a.server.migrations import CURRENT_STATE_STORE_SCHEMA_VERSION
 from opencode_a2a.server.state_store import (
     _INTERRUPT_REQUESTS,
     DatabaseSessionStateRepository,
     MemorySessionStateRepository,
     build_interrupt_request_repository,
+    build_runtime_state_runtime,
     build_session_state_repository,
     initialize_state_repository,
 )
-from opencode_a2a.server.task_store import build_database_engine
 from tests.support.helpers import make_settings
 
 
@@ -679,3 +681,24 @@ async def test_database_state_store_initialization_is_idempotent_across_reposito
     assert await _read_state_store_schema_row_count(engine) == 1
 
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_state_runtime_initializes_and_preserves_shared_engine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'runtime-state.db'}",
+    )
+    engine = build_database_engine(settings)
+    dispose_spy = AsyncMock()
+    monkeypatch.setattr(type(engine), "dispose", dispose_spy)
+
+    runtime = build_runtime_state_runtime(settings, engine=engine)
+    await runtime.startup()
+    await runtime.shutdown()
+
+    assert await _read_state_store_schema_version(engine) == CURRENT_STATE_STORE_SCHEMA_VERSION
+    dispose_spy.assert_not_awaited()

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -11,6 +11,7 @@ from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.types import Task, TaskState, TaskStatus
 from sqlalchemy import text
 
+from opencode_a2a.server.database import build_database_engine
 from opencode_a2a.server.task_store import (
     FirstTerminalStateWinsPolicy,
     GuardedTaskStore,
@@ -18,9 +19,10 @@ from opencode_a2a.server.task_store import (
     TaskPersistenceDecision,
     TaskStoreOperationError,
     TaskStoreOperationWrappingDecorator,
+    TaskStoreRuntime,
     TaskWritePolicy,
-    build_database_engine,
     build_task_store,
+    build_task_store_runtime,
     describe_lightweight_persistence_backend,
     initialize_task_store,
     unwrap_task_store,
@@ -58,6 +60,18 @@ def test_build_task_store_defaults_to_database_backend(tmp_path: Path) -> None:
     assert hasattr(store, "engine")
 
 
+def test_build_task_store_runtime_defaults_to_database_backend(tmp_path: Path) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'runtime-tasks.db'}",
+    )
+    runtime = build_task_store_runtime(settings)
+
+    assert isinstance(runtime, TaskStoreRuntime)
+    assert isinstance(runtime.task_store, GuardedTaskStore)
+    assert hasattr(runtime.task_store, "engine")
+
+
 def test_build_task_store_allows_explicit_memory_backend() -> None:
     from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 
@@ -68,6 +82,16 @@ def test_build_task_store_allows_explicit_memory_backend() -> None:
     assert isinstance(store, GuardedTaskStore)
     assert isinstance(store._inner, TaskStoreOperationWrappingDecorator)
     assert isinstance(store._inner._inner, InMemoryTaskStore)
+
+
+def test_build_task_store_runtime_allows_explicit_memory_backend() -> None:
+    runtime = build_task_store_runtime(
+        make_settings(test_bearer_token="test-token", a2a_task_store_backend="memory")
+    )
+
+    assert isinstance(runtime.task_store, GuardedTaskStore)
+    assert runtime.startup is not None
+    assert runtime.shutdown is not None
 
 
 def test_describe_lightweight_persistence_backend_marks_sqlite_first_scope() -> None:
@@ -261,6 +285,46 @@ async def test_initialize_task_store_delegates_back_to_sdk_initialize(
     assert called is True
 
 
+@pytest.mark.asyncio
+async def test_policy_aware_task_store_uses_public_initialize_for_atomic_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'public-init.db'}",
+    )
+    store = build_task_store(settings)
+    raw_store = unwrap_task_store(store)
+    assert isinstance(raw_store, DatabaseTaskStore)
+
+    original_initialize = DatabaseTaskStore.initialize
+    called = 0
+
+    async def _record_initialize(self) -> None:  # noqa: ANN001
+        nonlocal called
+        called += 1
+        await original_initialize(self)
+
+    async def _fail_private_initialize(self) -> None:  # noqa: ANN001
+        raise AssertionError("_ensure_initialized should not be used by task store adapter")
+
+    monkeypatch.setattr(DatabaseTaskStore, "initialize", _record_initialize)
+    monkeypatch.setattr(DatabaseTaskStore, "_ensure_initialized", _fail_private_initialize)
+
+    try:
+        await initialize_task_store(store)
+        await store.save(_task("task-1"))
+        completed = _set_status(_task("task-1"), TaskState.TASK_STATE_COMPLETED)
+        await store.save(completed)
+        late_failed = _set_status(_task("task-1"), TaskState.TASK_STATE_FAILED)
+        await store.save(late_failed)
+    finally:
+        await store.engine.dispose()
+
+    assert called >= 3
+
+
 def test_make_request_context_mock_uses_normalized_call_context() -> None:
     context = make_request_context_mock(
         task_id="task-1",
@@ -320,6 +384,26 @@ async def test_build_task_store_does_not_dispose_shared_engine(
 
     store = build_task_store(settings, engine=engine)
     await initialize_task_store(store)
+
+    dispose_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_task_store_runtime_does_not_dispose_shared_engine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'shared-runtime-engine.db'}",
+    )
+    engine = build_database_engine(settings)
+    dispose_spy = AsyncMock()
+    monkeypatch.setattr(type(engine), "dispose", dispose_spy)
+
+    runtime = build_task_store_runtime(settings, engine=engine)
+    await runtime.startup()
+    await runtime.shutdown()
 
     dispose_spy.assert_not_awaited()
 

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -1780,17 +1780,25 @@ def test_create_app_requires_control_guard_hooks(monkeypatch) -> None:
 
 def test_create_app_builds_configured_task_store(monkeypatch) -> None:
     import opencode_a2a.server.application as app_module
+    from opencode_a2a.server.task_store import TaskStoreRuntime
 
     captured: dict[str, object] = {}
 
-    def _build_task_store(settings, *, engine=None):  # noqa: ANN001
+    async def _noop() -> None:
+        return None
+
+    def _build_task_store_runtime(settings, *, engine=None):  # noqa: ANN001
         del engine
         captured["backend"] = settings.a2a_task_store_backend
         captured["database_url"] = settings.a2a_task_store_database_url
-        return MagicMock()
+        return TaskStoreRuntime(
+            task_store=MagicMock(),
+            startup=_noop,
+            shutdown=_noop,
+        )
 
     monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
-    monkeypatch.setattr(app_module, "build_task_store", _build_task_store)
+    monkeypatch.setattr(app_module, "build_task_store_runtime", _build_task_store_runtime)
 
     app_module.create_app(
         make_settings(


### PR DESCRIPTION
## 背景
本 PR 落实 `#450`，将数据库基础设施与持久化组件生命周期从 `create_app()` 中收敛出来，保持现有外部契约不变。

## 主要改动
- 新增 `src/opencode_a2a/server/database.py`，统一承载 database engine 创建与 SQLite tuning。
- 为 task store 引入 `TaskStoreRuntime`，统一 startup / shutdown，并将内部初始化切回 SDK 公开 `initialize()`。
- 为 session state / interrupt request 仓储引入 `RuntimeStateRuntime`，统一 DB 仓储初始化路径。
- 调整 `create_app()` 与 `lifespan` 只消费 runtime 组装结果，收敛资源所有权。
- 更新相关测试，覆盖 runtime 初始化、共享 engine 不被误释放、以及 `create_app()` 新装配路径。

## 非目标
- 不恢复 push notification config 对外能力。
- `#451` 仅继续追踪，不在本 PR 内实施。
- 不在本 PR 内彻底消除 task store 其余对 SDK 内部 ORM 细节的依赖；该问题继续由 `#446` 跟踪。

## 验证
- `./scripts/doctor.sh`
- `uv run pytest --no-cov tests/server/test_app_behaviors.py tests/server/test_transport_contract.py tests/server/test_database_app_persistence.py`

## 自审
- 代码路径与 `#450` 目标一致，未改变 push notification unsupported 契约。
- 未发现阻塞性问题；当前剩余风险主要是 `#446` 已跟踪的 SDK 内部 ORM 依赖尚未完全收敛，但本 PR 已先移除 `_ensure_initialized()` 这一类显式私有初始化耦合。

Closes #450
Closes #449
Related #446
Related #451
