### PR TITLE
fix: deduplicate working task updates

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -223,7 +223,7 @@ If one deployment works while another fails against the same upstream provider, 
 ## Streaming Contract
 
 - Streaming is always enabled in this server profile; `message:stream` is part of the stable runtime baseline.
-- Streaming (`/v1/message:stream`) emits incremental `TaskArtifactUpdateEvent` and then `TaskStatusUpdateEvent(final=true)`.
+- Streaming (`/v1/message:stream`) emits an initial working `Task`, then incremental `TaskArtifactUpdateEvent` / `TaskStatusUpdateEvent` updates, and finally a terminal `TaskStatusUpdateEvent(final=true)`.
 - Stream artifacts carry `artifact.metadata.shared.stream.block_type` with values `text` / `reasoning` / `tool_call`.
 - Stream artifacts are scoped to logical output lanes rather than one shared catch-all artifact:
   - text chunks use a stable text artifact ID
@@ -243,11 +243,12 @@ If one deployment works while another fails against the same upstream provider, 
 - When a request restricts `acceptedOutputModes`, the stream applies the same output filtering before persistence so later task snapshots do not re-expose filtered structured blocks.
 - Persistence is canonicalized separately from transport: stream subscribers still receive incremental artifact updates, while task-store persistence rewrites those updates into compact per-artifact snapshots so `GetTask` and terminal replay do not accumulate token-level fragments.
 - Final status event metadata may include normalized token usage at `metadata.shared.usage` with fields such as `input_tokens`, `output_tokens`, `total_tokens`, optional `reasoning_tokens`, optional `cache_tokens.read_tokens` / `cache_tokens.write_tokens`, and optional `cost`.
+- Progress metadata at `metadata.shared.progress` is emitted only when the client negotiated `urn:opencode-a2a:extension:shared:stream-hints:v1`; baseline streams do not emit duplicate generic `working` status updates just to carry progress hints.
 - Usage is extracted from documented info payloads and supported usage parts such as `step-finish`; non-usage parts with similar fields are ignored.
 - Interrupt events (`permission.asked` / `question.asked`) are mapped to `TaskStatusUpdateEvent(final=false, state=input-required)` with details at `metadata.shared.interrupt`, including `request_id`, interrupt `type`, `phase=asked`, and a normalized minimal callback payload.
 - Resolved interrupt events (`permission.replied` / `question.replied` / `question.rejected`) are emitted as `TaskStatusUpdateEvent(final=false, state=working)` with `metadata.shared.interrupt.phase=resolved` and a normalized `metadata.shared.interrupt.resolution`.
 - Duplicate or unknown resolved events are suppressed unless the matching request is still pending.
-- Non-streaming requests return a `Task` directly.
+- Non-streaming requests return a `Task` directly. When `configuration.returnImmediately=true`, the initial response is a working `Task` snapshot and completion continues in the background for later `GetTask` reads.
 - Non-streaming `message:send` responses may include normalized token usage at `Task.metadata.shared.usage` with the same field schema.
 
 ## Auth, Limits, and Failure Contract

--- a/src/opencode_a2a/execution/coordinator.py
+++ b/src/opencode_a2a/execution/coordinator.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 class PreparedExecution:
     identity: str
     streaming_request: bool
+    return_immediately: bool
     request_parts: list[Any]
     user_text: str
     session_title: str
@@ -115,13 +116,8 @@ class ExecutionCoordinator:
 
         try:
             await self._bind_session()
-            await self._event_queue.enqueue_event(
-                TaskStatusUpdateEvent(
-                    task_id=self._task_id,
-                    context_id=self._context_id,
-                    status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
-                )
-            )
+            if self._prepared.streaming_request or self._prepared.return_immediately:
+                await self._event_queue.enqueue_event(self._build_initial_task_snapshot())
 
             turn_request_parts = list(self._prepared.request_parts)
             user_text = self._prepared.user_text
@@ -480,6 +476,21 @@ class ExecutionCoordinator:
         )
         task.status.message.CopyFrom(assistant_message)
         await self._event_queue.enqueue_event(task)
+
+    def _build_initial_task_snapshot(self) -> Task:
+        current_task = self._context.current_task
+        if current_task is not None:
+            task = Task()
+            task.CopyFrom(current_task)
+        else:
+            task = Task(id=self._task_id, context_id=self._context_id)
+            if self._context.message:
+                task.history.append(self._context.message)
+
+        task.id = self._task_id
+        task.context_id = self._context_id
+        task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_WORKING))
+        return task
 
     async def _cleanup(self) -> None:
         if self._pending_preferred_claim and self._session_id:

--- a/src/opencode_a2a/execution/executor.py
+++ b/src/opencode_a2a/execution/executor.py
@@ -120,8 +120,13 @@ class OpencodeAgentExecutor(AgentExecutor):
         trace_id = call_context.state.get("trace_id") if call_context else None
 
         streaming_request = self._should_stream(context)
+        configuration = context.configuration
+        return_immediately = (
+            configuration is not None
+            and getattr(configuration, "return_immediately", False) is True
+        )
         requested_extensions = requested_extensions_from_call_context(context.call_context)
-        accepted_output_modes = normalize_accepted_output_modes(context.configuration)
+        accepted_output_modes = normalize_accepted_output_modes(configuration)
         message_parts = (
             getattr(context.message, "parts", None) if context.message is not None else None
         )
@@ -283,6 +288,7 @@ class OpencodeAgentExecutor(AgentExecutor):
         prepared = PreparedExecution(
             identity=identity,
             streaming_request=streaming_request,
+            return_immediately=return_immediately,
             request_parts=request_parts,
             user_text=user_text,
             session_title=session_title or user_text,

--- a/src/opencode_a2a/execution/stream_runtime.py
+++ b/src/opencode_a2a/execution/stream_runtime.py
@@ -435,9 +435,12 @@ class StreamRuntime:
                                         sort_keys=True,
                                         separators=(",", ":"),
                                     )
-                                    if stream_state.register_progress(
-                                        identity=progress_identity,
-                                        content_key=progress_key,
+                                    if (
+                                        stream_state.register_progress(
+                                            identity=progress_identity,
+                                            content_key=progress_key,
+                                        )
+                                        and emit_streaming_metadata
                                     ):
                                         sequence = stream_state.next_sequence()
                                         await event_queue.enqueue_event(

--- a/tests/execution/test_streaming_output_contract_core.py
+++ b/tests/execution/test_streaming_output_contract_core.py
@@ -2,8 +2,14 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+from a2a.server.agent_execution import RequestContext
+from a2a.server.context import ServerCallContext
 from a2a.types import (
+    Message,
     Part,
+    Role,
+    SendMessageConfiguration,
+    SendMessageRequest,
     Task,
     TaskState,
     TaskStatusUpdateEvent,
@@ -12,6 +18,7 @@ from a2a.types import (
 from opencode_a2a.execution.executor import OpencodeAgentExecutor
 from opencode_a2a.execution.stream_events import _extract_token_usage, _extract_tool_part_payload
 from opencode_a2a.execution.stream_state import _StreamOutputState
+from opencode_a2a.server.context_helpers import normalize_server_call_context
 from opencode_a2a.task_states import TERMINAL_TASK_STATES
 from tests.support.helpers import (
     DummyEventQueue,
@@ -66,6 +73,30 @@ async def test_streaming_accepts_file_input_without_breaking_contract() -> None:
 
     assert _is_terminal_status_event(status_events[-1])
     assert status_events[-1].status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_streaming_emits_initial_working_task_snapshot() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            _event(session_id="ses-1", role="assistant", part_type="text", delta="hello"),
+        ],
+        response_text="hello",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    await executor.execute(
+        make_request_context(task_id="task-1", context_id="ctx-1", text="hi"), queue
+    )
+
+    assert isinstance(queue.events[0], Task)
+    assert queue.events[0].status.state == TaskState.TASK_STATE_WORKING
+    assert queue.events[0].id == "task-1"
+    assert queue.events[0].context_id == "ctx-1"
+    assert len(queue.events[0].history) == 1
+    assert queue.events[0].history[0].parts[0].text == "hi"
 
 
 def test_stream_output_state_deduplicates_non_accumulating_tool_chunks() -> None:
@@ -834,6 +865,56 @@ async def test_streaming_emits_progress_metadata_for_snapshot_without_text_artif
 
 
 @pytest.mark.asyncio
+async def test_streaming_progress_without_extension_avoids_duplicate_working_status() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "part": {
+                        "id": "prt-step-start-1",
+                        "sessionID": "ses-1",
+                        "messageID": "msg-1",
+                        "type": "step-start",
+                        "reason": "run",
+                        "state": {
+                            "status": "running",
+                            "title": "Planning",
+                        },
+                    }
+                },
+            },
+        ],
+        response_text="done",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+    call_context = normalize_server_call_context(ServerCallContext(requested_extensions=set()))
+
+    await executor.execute(
+        make_request_context(
+            task_id="task-progress",
+            context_id="ctx-progress",
+            text="hello",
+            call_context=call_context,
+        ),
+        queue,
+    )
+
+    assert isinstance(queue.events[0], Task)
+    assert queue.events[0].status.state == TaskState.TASK_STATE_WORKING
+    working_status_updates = [
+        event
+        for event in queue.events
+        if isinstance(event, TaskStatusUpdateEvent)
+        and not _is_terminal_status_event(event)
+        and event.status.state == TaskState.TASK_STATE_WORKING
+    ]
+    assert working_status_updates == []
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_response_task_state_is_completed() -> None:
     client = DummyStreamingClient(
         stream_events_payload=[],
@@ -851,4 +932,35 @@ async def test_non_streaming_response_task_state_is_completed() -> None:
 
     tasks = [event for event in queue.events if isinstance(event, Task)]
     assert tasks
+    assert tasks[-1].status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_return_immediately_emits_initial_working_task() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[],
+        response_text="answer",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    queue = DummyEventQueue()
+    call_context = normalize_server_call_context(ServerCallContext(requested_extensions=set()))
+    context = RequestContext(
+        request=SendMessageRequest(
+            message=Message(
+                message_id="req-1",
+                role=Role.ROLE_USER,
+                parts=[Part(text="hello")],
+            ),
+            configuration=SendMessageConfiguration(return_immediately=True),
+        ),
+        task_id="task-return-immediately",
+        context_id="ctx-return-immediately",
+        call_context=call_context,
+    )
+
+    await executor.execute(context, queue)
+
+    assert isinstance(queue.events[0], Task)
+    assert queue.events[0].status.state == TaskState.TASK_STATE_WORKING
+    tasks = [event for event in queue.events if isinstance(event, Task)]
     assert tasks[-1].status.state == TaskState.TASK_STATE_COMPLETED


### PR DESCRIPTION
## 概要
- 修复流式执行中重复发出 indistinguishable `working` 状态更新的问题。
- 对齐 `a2a-sdk` 的非阻塞 `SendMessage` 语义，补上 `returnImmediately=true` 时的初始 `Task(working)` 快照。
- 同步更新流式/非流式契约文档与回归测试。

## 变更说明
- `message:stream` 首个事件改为 `Task(state=working)`，不再使用通用 `TaskStatusUpdateEvent(state=working)` 作为初始快照。
- 普通 progress 仅在协商 `urn:opencode-a2a:extension:shared:stream-hints:v1` 时才发带 `metadata.shared.progress` 的 `TaskStatusUpdateEvent(state=working)`。
- `message:send` 阻塞模式保持不变；`configuration.returnImmediately=true` 时先返回 `Task(state=working)`，后续由后台继续完成并持久化。
- 补充流式首包形态、无扩展去重、非流式非阻塞初始快照等回归测试，并更新 `docs/guide.md`。

## 验证
- `./scripts/doctor.sh`
- 结果：`620 passed`，coverage `91.18%`

## Issue 关联
Closes #453
