### PR TITLE
refactor: narrow shared metadata contract surface

### DIFF
--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -58,7 +58,6 @@ Extension URI:
 - Disclosure: public Agent Card and authenticated extended Agent Card
 - Activation: client requests the URI via `A2A-Extensions` and sends `metadata.shared.session.id`
 - Runtime fields: `metadata.shared.session.id`, `metadata.shared.session`, optional provider-private companions `metadata.opencode.directory` and `metadata.opencode.workspace.id`
-- Detailed-only display field: `metadata.shared.session.title` may be emitted when known, but it is not part of the minimum public consumer contract
 - Dependencies: none declared by this version
 - Security boundary: shared session identity is portable; provider-private routing metadata remains deployment-scoped
 - Versioning: breaking changes require a new versioned URI

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -58,6 +58,7 @@ Extension URI:
 - Disclosure: public Agent Card and authenticated extended Agent Card
 - Activation: client requests the URI via `A2A-Extensions` and sends `metadata.shared.session.id`
 - Runtime fields: `metadata.shared.session.id`, `metadata.shared.session`, optional provider-private companions `metadata.opencode.directory` and `metadata.opencode.workspace.id`
+- Detailed-only display field: `metadata.shared.session.title` may be emitted when known, but it is not part of the minimum public consumer contract
 - Dependencies: none declared by this version
 - Security boundary: shared session identity is portable; provider-private routing metadata remains deployment-scoped
 - Versioning: breaking changes require a new versioned URI
@@ -85,6 +86,7 @@ Extension URI:
 - Disclosure: public Agent Card and authenticated extended Agent Card
 - Activation: client requests the URI via `A2A-Extensions`; runtime emits shared metadata on streamed events and final task payloads
 - Runtime fields: `metadata.shared.stream`, `metadata.shared.progress`, `metadata.shared.usage`
+- Detailed-only correlation fields: `metadata.shared.stream.message_id` and `metadata.shared.stream.event_id` may be emitted for timeline stitching and diagnostics, but are not part of the minimum public consumer contract
 - Dependencies: none declared by this version
 - Security boundary: this extension is observational metadata only; callback methods are defined by the separate shared interactive interrupt extension
 - Versioning: breaking changes require a new versioned URI

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -54,7 +54,7 @@ Provider-private contract note:
 Extension URI:
 `urn:opencode-a2a:extension:shared:session-binding:v1`
 
-- Scope: shared A2A request metadata for rebinding to an existing upstream OpenCode session
+- Scope: shared A2A request metadata for rebinding to an existing upstream OpenCode session, plus negotiated response/task session metadata
 - Disclosure: public Agent Card and authenticated extended Agent Card
 - Activation: client requests the URI via `A2A-Extensions` and sends `metadata.shared.session.id`
 - Runtime fields: `metadata.shared.session.id`, `metadata.shared.session`, optional provider-private companions `metadata.opencode.directory` and `metadata.opencode.workspace.id`
@@ -81,10 +81,10 @@ Extension URI:
 Extension URI:
 `urn:opencode-a2a:extension:shared:stream-hints:v1`
 
-- Scope: shared response/task/stream metadata for block identity, progress, usage, interrupt, and session hints
+- Scope: shared response/task/stream metadata for block identity, progress, and usage hints
 - Disclosure: public Agent Card and authenticated extended Agent Card
 - Activation: client requests the URI via `A2A-Extensions`; runtime emits shared metadata on streamed events and final task payloads
-- Runtime fields: `metadata.shared.stream`, `metadata.shared.progress`, `metadata.shared.interrupt`, `metadata.shared.usage`, `metadata.shared.session`
+- Runtime fields: `metadata.shared.stream`, `metadata.shared.progress`, `metadata.shared.usage`
 - Dependencies: none declared by this version
 - Security boundary: this extension is observational metadata only; callback methods are defined by the separate shared interactive interrupt extension
 - Versioning: breaking changes require a new versioned URI
@@ -98,7 +98,7 @@ Extension URI:
 - Disclosure: public Agent Card and authenticated extended Agent Card
 - Activation: client requests the URI via `A2A-Extensions` before calling `a2a.interrupt.*` methods
 - Methods: `a2a.interrupt.permission.reply`, `a2a.interrupt.question.reply`, `a2a.interrupt.question.reject`
-- Runtime fields: `metadata.shared.interrupt.request_id` provides the callback correlation key
+- Runtime fields: `metadata.shared.interrupt`, including `metadata.shared.interrupt.request_id` as the callback correlation key
 - Dependencies: none declared by this version
 - Security boundary: the methods are shared, but request IDs remain scoped to authenticated caller identity and local interrupt state
 - Versioning: breaking changes require a new versioned URI

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -244,8 +244,8 @@ If one deployment works while another fails against the same upstream provider, 
 - Final status event metadata may include normalized token usage at `metadata.shared.usage` with fields such as `input_tokens`, `output_tokens`, `total_tokens`, optional `reasoning_tokens`, optional `cache_tokens.read_tokens` / `cache_tokens.write_tokens`, and optional `cost`.
 - Progress metadata at `metadata.shared.progress` is emitted only when the client negotiated `urn:opencode-a2a:extension:shared:stream-hints:v1`; baseline streams do not emit duplicate generic `working` status updates just to carry progress hints.
 - Usage is extracted from documented info payloads and supported usage parts such as `step-finish`; non-usage parts with similar fields are ignored.
-- Interrupt events (`permission.asked` / `question.asked`) are mapped to `TaskStatusUpdateEvent(final=false, state=input-required)` with details at `metadata.shared.interrupt`, including `request_id`, interrupt `type`, `phase=asked`, and a normalized minimal callback payload.
-- Resolved interrupt events (`permission.replied` / `question.replied` / `question.rejected`) are emitted as `TaskStatusUpdateEvent(final=false, state=working)` with `metadata.shared.interrupt.phase=resolved` and a normalized `metadata.shared.interrupt.resolution`.
+- Interrupt events (`permission.asked` / `question.asked`) are mapped to `TaskStatusUpdateEvent(final=false, state=input-required)` with details at `metadata.shared.interrupt` when the client negotiated `urn:opencode-a2a:extension:shared:interactive-interrupt:v1`.
+- Resolved interrupt events (`permission.replied` / `question.replied` / `question.rejected`) are emitted as `TaskStatusUpdateEvent(final=false, state=working)` with `metadata.shared.interrupt.phase=resolved` only when the same interactive interrupt extension is negotiated.
 - Duplicate or unknown resolved events are suppressed unless the matching request is still pending.
 - Non-streaming requests return a `Task` directly. When `configuration.returnImmediately=true`, the initial response is a working `Task` snapshot and completion continues in the background for later `GetTask` reads.
 - Non-streaming `message:send` responses may include normalized token usage at `Task.metadata.shared.usage` with the same field schema.
@@ -476,7 +476,7 @@ Consumer guidance:
 
 - Use this extension declaration to decide whether the server explicitly supports shared session rebinding.
 - On the request path, write the upstream session identity to `metadata.shared.session.id`.
-- On the response/query path, treat `metadata.shared.session` as runtime metadata and not as a separate capability declaration.
+- On the response/query path, treat `metadata.shared.session` as runtime metadata negotiated by the same extension.
 
 Minimal example:
 
@@ -561,7 +561,7 @@ Stable specification URI:
 
 This section focuses on how clients should interpret runtime metadata. For the stable URI record and public-vs-extended disclosure policy, see [`extension-specifications.md`](./extension-specifications.md).
 
-This extension declares that streaming and final task payloads use canonical shared metadata for block, usage, interrupt, and session hints.
+This extension declares that streaming and final task payloads use canonical shared metadata for block, progress, and usage hints.
 
 Runtime payload:
 
@@ -573,17 +573,12 @@ Shared runtime fields:
   - block-level stream metadata such as `block_type`, `message_id`, `event_id`, and `sequence`
 - `metadata.shared.usage`
   - normalized usage data such as `input_tokens`, `output_tokens`, `total_tokens`, optional `reasoning_tokens`, optional `cache_tokens.read_tokens` / `cache_tokens.write_tokens`, and optional `cost`
-- `metadata.shared.interrupt`
-  - normalized interrupt request or resolution metadata including `request_id`, `type`, `phase`, optional `resolution`, and callback-safe details
-- `metadata.shared.session`
-  - session-level metadata such as the bound upstream session ID and session title when available
 
 Consumer guidance:
 
 - Use the extension declaration to know the server emits canonical shared stream hints.
-- Use runtime metadata to render block timelines, token usage, and interactive interruptions.
+- Use runtime metadata to render block timelines, progress states, and token usage.
 - Do not infer capability support only from seeing one runtime field on one response; rely on Agent Card discovery first when possible.
-- Treat `metadata.shared.interrupt` as observation data. Callback operations are a separate shared capability declared by `urn:opencode-a2a:extension:shared:interactive-interrupt:v1`.
 
 Minimal stream semantics summary:
 
@@ -591,7 +586,7 @@ Minimal stream semantics summary:
 - `text` and `reasoning` blocks use text parts, while `tool_call` uses structured v1 part payloads
 - `message_id` and `event_id` preserve stable timeline identity where possible
 - `sequence` is the per-request canonical stream sequence
-- final task/status metadata may repeat normalized usage and interrupt context even after the streaming phase ends
+- final task/status metadata may repeat normalized usage after the streaming phase ends
 
 ## OpenCode Session Management A2A Extension
 
@@ -1165,7 +1160,7 @@ Notes:
 
 ## Shared Interrupt Callback (A2A Extension)
 
-When stream metadata reports an interrupt request at `metadata.shared.interrupt`, clients can reply through JSON-RPC extension methods:
+When the shared interactive interrupt extension is negotiated, runtime status updates may report an interrupt request at `metadata.shared.interrupt`, and clients can reply through JSON-RPC extension methods:
 
 - `a2a.interrupt.permission.reply`
   - required: `request_id`
@@ -1182,7 +1177,7 @@ When stream metadata reports an interrupt request at `metadata.shared.interrupt`
 
 Notes:
 
-- `request_id` must be a live interrupt request observed from stream metadata (`metadata.shared.interrupt.request_id`) or rediscovered through `opencode.permissions.list` / `opencode.questions.list`.
+- `request_id` must be a live interrupt request observed from negotiated runtime metadata (`metadata.shared.interrupt.request_id`) or rediscovered through `opencode.permissions.list` / `opencode.questions.list`.
 - The server keeps an interrupt binding registry; callbacks with unknown or expired `request_id` are rejected.
 - The cache retention windows are controlled by `A2A_INTERRUPT_REQUEST_TTL_SECONDS` (default: `10800` seconds / `180` minutes) and `A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS` (default: `600` seconds / `10` minutes). After the active TTL elapses, the server keeps a short-lived tombstone so repeated replies continue to return `INTERRUPT_REQUEST_EXPIRED` before eventually aging out to `INTERRUPT_REQUEST_NOT_FOUND`.
 - These values are deployment/runtime settings and are intentionally not part of the shared extension method contract.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -231,6 +231,7 @@ If one deployment works while another fails against the same upstream provider, 
   - tool-call updates use a stable per-tool-part artifact ID when the upstream part is identifiable
 - `artifact.metadata.shared.stream.event_id` preserves the original cross-artifact stream timeline, even when different logical lanes use different artifact IDs.
 - `artifact.metadata.shared.stream.message_id` remains best-effort metadata: when upstream omits `message_id`, the service falls back to a stable request-scoped message identity.
+- `message_id` and `event_id` are advanced correlation fields: they help timeline stitching, deduplication, diagnostics, and advanced UI linking, but generic A2A consumers must not require them.
 - `artifact.metadata.shared.stream.sequence` carries the canonical per-request stream sequence.
 - A final complete text snapshot is emitted only when streaming chunks did not already produce the same final text.
 - That final complete text snapshot uses `append=false` on the text artifact so clients and the task store can treat it as the canonical replace-on-finish version rather than another fragment.
@@ -477,6 +478,7 @@ Consumer guidance:
 - Use this extension declaration to decide whether the server explicitly supports shared session rebinding.
 - On the request path, write the upstream session identity to `metadata.shared.session.id`.
 - On the response/query path, treat `metadata.shared.session` as runtime metadata negotiated by the same extension.
+- Treat `metadata.shared.session.title` as a display hint only; do not build client logic on it.
 
 Minimal example:
 
@@ -578,13 +580,14 @@ Consumer guidance:
 
 - Use the extension declaration to know the server emits canonical shared stream hints.
 - Use runtime metadata to render block timelines, progress states, and token usage.
+- Treat `message_id` and `event_id` as optional advanced correlation fields rather than baseline consumer requirements.
 - Do not infer capability support only from seeing one runtime field on one response; rely on Agent Card discovery first when possible.
 
 Minimal stream semantics summary:
 
 - `text`, `reasoning`, and `tool_call` are emitted as canonical block types
 - `text` and `reasoning` blocks use text parts, while `tool_call` uses structured v1 part payloads
-- `message_id` and `event_id` preserve stable timeline identity where possible
+- `message_id` and `event_id` preserve stable timeline identity where possible and are emitted only as optional advanced correlation hints
 - `sequence` is the per-request canonical stream sequence
 - final task/status metadata may repeat normalized usage after the streaming phase ends
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -478,7 +478,6 @@ Consumer guidance:
 - Use this extension declaration to decide whether the server explicitly supports shared session rebinding.
 - On the request path, write the upstream session identity to `metadata.shared.session.id`.
 - On the response/query path, treat `metadata.shared.session` as runtime metadata negotiated by the same extension.
-- Treat `metadata.shared.session.title` as a display hint only; do not build client logic on it.
 
 Minimal example:
 
@@ -618,7 +617,7 @@ Detailed contract discovery for this provider-private surface is intentionally a
   - `opencode.sessions.messages.list` also returns `result.next_cursor` when older messages are available
   - `contextId` is an A2A context key derived by the adapter (format: `ctx:opencode-session:<session_id>`, not raw OpenCode session ID)
   - OpenCode session identity is exposed explicitly at `metadata.shared.session.id`
-  - session title is available at `metadata.shared.session.title`
+  - session titles remain provider-private summary fields such as `result.item.title` / `result.items[].title`; they are not duplicated under `metadata.shared.session`
 - Session list filters:
   - optional `directory`, `roots`, `start`, `search`, `limit`
   - optional `metadata.opencode.workspace.id`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -230,7 +230,6 @@ If one deployment works while another fails against the same upstream provider, 
   - reasoning chunks use a stable reasoning artifact ID
   - tool-call updates use a stable per-tool-part artifact ID when the upstream part is identifiable
 - `artifact.metadata.shared.stream.event_id` preserves the original cross-artifact stream timeline, even when different logical lanes use different artifact IDs.
-- `artifact.metadata.shared.stream.part_id` is best-effort metadata for the upstream part identity that drove the chunk.
 - `artifact.metadata.shared.stream.message_id` remains best-effort metadata: when upstream omits `message_id`, the service falls back to a stable request-scoped message identity.
 - `artifact.metadata.shared.stream.sequence` carries the canonical per-request stream sequence.
 - A final complete text snapshot is emitted only when streaming chunks did not already produce the same final text.
@@ -571,7 +570,7 @@ Runtime payload:
 Shared runtime fields:
 
 - `metadata.shared.stream`
-  - block-level stream metadata such as `block_type`, `source`, `message_id`, `event_id`, `sequence`, and `role`
+  - block-level stream metadata such as `block_type`, `message_id`, `event_id`, and `sequence`
 - `metadata.shared.usage`
   - normalized usage data such as `input_tokens`, `output_tokens`, `total_tokens`, optional `reasoning_tokens`, optional `cache_tokens.read_tokens` / `cache_tokens.write_tokens`, and optional `cost`
 - `metadata.shared.interrupt`

--- a/src/opencode_a2a/contracts/extensions/__init__.py
+++ b/src/opencode_a2a/contracts/extensions/__init__.py
@@ -51,6 +51,7 @@ from .private_params import (
 from .public_params import (
     build_interrupt_callback_extension_params,
     build_model_selection_extension_params,
+    build_public_interrupt_callback_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_streaming_extension_params,

--- a/src/opencode_a2a/contracts/extensions/__init__.py
+++ b/src/opencode_a2a/contracts/extensions/__init__.py
@@ -52,6 +52,7 @@ from .public_params import (
     build_interrupt_callback_extension_params,
     build_model_selection_extension_params,
     build_public_interrupt_callback_extension_params,
+    build_public_session_binding_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_streaming_extension_params,

--- a/src/opencode_a2a/contracts/extensions/public_params.py
+++ b/src/opencode_a2a/contracts/extensions/public_params.py
@@ -59,8 +59,6 @@ def build_public_streaming_extension_params(
     return {
         "artifact_metadata_field": params["artifact_metadata_field"],
         "progress_metadata_field": params["progress_metadata_field"],
-        "interrupt_metadata_field": params["interrupt_metadata_field"],
-        "session_metadata_field": params["session_metadata_field"],
         "usage_metadata_field": params["usage_metadata_field"],
         "block_types": params["block_types"],
         "stream_fields": select_public_extension_params(
@@ -71,17 +69,24 @@ def build_public_streaming_extension_params(
             params["progress_fields"],
             keys=("type", "status"),
         ),
-        "interrupt_fields": select_public_extension_params(
-            params["interrupt_fields"],
-            keys=("request_id", "type", "phase"),
-        ),
-        "session_fields": select_public_extension_params(
-            params["session_fields"],
-            keys=("id", "title"),
-        ),
         "usage_fields": select_public_extension_params(
             params["usage_fields"],
             keys=("input_tokens", "output_tokens", "total_tokens"),
+        ),
+    }
+
+
+def build_public_interrupt_callback_extension_params(
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "methods": params["methods"],
+        "supported_interrupt_events": params["supported_interrupt_events"],
+        "request_id_field": params["request_id_field"],
+        "interrupt_metadata_field": params["interrupt_metadata_field"],
+        "interrupt_fields": select_public_extension_params(
+            params["interrupt_fields"],
+            keys=("request_id", "type", "phase"),
         ),
     }
 
@@ -92,12 +97,17 @@ def build_session_binding_extension_params(
 ) -> dict[str, Any]:
     return {
         "metadata_field": identifiers.SHARED_SESSION_BINDING_FIELD,
+        "session_metadata_field": identifiers.SHARED_SESSION_METADATA_FIELD,
         "behavior": "prefer_metadata_binding_else_create_session",
         "supported_metadata": [
             "shared.session.id",
             "opencode.directory",
             "opencode.workspace.id",
         ],
+        "session_fields": {
+            "id": f"{identifiers.SHARED_SESSION_METADATA_FIELD}.id",
+            "title": f"{identifiers.SHARED_SESSION_METADATA_FIELD}.title",
+        },
         "provider_private_metadata": ["opencode.directory", "opencode.workspace.id"],
         "profile": runtime_profile.summary_dict(),
         "notes": [
@@ -156,8 +166,6 @@ def build_streaming_extension_params() -> dict[str, Any]:
         "artifact_metadata_field": identifiers.SHARED_STREAM_METADATA_FIELD,
         "status_metadata_field": identifiers.SHARED_STREAM_METADATA_FIELD,
         "progress_metadata_field": identifiers.SHARED_PROGRESS_METADATA_FIELD,
-        "interrupt_metadata_field": identifiers.SHARED_INTERRUPT_METADATA_FIELD,
-        "session_metadata_field": identifiers.SHARED_SESSION_METADATA_FIELD,
         "usage_metadata_field": identifiers.SHARED_USAGE_METADATA_FIELD,
         "block_types": ["text", "reasoning", "tool_call"],
         "block_contracts": {
@@ -198,17 +206,6 @@ def build_streaming_extension_params() -> dict[str, Any]:
             "title": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.title",
             "subtitle": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.subtitle",
         },
-        "interrupt_fields": {
-            "request_id": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.request_id",
-            "type": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.type",
-            "phase": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.phase",
-            "details": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.details",
-            "resolution": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.resolution",
-        },
-        "session_fields": {
-            "id": f"{identifiers.SHARED_SESSION_METADATA_FIELD}.id",
-            "title": f"{identifiers.SHARED_SESSION_METADATA_FIELD}.title",
-        },
         "usage_fields": {
             "input_tokens": f"{identifiers.SHARED_USAGE_METADATA_FIELD}.input_tokens",
             "output_tokens": f"{identifiers.SHARED_USAGE_METADATA_FIELD}.output_tokens",
@@ -246,6 +243,14 @@ def build_interrupt_callback_extension_params(
             "answers": "array of answer arrays (same order as asked questions)"
         },
         "request_id_field": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.request_id",
+        "interrupt_metadata_field": identifiers.SHARED_INTERRUPT_METADATA_FIELD,
+        "interrupt_fields": {
+            "request_id": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.request_id",
+            "type": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.type",
+            "phase": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.phase",
+            "details": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.details",
+            "resolution": f"{identifiers.SHARED_INTERRUPT_METADATA_FIELD}.resolution",
+        },
         "supported_metadata": ["opencode.directory", "opencode.workspace.id"],
         "provider_private_metadata": ["opencode.directory", "opencode.workspace.id"],
         "context_fields": {

--- a/src/opencode_a2a/contracts/extensions/public_params.py
+++ b/src/opencode_a2a/contracts/extensions/public_params.py
@@ -63,7 +63,7 @@ def build_public_streaming_extension_params(
         "block_types": params["block_types"],
         "stream_fields": select_public_extension_params(
             params["stream_fields"],
-            keys=("block_type", "message_id", "sequence"),
+            keys=("block_type", "sequence"),
         ),
         "progress_fields": select_public_extension_params(
             params["progress_fields"],
@@ -88,6 +88,22 @@ def build_public_interrupt_callback_extension_params(
             params["interrupt_fields"],
             keys=("request_id", "type", "phase"),
         ),
+    }
+
+
+def build_public_session_binding_extension_params(
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "metadata_field": params["metadata_field"],
+        "session_metadata_field": params["session_metadata_field"],
+        "behavior": params["behavior"],
+        "supported_metadata": params["supported_metadata"],
+        "session_fields": select_public_extension_params(
+            params["session_fields"],
+            keys=("id",),
+        ),
+        "provider_private_metadata": params["provider_private_metadata"],
     }
 
 

--- a/src/opencode_a2a/contracts/extensions/public_params.py
+++ b/src/opencode_a2a/contracts/extensions/public_params.py
@@ -122,7 +122,6 @@ def build_session_binding_extension_params(
         ],
         "session_fields": {
             "id": f"{identifiers.SHARED_SESSION_METADATA_FIELD}.id",
-            "title": f"{identifiers.SHARED_SESSION_METADATA_FIELD}.title",
         },
         "provider_private_metadata": ["opencode.directory", "opencode.workspace.id"],
         "profile": runtime_profile.summary_dict(),
@@ -216,11 +215,7 @@ def build_streaming_extension_params() -> dict[str, Any]:
         },
         "progress_fields": {
             "type": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.type",
-            "part_id": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.part_id",
-            "reason": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.reason",
             "status": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.status",
-            "title": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.title",
-            "subtitle": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.subtitle",
         },
         "usage_fields": {
             "input_tokens": f"{identifiers.SHARED_USAGE_METADATA_FIELD}.input_tokens",

--- a/src/opencode_a2a/contracts/extensions/public_params.py
+++ b/src/opencode_a2a/contracts/extensions/public_params.py
@@ -186,11 +186,9 @@ def build_streaming_extension_params() -> dict[str, Any]:
         },
         "stream_fields": {
             "block_type": f"{identifiers.SHARED_STREAM_METADATA_FIELD}.block_type",
-            "source": f"{identifiers.SHARED_STREAM_METADATA_FIELD}.source",
             "message_id": f"{identifiers.SHARED_STREAM_METADATA_FIELD}.message_id",
             "event_id": f"{identifiers.SHARED_STREAM_METADATA_FIELD}.event_id",
             "sequence": f"{identifiers.SHARED_STREAM_METADATA_FIELD}.sequence",
-            "role": f"{identifiers.SHARED_STREAM_METADATA_FIELD}.role",
         },
         "progress_fields": {
             "type": f"{identifiers.SHARED_PROGRESS_METADATA_FIELD}.type",

--- a/src/opencode_a2a/execution/coordinator.py
+++ b/src/opencode_a2a/execution/coordinator.py
@@ -61,6 +61,7 @@ class PreparedExecution:
     allow_structured_output: bool
     emit_session_metadata: bool
     emit_streaming_metadata: bool
+    emit_interrupt_metadata: bool
 
 
 def build_session_binding_context_id(
@@ -294,6 +295,7 @@ class ExecutionCoordinator:
                     allow_structured_output=self._prepared.allow_structured_output,
                     emit_session_metadata=self._prepared.emit_session_metadata,
                     emit_streaming_metadata=self._prepared.emit_streaming_metadata,
+                    emit_interrupt_metadata=self._prepared.emit_interrupt_metadata,
                 )
             )
 
@@ -427,6 +429,7 @@ class ExecutionCoordinator:
                     },
                     include_session_metadata=self._prepared.emit_session_metadata,
                     include_streaming_metadata=self._prepared.emit_streaming_metadata,
+                    include_interrupt_metadata=self._prepared.emit_interrupt_metadata,
                 ),
             )
         )
@@ -469,6 +472,7 @@ class ExecutionCoordinator:
                 usage=resolved_token_usage,
                 include_session_metadata=self._prepared.emit_session_metadata,
                 include_streaming_metadata=self._prepared.emit_streaming_metadata,
+                include_interrupt_metadata=self._prepared.emit_interrupt_metadata,
             ),
         )
         task.status.message.CopyFrom(assistant_message)

--- a/src/opencode_a2a/execution/coordinator.py
+++ b/src/opencode_a2a/execution/coordinator.py
@@ -406,8 +406,6 @@ class ExecutionCoordinator:
                 last_chunk=True,
                 artifact_metadata=_build_stream_artifact_metadata(
                     block_type=BlockType.TEXT,
-                    shared_source="final_snapshot",
-                    part_id=None,
                     message_id=resolved_message_id,
                     event_id=self._stream_state.build_event_id(sequence),
                     sequence=sequence,
@@ -426,7 +424,6 @@ class ExecutionCoordinator:
                     stream={
                         "message_id": resolved_message_id,
                         "event_id": f"{self._stream_state.event_id_namespace}:status",
-                        "source": "status",
                     },
                     include_session_metadata=self._prepared.emit_session_metadata,
                     include_streaming_metadata=self._prepared.emit_streaming_metadata,

--- a/src/opencode_a2a/execution/executor.py
+++ b/src/opencode_a2a/execution/executor.py
@@ -26,6 +26,7 @@ from a2a.types import (
 )
 
 from ..contracts.extensions import (
+    INTERRUPT_CALLBACK_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     STREAMING_EXTENSION_URI,
 )
@@ -260,14 +261,9 @@ class OpencodeAgentExecutor(AgentExecutor):
             accepted_output_modes,
             _APPLICATION_JSON_MEDIA_TYPE,
         )
-        emit_session_metadata = bool(
-            {
-                SESSION_BINDING_EXTENSION_URI,
-                STREAMING_EXTENSION_URI,
-            }
-            & set(requested_extensions)
-        )
+        emit_session_metadata = SESSION_BINDING_EXTENSION_URI in requested_extensions
         emit_streaming_metadata = STREAMING_EXTENSION_URI in requested_extensions
+        emit_interrupt_metadata = INTERRUPT_CALLBACK_EXTENSION_URI in requested_extensions
 
         logger.debug(
             (
@@ -301,6 +297,7 @@ class OpencodeAgentExecutor(AgentExecutor):
             allow_structured_output=allow_structured_output,
             emit_session_metadata=emit_session_metadata,
             emit_streaming_metadata=emit_streaming_metadata,
+            emit_interrupt_metadata=emit_interrupt_metadata,
         )
         coordinator = ExecutionCoordinator(
             self,
@@ -518,6 +515,7 @@ class OpencodeAgentExecutor(AgentExecutor):
         allow_structured_output: bool = True,
         emit_session_metadata: bool = True,
         emit_streaming_metadata: bool = True,
+        emit_interrupt_metadata: bool = True,
     ) -> None:
         await self._stream_runtime.consume(
             session_id=session_id,
@@ -534,4 +532,5 @@ class OpencodeAgentExecutor(AgentExecutor):
             allow_structured_output=allow_structured_output,
             emit_session_metadata=emit_session_metadata,
             emit_streaming_metadata=emit_streaming_metadata,
+            emit_interrupt_metadata=emit_interrupt_metadata,
         )

--- a/src/opencode_a2a/execution/stream_events.py
+++ b/src/opencode_a2a/execution/stream_events.py
@@ -299,23 +299,11 @@ def _extract_progress_metadata(
     if part_type not in {"step-start", "step-finish", "snapshot"}:
         return None
     progress: dict[str, Any] = {"type": part_type}
-    part_id = _extract_stream_part_id(part, props)
-    if part_id:
-        progress["part_id"] = part_id
-    reason = _extract_first_nonempty_string(part, ("reason",))
-    if reason:
-        progress["reason"] = reason
     state = part.get("state")
     if isinstance(state, Mapping):
         status = _extract_first_nonempty_string(state, ("status",))
         if status:
             progress["status"] = status
-        title = _extract_first_nonempty_string(state, ("title",))
-        if title:
-            progress["title"] = title
-        subtitle = _extract_first_nonempty_string(state, ("subtitle",))
-        if subtitle:
-            progress["subtitle"] = subtitle
     return progress
 
 

--- a/src/opencode_a2a/execution/stream_runtime.py
+++ b/src/opencode_a2a/execution/stream_runtime.py
@@ -79,6 +79,7 @@ class StreamRuntime:
         allow_structured_output: bool = True,
         emit_session_metadata: bool = True,
         emit_streaming_metadata: bool = True,
+        emit_interrupt_metadata: bool = True,
     ) -> None:
         part_states: dict[str, _StreamPartState] = {}
         pending_deltas: defaultdict[str, list[_PendingDelta]] = defaultdict(list)
@@ -170,6 +171,7 @@ class StreamRuntime:
                         interrupt=interrupt_metadata,
                         include_session_metadata=emit_session_metadata,
                         include_streaming_metadata=emit_streaming_metadata,
+                        include_interrupt_metadata=emit_interrupt_metadata,
                     ),
                 )
             )
@@ -467,6 +469,9 @@ class StreamRuntime:
                                                     ),
                                                     include_streaming_metadata=(
                                                         emit_streaming_metadata
+                                                    ),
+                                                    include_interrupt_metadata=(
+                                                        emit_interrupt_metadata
                                                     ),
                                                 ),
                                             )

--- a/src/opencode_a2a/execution/stream_runtime.py
+++ b/src/opencode_a2a/execution/stream_runtime.py
@@ -116,10 +116,7 @@ class StreamRuntime:
                     last_chunk=False,
                     artifact_metadata=_build_stream_artifact_metadata(
                         block_type=chunk.block_type,
-                        shared_source=chunk.shared_source,
-                        part_id=chunk.part_id,
                         message_id=resolved_message_id,
-                        role=chunk.role,
                         event_id=stream_state.build_event_id(sequence),
                         sequence=sequence,
                         include_shared_stream_metadata=emit_streaming_metadata,
@@ -168,7 +165,6 @@ class StreamRuntime:
                         stream={
                             "message_id": stream_state.resolve_message_id(None),
                             "event_id": stream_state.build_event_id(sequence),
-                            "source": "interrupt",
                             "sequence": sequence,
                         },
                         interrupt=interrupt_metadata,
@@ -463,7 +459,6 @@ class StreamRuntime:
                                                         "event_id": stream_state.build_event_id(
                                                             sequence
                                                         ),
-                                                        "source": "progress",
                                                         "sequence": sequence,
                                                     },
                                                     progress=dict(progress),

--- a/src/opencode_a2a/execution/stream_state.py
+++ b/src/opencode_a2a/execution/stream_state.py
@@ -241,10 +241,7 @@ class _TTLCache:
 def _build_stream_artifact_metadata(
     *,
     block_type: BlockType,
-    shared_source: str,
-    part_id: str | None = None,
     message_id: str | None = None,
-    role: str | None = None,
     event_id: str | None = None,
     sequence: int | None = None,
     include_shared_stream_metadata: bool = True,
@@ -253,14 +250,9 @@ def _build_stream_artifact_metadata(
         return None
     stream_meta: dict[str, Any] = {
         "block_type": block_type.value,
-        "source": shared_source,
     }
-    if part_id:
-        stream_meta["part_id"] = part_id
     if message_id:
         stream_meta["message_id"] = message_id
-    if role:
-        stream_meta["role"] = role
     if event_id:
         stream_meta["event_id"] = event_id
     if sequence is not None:
@@ -276,7 +268,6 @@ def _build_output_metadata(
     stream: Mapping[str, Any] | None = None,
     progress: Mapping[str, Any] | None = None,
     interrupt: Mapping[str, Any] | None = None,
-    opencode_private: Mapping[str, Any] | None = None,
     include_session_metadata: bool = True,
     include_streaming_metadata: bool = True,
 ) -> dict[str, Any] | None:
@@ -298,6 +289,4 @@ def _build_output_metadata(
         shared_meta["interrupt"] = dict(interrupt)
     if shared_meta:
         metadata["shared"] = shared_meta
-    if opencode_private:
-        metadata["opencode"] = dict(opencode_private)
     return metadata or None

--- a/src/opencode_a2a/execution/stream_state.py
+++ b/src/opencode_a2a/execution/stream_state.py
@@ -270,6 +270,7 @@ def _build_output_metadata(
     interrupt: Mapping[str, Any] | None = None,
     include_session_metadata: bool = True,
     include_streaming_metadata: bool = True,
+    include_interrupt_metadata: bool = True,
 ) -> dict[str, Any] | None:
     metadata: dict[str, Any] = {}
     shared_meta: dict[str, Any] = {}
@@ -285,7 +286,7 @@ def _build_output_metadata(
         shared_meta["stream"] = dict(stream)
     if include_streaming_metadata and progress is not None:
         shared_meta["progress"] = dict(progress)
-    if include_streaming_metadata and interrupt is not None:
+    if include_interrupt_metadata and interrupt is not None:
         shared_meta["interrupt"] = dict(interrupt)
     if shared_meta:
         metadata["shared"] = shared_meta

--- a/src/opencode_a2a/execution/stream_state.py
+++ b/src/opencode_a2a/execution/stream_state.py
@@ -263,7 +263,6 @@ def _build_stream_artifact_metadata(
 def _build_output_metadata(
     *,
     session_id: str | None = None,
-    session_title: str | None = None,
     usage: Mapping[str, Any] | None = None,
     stream: Mapping[str, Any] | None = None,
     progress: Mapping[str, Any] | None = None,
@@ -276,10 +275,7 @@ def _build_output_metadata(
     shared_meta: dict[str, Any] = {}
 
     if include_session_metadata and session_id:
-        session_meta: dict[str, Any] = {"id": session_id}
-        if session_title is not None:
-            session_meta["title"] = session_title
-        shared_meta["session"] = session_meta
+        shared_meta["session"] = {"id": session_id}
     if include_streaming_metadata and usage is not None:
         shared_meta["usage"] = dict(usage)
     if include_streaming_metadata and stream is not None:

--- a/src/opencode_a2a/extension_negotiation.py
+++ b/src/opencode_a2a/extension_negotiation.py
@@ -26,7 +26,8 @@ from .contracts.extensions import (
     WORKSPACE_CONTROL_METHODS,
 )
 
-_STREAMING_SHARED_METADATA_KEYS = frozenset({"stream", "progress", "interrupt", "usage"})
+_STREAMING_SHARED_METADATA_KEYS = frozenset({"stream", "progress", "usage"})
+_INTERRUPT_SHARED_METADATA_KEYS = frozenset({"interrupt"})
 
 JSONRPC_EXTENSION_URI_BY_METHOD: dict[str, str] = {
     **{method: SESSION_MANAGEMENT_EXTENSION_URI for method in SESSION_METHODS.values()},
@@ -98,15 +99,15 @@ def _set_filtered_metadata(
     shared_metadata = filtered_metadata.get("shared")
     if isinstance(shared_metadata, Mapping):
         filtered_shared = dict(shared_metadata)
-        if (
-            SESSION_BINDING_EXTENSION_URI not in requested_extensions
-            and STREAMING_EXTENSION_URI not in requested_extensions
-        ):
+        if SESSION_BINDING_EXTENSION_URI not in requested_extensions:
             filtered_shared.pop("session", None)
         if MODEL_SELECTION_EXTENSION_URI not in requested_extensions:
             filtered_shared.pop("model", None)
         if STREAMING_EXTENSION_URI not in requested_extensions:
             for key in _STREAMING_SHARED_METADATA_KEYS:
+                filtered_shared.pop(key, None)
+        if INTERRUPT_CALLBACK_EXTENSION_URI not in requested_extensions:
+            for key in _INTERRUPT_SHARED_METADATA_KEYS:
                 filtered_shared.pop(key, None)
         if filtered_shared:
             filtered_metadata["shared"] = filtered_shared

--- a/src/opencode_a2a/jsonrpc/methods.py
+++ b/src/opencode_a2a/jsonrpc/methods.py
@@ -337,12 +337,11 @@ def _as_a2a_session_task(session: Any) -> dict[str, Any] | None:
     if session_id is None:
         return None
     context_id = _as_a2a_session_context_id(session_id)
-    title = _extract_session_title(session)
     task = Task(
         id=session_id,
         context_id=context_id,
         status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
-        metadata={"shared": {"session": {"id": session_id, "title": title}}},
+        metadata={"shared": {"session": {"id": session_id}}},
     )
     return cast(dict[str, Any], MessageToDict(task))
 

--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -37,6 +37,7 @@ from ..contracts.extensions import (
     build_model_selection_extension_params,
     build_provider_discovery_extension_params,
     build_public_interrupt_callback_extension_params,
+    build_public_session_binding_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_session_management_extension_params,
@@ -222,17 +223,7 @@ def _build_agent_extensions(
             params=(
                 session_binding_extension_params
                 if include_detailed_contracts
-                else select_public_extension_params(
-                    session_binding_extension_params,
-                    keys=(
-                        "metadata_field",
-                        "session_metadata_field",
-                        "behavior",
-                        "supported_metadata",
-                        "session_fields",
-                        "provider_private_metadata",
-                    ),
-                )
+                else build_public_session_binding_extension_params(session_binding_extension_params)
             ),
         ),
         AgentExtension(

--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -36,6 +36,7 @@ from ..contracts.extensions import (
     build_interrupt_recovery_extension_params,
     build_model_selection_extension_params,
     build_provider_discovery_extension_params,
+    build_public_interrupt_callback_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_session_management_extension_params,
@@ -225,8 +226,10 @@ def _build_agent_extensions(
                     session_binding_extension_params,
                     keys=(
                         "metadata_field",
+                        "session_metadata_field",
                         "behavior",
                         "supported_metadata",
+                        "session_fields",
                         "provider_private_metadata",
                     ),
                 )
@@ -261,7 +264,7 @@ def _build_agent_extensions(
             required=False,
             description=(
                 "Shared streaming metadata contract for canonical block hints, "
-                "timeline identity, usage, and interactive interrupt metadata."
+                "progress hints, and usage metadata."
             ),
             params=(
                 streaming_extension_params
@@ -279,9 +282,8 @@ def _build_agent_extensions(
             params=(
                 interrupt_callback_extension_params
                 if include_detailed_contracts
-                else select_public_extension_params(
-                    interrupt_callback_extension_params,
-                    keys=("methods", "supported_interrupt_events", "request_id_field"),
+                else build_public_interrupt_callback_extension_params(
+                    interrupt_callback_extension_params
                 )
             ),
         ),

--- a/src/opencode_a2a/server/openapi.py
+++ b/src/opencode_a2a/server/openapi.py
@@ -9,6 +9,7 @@ from ..contracts.extensions import (
     INTERRUPT_CALLBACK_METHODS,
     build_interrupt_callback_extension_params,
     build_model_selection_extension_params,
+    build_public_interrupt_callback_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_streaming_extension_params,
@@ -274,8 +275,10 @@ def _patch_jsonrpc_openapi_contract(
                             session_binding,
                             keys=(
                                 "metadata_field",
+                                "session_metadata_field",
                                 "behavior",
                                 "supported_metadata",
+                                "session_fields",
                                 "provider_private_metadata",
                             ),
                         ),
@@ -292,8 +295,14 @@ def _patch_jsonrpc_openapi_contract(
                         ),
                         "streaming": build_public_streaming_extension_params(streaming),
                         "interrupt_callback": select_public_extension_params(
-                            interrupt_callback,
-                            keys=("methods", "supported_interrupt_events", "request_id_field"),
+                            build_public_interrupt_callback_extension_params(interrupt_callback),
+                            keys=(
+                                "methods",
+                                "supported_interrupt_events",
+                                "request_id_field",
+                                "interrupt_metadata_field",
+                                "interrupt_fields",
+                            ),
                         ),
                     }
 

--- a/src/opencode_a2a/server/openapi.py
+++ b/src/opencode_a2a/server/openapi.py
@@ -10,6 +10,7 @@ from ..contracts.extensions import (
     build_interrupt_callback_extension_params,
     build_model_selection_extension_params,
     build_public_interrupt_callback_extension_params,
+    build_public_session_binding_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_streaming_extension_params,
@@ -271,16 +272,8 @@ def _patch_jsonrpc_openapi_contract(
                     post["summary"] = "Handle A2A JSON-RPC Requests"
                     post["description"] = _build_jsonrpc_extension_openapi_description()
                     post["x-a2a-extension-contracts"] = {
-                        "session_binding": select_public_extension_params(
-                            session_binding,
-                            keys=(
-                                "metadata_field",
-                                "session_metadata_field",
-                                "behavior",
-                                "supported_metadata",
-                                "session_fields",
-                                "provider_private_metadata",
-                            ),
+                        "session_binding": build_public_session_binding_extension_params(
+                            session_binding
                         ),
                         "model_selection": select_public_extension_params(
                             model_selection,

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -26,6 +26,7 @@ from opencode_a2a.contracts.extensions import (
     build_interrupt_recovery_extension_params,
     build_model_selection_extension_params,
     build_provider_discovery_extension_params,
+    build_public_interrupt_callback_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_session_management_extension_params,
@@ -180,8 +181,10 @@ def test_openapi_jsonrpc_contract_extension_matches_public_disclosure_policy() -
         build_session_binding_extension_params(runtime_profile=runtime_profile),
         keys=(
             "metadata_field",
+            "session_metadata_field",
             "behavior",
             "supported_metadata",
+            "session_fields",
             "provider_private_metadata",
         ),
     )
@@ -197,9 +200,8 @@ def test_openapi_jsonrpc_contract_extension_matches_public_disclosure_policy() -
         ),
     )
     expected_streaming = build_public_streaming_extension_params(build_streaming_extension_params())
-    expected_interrupt_callback = select_public_extension_params(
+    expected_interrupt_callback = build_public_interrupt_callback_extension_params(
         build_interrupt_callback_extension_params(runtime_profile=runtime_profile),
-        keys=("methods", "supported_interrupt_events", "request_id_field"),
     )
 
     assert session_binding == expected_session_binding, (

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -27,6 +27,7 @@ from opencode_a2a.contracts.extensions import (
     build_model_selection_extension_params,
     build_provider_discovery_extension_params,
     build_public_interrupt_callback_extension_params,
+    build_public_session_binding_extension_params,
     build_public_streaming_extension_params,
     build_session_binding_extension_params,
     build_session_management_extension_params,
@@ -177,16 +178,8 @@ def test_openapi_jsonrpc_contract_extension_matches_public_disclosure_policy() -
     }
     settings = make_settings(test_bearer_token="test-token")
     runtime_profile = build_runtime_profile(settings)
-    expected_session_binding = select_public_extension_params(
+    expected_session_binding = build_public_session_binding_extension_params(
         build_session_binding_extension_params(runtime_profile=runtime_profile),
-        keys=(
-            "metadata_field",
-            "session_metadata_field",
-            "behavior",
-            "supported_metadata",
-            "session_fields",
-            "provider_private_metadata",
-        ),
     )
     expected_model_selection = select_public_extension_params(
         build_model_selection_extension_params(runtime_profile=runtime_profile),

--- a/tests/execution/test_agent_helpers.py
+++ b/tests/execution/test_agent_helpers.py
@@ -210,7 +210,6 @@ def test_build_output_metadata_and_number_coercion_helpers() -> None:
         stream={"block_type": "text"},
         progress={"type": "step-finish"},
         interrupt={"phase": "asked"},
-        opencode_private={"directory": "/tmp/workspace"},
     )
 
     assert metadata == {
@@ -220,8 +219,7 @@ def test_build_output_metadata_and_number_coercion_helpers() -> None:
             "stream": {"block_type": "text"},
             "progress": {"type": "step-finish"},
             "interrupt": {"phase": "asked"},
-        },
-        "opencode": {"directory": "/tmp/workspace"},
+        }
     }
     assert _build_output_metadata() is None
     assert _coerce_number(True) is None

--- a/tests/execution/test_agent_helpers.py
+++ b/tests/execution/test_agent_helpers.py
@@ -205,7 +205,6 @@ def test_ttl_cache_handles_disabled_refresh_and_pop() -> None:
 def test_build_output_metadata_and_number_coercion_helpers() -> None:
     metadata = _build_output_metadata(
         session_id="ses-1",
-        session_title=None,
         usage={"total_tokens": 3},
         stream={"block_type": "text"},
         progress={"type": "step-finish"},
@@ -322,11 +321,7 @@ def test_upstream_error_and_progress_extractors_cover_edge_cases() -> None:
     )
     assert progress == {
         "type": "step-finish",
-        "part_id": "part-1",
-        "reason": "done",
         "status": "ok",
-        "title": "Write tests",
-        "subtitle": "finished",
     }
     assert (
         _build_progress_identity(

--- a/tests/execution/test_streaming_output_contract_blocks.py
+++ b/tests/execution/test_streaming_output_contract_blocks.py
@@ -233,12 +233,10 @@ async def test_streaming_never_resets_single_artifact_after_first_chunk() -> Non
     updates = _artifact_updates(queue)
     assert len(updates) >= 2
     assert updates[0].append is False
-    stream_updates = [ev for ev in updates if _artifact_stream_meta(ev)["source"] == "stream"]
+    stream_updates = [ev for ev in updates if ev.last_chunk is False]
     assert stream_updates[0].append is False
     assert all(ev.append is True for ev in stream_updates[1:])
-    final_snapshots = [
-        ev for ev in updates if _artifact_stream_meta(ev)["source"] == "final_snapshot"
-    ]
+    final_snapshots = [ev for ev in updates if ev.last_chunk is True]
     assert final_snapshots
     assert all(ev.append is False for ev in final_snapshots)
 
@@ -325,7 +323,7 @@ async def test_streaming_supports_message_part_delta_events() -> None:
     assert reasoning_updates
     merged = "".join(_part_text(ev) for ev in reasoning_updates)
     assert merged == "first second"
-    assert {_artifact_stream_meta(ev)["source"] for ev in reasoning_updates} == {"stream"}
+    assert all("source" not in _artifact_stream_meta(ev) for ev in reasoning_updates)
 
 
 @pytest.mark.asyncio
@@ -364,4 +362,4 @@ async def test_streaming_buffers_delta_until_part_updated_arrives() -> None:
     assert reasoning_updates
     merged = "".join(_part_text(ev) for ev in reasoning_updates)
     assert merged == "first second"
-    assert {_artifact_stream_meta(ev)["source"] for ev in reasoning_updates} == {"stream"}
+    assert all("source" not in _artifact_stream_meta(ev) for ev in reasoning_updates)

--- a/tests/execution/test_streaming_output_contract_core.py
+++ b/tests/execution/test_streaming_output_contract_core.py
@@ -801,18 +801,11 @@ async def test_streaming_emits_progress_metadata_for_step_events() -> None:
     assert len(progress_statuses) == 2
 
     first = _progress_meta(progress_statuses[0])
-    assert first["type"] == "step-start"
-    assert first["part_id"] == "prt-step-start-1"
-    assert first["reason"] == "run"
-    assert first["status"] == "running"
-    assert first["title"] == "Planning"
-    assert first["subtitle"] == "Inspecting repository"
+    assert first == {"type": "step-start", "status": "running"}
     assert "source" not in _status_shared_meta(progress_statuses[0])["stream"]
 
     second = _progress_meta(progress_statuses[1])
-    assert second["type"] == "step-finish"
-    assert second["part_id"] == "prt-step-finish-1"
-    assert second["reason"] == "stop"
+    assert second == {"type": "step-finish"}
 
 
 @pytest.mark.asyncio
@@ -855,7 +848,7 @@ async def test_streaming_emits_progress_metadata_for_snapshot_without_text_artif
     ]
     assert len(progress_statuses) == 1
     progress = _progress_meta(progress_statuses[0])
-    assert progress == {"type": "snapshot", "part_id": "prt-snapshot-1"}
+    assert progress == {"type": "snapshot"}
     text_updates = [
         event
         for event in _artifact_updates(queue)

--- a/tests/execution/test_streaming_output_contract_core.py
+++ b/tests/execution/test_streaming_output_contract_core.py
@@ -355,7 +355,7 @@ async def test_streaming_does_not_send_duplicate_final_snapshot_when_chunks_exis
     ]
     assert len(final_updates) == 1
     assert _part_text(final_updates[0]) == "stable final answer"
-    assert _artifact_stream_meta(final_updates[0])["source"] == "stream"
+    assert "source" not in _artifact_stream_meta(final_updates[0])
 
 
 @pytest.mark.asyncio
@@ -382,7 +382,7 @@ async def test_streaming_emits_final_snapshot_only_when_stream_has_no_final_answ
     assert len(final_updates) == 1
     final_event = final_updates[0]
     assert _part_text(final_event) == "final answer from send_message"
-    assert _artifact_stream_meta(final_event)["source"] == "final_snapshot"
+    assert "source" not in _artifact_stream_meta(final_event)
     assert final_event.append is False
     assert final_event.last_chunk is True
 
@@ -425,7 +425,7 @@ async def test_streaming_final_snapshot_does_not_repeat_reasoning_content() -> N
     assert len(text_updates) == 1
     assert _part_text(text_updates[0]) == "final answer from send_message"
     assert "draft plan" not in _part_text(text_updates[0])
-    assert _artifact_stream_meta(text_updates[0])["source"] == "final_snapshot"
+    assert "source" not in _artifact_stream_meta(text_updates[0])
 
 
 @pytest.mark.asyncio
@@ -485,7 +485,7 @@ async def test_streaming_emits_events_without_message_id_using_stable_fallback()
     assert len(updates) == 1
     update = updates[0]
     assert _part_text(update) == "final answer from send_message"
-    assert _artifact_stream_meta(update)["source"] == "stream"
+    assert "source" not in _artifact_stream_meta(update)
     assert _artifact_stream_meta(update)["block_type"] == "text"
     assert _artifact_stream_meta(update)["message_id"] == "task-6:ctx-6:assistant"
     assert _artifact_stream_meta(update)["event_id"] == "task-6:ctx-6:task-6:stream:1"
@@ -532,7 +532,7 @@ async def test_streaming_emits_snapshot_when_message_id_missing_and_stream_is_pa
     assert _part_text(first) == "partial "
     assert first.append is False
     assert first.last_chunk is False
-    assert _artifact_stream_meta(first)["source"] == "stream"
+    assert "source" not in _artifact_stream_meta(first)
     assert _artifact_stream_meta(first)["message_id"] == "task-6b:ctx-6b:assistant"
     assert _artifact_stream_meta(first)["event_id"] == "task-6b:ctx-6b:task-6b:stream:1"
     assert _artifact_stream_meta(first)["sequence"] == 1
@@ -540,7 +540,7 @@ async def test_streaming_emits_snapshot_when_message_id_missing_and_stream_is_pa
     assert _part_text(second) == "partial final answer"
     assert second.append is False
     assert second.last_chunk is True
-    assert _artifact_stream_meta(second)["source"] == "final_snapshot"
+    assert "source" not in _artifact_stream_meta(second)
     assert _artifact_stream_meta(second)["message_id"] == "task-6b:ctx-6b:assistant"
     assert _artifact_stream_meta(second)["event_id"] == "task-6b:ctx-6b:task-6b:stream:2"
     assert _artifact_stream_meta(second)["sequence"] == 2
@@ -807,7 +807,7 @@ async def test_streaming_emits_progress_metadata_for_step_events() -> None:
     assert first["status"] == "running"
     assert first["title"] == "Planning"
     assert first["subtitle"] == "Inspecting repository"
-    assert _status_shared_meta(progress_statuses[0])["stream"]["source"] == "progress"
+    assert "source" not in _status_shared_meta(progress_statuses[0])["stream"]
 
     second = _progress_meta(progress_statuses[1])
     assert second["type"] == "step-finish"

--- a/tests/execution/test_streaming_output_contract_interrupts.py
+++ b/tests/execution/test_streaming_output_contract_interrupts.py
@@ -1,12 +1,15 @@
 import pytest
+from a2a.server.context import ServerCallContext
 from a2a.types import (
     TaskState,
     TaskStatusUpdateEvent,
 )
 
+from opencode_a2a.contracts.extensions import INTERRUPT_CALLBACK_EXTENSION_URI
 from opencode_a2a.execution.executor import (
     OpencodeAgentExecutor,
 )
+from opencode_a2a.server.context_helpers import normalize_server_call_context
 from opencode_a2a.task_states import TERMINAL_TASK_STATES
 from tests.support.helpers import (
     DummyEventQueue,
@@ -34,6 +37,12 @@ def _interrupt_type(event: TaskStatusUpdateEvent) -> str | None:
     return _interrupt_meta(event).get("type")
 
 
+def _interrupt_enabled_call_context() -> ServerCallContext:
+    return normalize_server_call_context(
+        ServerCallContext(requested_extensions={INTERRUPT_CALLBACK_EXTENSION_URI})
+    )
+
+
 @pytest.mark.asyncio
 async def test_streaming_emits_interrupt_status_for_permission_asked_event() -> None:
     client = DummyStreamingClient(
@@ -49,7 +58,12 @@ async def test_streaming_emits_interrupt_status_for_permission_asked_event() -> 
     queue = DummyEventQueue()
 
     await executor.execute(
-        make_request_context(task_id="task-perm", context_id="ctx-perm", text="hello"),
+        make_request_context(
+            task_id="task-perm",
+            context_id="ctx-perm",
+            text="hello",
+            call_context=_interrupt_enabled_call_context(),
+        ),
         queue,
     )
 
@@ -89,7 +103,12 @@ async def test_streaming_emits_interrupt_status_for_question_asked_event() -> No
     queue = DummyEventQueue()
 
     await executor.execute(
-        make_request_context(task_id="task-question", context_id="ctx-question", text="hello"),
+        make_request_context(
+            task_id="task-question",
+            context_id="ctx-question",
+            text="hello",
+            call_context=_interrupt_enabled_call_context(),
+        ),
         queue,
     )
 
@@ -174,6 +193,7 @@ async def test_streaming_normalizes_question_interrupt_details() -> None:
             task_id="task-question-normalized",
             context_id="ctx-question-normalized",
             text="hello",
+            call_context=_interrupt_enabled_call_context(),
         ),
         queue,
     )
@@ -229,6 +249,7 @@ async def test_streaming_resolved_interrupt_only_clears_internal_pending_state()
             task_id="task-interrupt-resolved",
             context_id="ctx-interrupt-resolved",
             text="hello",
+            call_context=_interrupt_enabled_call_context(),
         ),
         queue,
     )
@@ -288,6 +309,7 @@ async def test_streaming_duplicate_interrupt_resolved_event_is_not_emitted_twice
             task_id="task-interrupt-resolved-dedupe",
             context_id="ctx-interrupt-resolved-dedupe",
             text="hello",
+            call_context=_interrupt_enabled_call_context(),
         ),
         queue,
     )

--- a/tests/jsonrpc/test_opencode_session_extension_lifecycle.py
+++ b/tests/jsonrpc/test_opencode_session_extension_lifecycle.py
@@ -84,7 +84,7 @@ async def test_session_lifecycle_status_get_and_children_success(monkeypatch):
     assert get_response.status_code == 200
     get_item = get_response.json()["result"]["item"]
     assert get_item["id"] == "s-1"
-    assert _session_meta(get_item)["title"] == "Session s-1"
+    assert _session_meta(get_item) == {"id": "s-1"}
 
     assert children_response.status_code == 200
     children_items = children_response.json()["result"]["items"]

--- a/tests/jsonrpc/test_opencode_session_extension_queries.py
+++ b/tests/jsonrpc/test_opencode_session_extension_queries.py
@@ -99,7 +99,7 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
         assert session["contextId"] == "ctx:opencode-session:s-1"
         assert session["contextId"] != _session_meta(session)["id"]
         assert _session_meta(session)["id"] == "s-1"
-        assert _session_meta(session)["title"] == "Session s-1"
+        assert _session_meta(session) == {"id": "s-1"}
         assert "raw" not in session["metadata"]["shared"]
         assert dummy.last_sessions_params is not None
         assert dummy.last_sessions_params.get("limit") == 10
@@ -792,7 +792,7 @@ async def test_session_query_extension_session_title_is_extracted_or_placeholder
         payload = resp.json()
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
-        assert _session_meta(session)["title"] == "My Session"
+        assert _session_meta(session) == {"id": "s-1"}
 
 
 @pytest.mark.asyncio
@@ -820,7 +820,7 @@ async def test_session_query_extension_keeps_session_with_empty_title(monkeypatc
         payload = resp.json()
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
-        assert _session_meta(session)["title"] == ""
+        assert _session_meta(session) == {"id": "s-1"}
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -233,7 +233,6 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     ]
     assert binding.params["session_fields"] == {
         "id": "metadata.shared.session.id",
-        "title": "metadata.shared.session.title",
     }
     assert profile["profile_id"] == "opencode-a2a-single-tenant-coding-v1"
     assert profile["deployment"] == {

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -106,12 +106,17 @@ def test_public_agent_card_is_slimmed_but_keeps_core_shared_contract_hints() -> 
 
     assert ext_by_uri[SESSION_BINDING_EXTENSION_URI].params == {
         "metadata_field": "metadata.shared.session.id",
+        "session_metadata_field": "metadata.shared.session",
         "behavior": "prefer_metadata_binding_else_create_session",
         "supported_metadata": [
             "shared.session.id",
             "opencode.directory",
             "opencode.workspace.id",
         ],
+        "session_fields": {
+            "id": "metadata.shared.session.id",
+            "title": "metadata.shared.session.title",
+        },
         "provider_private_metadata": [
             "opencode.directory",
             "opencode.workspace.id",
@@ -134,8 +139,6 @@ def test_public_agent_card_is_slimmed_but_keeps_core_shared_contract_hints() -> 
     assert ext_by_uri[STREAMING_EXTENSION_URI].params == {
         "artifact_metadata_field": "metadata.shared.stream",
         "progress_metadata_field": "metadata.shared.progress",
-        "interrupt_metadata_field": "metadata.shared.interrupt",
-        "session_metadata_field": "metadata.shared.session",
         "usage_metadata_field": "metadata.shared.usage",
         "block_types": ["text", "reasoning", "tool_call"],
         "stream_fields": {
@@ -146,15 +149,6 @@ def test_public_agent_card_is_slimmed_but_keeps_core_shared_contract_hints() -> 
         "progress_fields": {
             "type": "metadata.shared.progress.type",
             "status": "metadata.shared.progress.status",
-        },
-        "interrupt_fields": {
-            "request_id": "metadata.shared.interrupt.request_id",
-            "type": "metadata.shared.interrupt.type",
-            "phase": "metadata.shared.interrupt.phase",
-        },
-        "session_fields": {
-            "id": "metadata.shared.session.id",
-            "title": "metadata.shared.session.title",
         },
         "usage_fields": {
             "input_tokens": "metadata.shared.usage.input_tokens",
@@ -173,6 +167,12 @@ def test_public_agent_card_is_slimmed_but_keeps_core_shared_contract_hints() -> 
             "question.asked",
         ],
         "request_id_field": "metadata.shared.interrupt.request_id",
+        "interrupt_metadata_field": "metadata.shared.interrupt",
+        "interrupt_fields": {
+            "request_id": "metadata.shared.interrupt.request_id",
+            "type": "metadata.shared.interrupt.type",
+            "phase": "metadata.shared.interrupt.phase",
+        },
     }
 
     for uri in AUTHENTICATED_ONLY_EXTENSION_URIS:
@@ -223,6 +223,7 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     binding = ext_by_uri[SESSION_BINDING_EXTENSION_URI]
     profile = binding.params["profile"]
     assert binding.params["metadata_field"] == "metadata.shared.session.id"
+    assert binding.params["session_metadata_field"] == "metadata.shared.session"
     assert binding.params["supported_metadata"] == [
         "shared.session.id",
         "opencode.directory",
@@ -232,6 +233,10 @@ def test_agent_card_injects_profile_into_extensions() -> None:
         "opencode.directory",
         "opencode.workspace.id",
     ]
+    assert binding.params["session_fields"] == {
+        "id": "metadata.shared.session.id",
+        "title": "metadata.shared.session.title",
+    }
     assert profile["profile_id"] == "opencode-a2a-single-tenant-coding-v1"
     assert profile["deployment"] == {
         "id": "single_tenant_shared_workspace",
@@ -286,8 +291,6 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     streaming = ext_by_uri[STREAMING_EXTENSION_URI]
     assert streaming.params["artifact_metadata_field"] == "metadata.shared.stream"
     assert streaming.params["progress_metadata_field"] == "metadata.shared.progress"
-    assert streaming.params["interrupt_metadata_field"] == "metadata.shared.interrupt"
-    assert streaming.params["session_metadata_field"] == "metadata.shared.session"
     assert streaming.params["usage_metadata_field"] == "metadata.shared.usage"
     assert streaming.params["block_types"] == ["text", "reasoning", "tool_call"]
     assert streaming.params["block_contracts"] == {
@@ -316,17 +319,6 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     }
     assert streaming.params["stream_fields"]["sequence"] == "metadata.shared.stream.sequence"
     assert streaming.params["progress_fields"]["type"] == "metadata.shared.progress.type"
-    assert streaming.params["interrupt_fields"] == {
-        "request_id": "metadata.shared.interrupt.request_id",
-        "type": "metadata.shared.interrupt.type",
-        "phase": "metadata.shared.interrupt.phase",
-        "details": "metadata.shared.interrupt.details",
-        "resolution": "metadata.shared.interrupt.resolution",
-    }
-    assert streaming.params["session_fields"] == {
-        "id": "metadata.shared.session.id",
-        "title": "metadata.shared.session.title",
-    }
     assert streaming.params["usage_fields"] == {
         "input_tokens": "metadata.shared.usage.input_tokens",
         "output_tokens": "metadata.shared.usage.output_tokens",
@@ -628,6 +620,14 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     interrupt = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
     assert interrupt.params["profile"]["runtime_context"]["project"] == "alpha"
     assert interrupt.params["request_id_field"] == "metadata.shared.interrupt.request_id"
+    assert interrupt.params["interrupt_metadata_field"] == "metadata.shared.interrupt"
+    assert interrupt.params["interrupt_fields"] == {
+        "request_id": "metadata.shared.interrupt.request_id",
+        "type": "metadata.shared.interrupt.type",
+        "phase": "metadata.shared.interrupt.phase",
+        "details": "metadata.shared.interrupt.details",
+        "resolution": "metadata.shared.interrupt.resolution",
+    }
     assert interrupt.params["supported_metadata"] == [
         "opencode.directory",
         "opencode.workspace.id",

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -115,7 +115,6 @@ def test_public_agent_card_is_slimmed_but_keeps_core_shared_contract_hints() -> 
         ],
         "session_fields": {
             "id": "metadata.shared.session.id",
-            "title": "metadata.shared.session.title",
         },
         "provider_private_metadata": [
             "opencode.directory",
@@ -143,7 +142,6 @@ def test_public_agent_card_is_slimmed_but_keeps_core_shared_contract_hints() -> 
         "block_types": ["text", "reasoning", "tool_call"],
         "stream_fields": {
             "block_type": "metadata.shared.stream.block_type",
-            "message_id": "metadata.shared.stream.message_id",
             "sequence": "metadata.shared.stream.sequence",
         },
         "progress_fields": {

--- a/tests/server/test_output_negotiation.py
+++ b/tests/server/test_output_negotiation.py
@@ -231,7 +231,6 @@ async def test_negotiating_result_aggregator_compacts_stream_artifacts_for_persi
         "shared": {
             "stream": {
                 "block_type": "text",
-                "source": "stream",
                 "message_id": "msg-stream-1",
             }
         }

--- a/tests/server/test_output_negotiation.py
+++ b/tests/server/test_output_negotiation.py
@@ -99,7 +99,7 @@ def _task_with_extension_metadata(*, task_id: str, context_id: str) -> Task:
     metadata = build_output_negotiation_metadata(["text/plain"])
     assert metadata is not None
     metadata["shared"] = {
-        "session": {"id": "ses-1", "title": "Alpha"},
+        "session": {"id": "ses-1"},
         "interrupt": {"request_id": "irq-1", "type": "permission", "phase": "asked"},
         "model": {"providerID": "openai", "modelID": "gpt-5"},
         "usage": {"input_tokens": 12},

--- a/tests/server/test_output_negotiation.py
+++ b/tests/server/test_output_negotiation.py
@@ -25,6 +25,7 @@ from a2a.types import (
 
 from opencode_a2a.a2a_utils import make_data_part
 from opencode_a2a.contracts.extensions import (
+    INTERRUPT_CALLBACK_EXTENSION_URI,
     MODEL_SELECTION_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     STREAMING_EXTENSION_URI,
@@ -99,6 +100,7 @@ def _task_with_extension_metadata(*, task_id: str, context_id: str) -> Task:
     assert metadata is not None
     metadata["shared"] = {
         "session": {"id": "ses-1", "title": "Alpha"},
+        "interrupt": {"request_id": "irq-1", "type": "permission", "phase": "asked"},
         "model": {"providerID": "openai", "modelID": "gpt-5"},
         "usage": {"input_tokens": 12},
     }
@@ -358,6 +360,7 @@ async def test_on_get_task_filters_unnegotiated_shared_extension_metadata() -> N
         context=ServerCallContext(
             requested_extensions={
                 SESSION_BINDING_EXTENSION_URI,
+                INTERRUPT_CALLBACK_EXTENSION_URI,
                 MODEL_SELECTION_EXTENSION_URI,
                 STREAMING_EXTENSION_URI,
             }
@@ -365,5 +368,19 @@ async def test_on_get_task_filters_unnegotiated_shared_extension_metadata() -> N
     )
     assert negotiated is not None
     assert negotiated.metadata["shared"]["session"]["id"] == "ses-1"
+    assert negotiated.metadata["shared"]["interrupt"]["request_id"] == "irq-1"
     assert negotiated.metadata["shared"]["model"]["providerID"] == "openai"
     assert negotiated.metadata["shared"]["usage"]["input_tokens"] == 12
+
+    streaming_only = await handler.on_get_task(
+        GetTaskRequest(id="task-filter"),
+        context=ServerCallContext(
+            requested_extensions={
+                STREAMING_EXTENSION_URI,
+            }
+        ),
+    )
+    assert streaming_only is not None
+    assert "session" not in streaming_only.metadata["shared"]
+    assert "interrupt" not in streaming_only.metadata["shared"]
+    assert streaming_only.metadata["shared"]["usage"]["input_tokens"] == 12


### PR DESCRIPTION
## 概要
本 PR 汇总 #456 - #459，继续收敛 shared metadata 的公开契约与 runtime 发射面，目标是减少不必要的私有字段暴露，并把 session / interrupt / streaming 的 metadata ownership 调整到更明确的 extension 归属下。

## 主要改动
- 删除 `shared.stream` 中不必要的公共字段：`source`、`role`、`part_id`
- 将 `shared.session.*` 与 `shared.interrupt.*` 从 streaming extension 的默认暴露面中分离，改为分别由 `session-binding` 与 `interrupt-callback` 承载
- 收窄 public extension 暴露面，隐藏高级关联字段和展示字段
- 删除 `shared.progress.part_id` / `reason` / `title` / `subtitle`
- 删除 `shared.session.title` 的 runtime 发射与详细契约暴露
- 同步更新 Agent Card、OpenAPI、扩展契约文档、输出协商与测试

## 验证
- `./scripts/doctor.sh`
- 聚焦契约与流式输出相关测试已通过

## Issue 关联
Closes #456
Closes #457
Closes #458
Closes #459
Related #455（本 PR 基于该审查结论继续推进 metadata 收口）
Related #460（后续评估项已单独跟踪，不在本 PR 内解决）
