### PR TITLE
fix: continue persisting streaming tasks after disconnect

### DIFF
--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -604,6 +604,32 @@ class OpencodeRequestHandler(LegacyRequestHandler):
         except TaskStoreOperationError as exc:
             raise self._task_store_server_error(exc) from exc
 
+    async def _continue_stream_after_disconnect(
+        self,
+        *,
+        task_id: str,
+        result_aggregator: ResultAggregator,
+        queue: EventQueueLegacy,
+    ) -> None:
+        """Drain and persist the remaining task stream after the client disconnects."""
+        consumer = EventConsumer(queue)
+        try:
+            async for event in result_aggregator.consume_and_emit(consumer):
+                if hasattr(event, "id") and event.id:
+                    self._validate_task_id_match(task_id, event.id)
+                await self._send_push_notification_if_needed(task_id, event)
+        except TaskStoreOperationError:
+            logger.exception(
+                "Task store operation failed while draining disconnected stream task_id=%s",
+                task_id,
+            )
+        except asyncio.CancelledError:
+            logger.debug(
+                "Background stream drain cancelled task_id=%s",
+                task_id,
+            )
+            raise
+
     async def on_message_send_stream(self, params, context=None):
         self._validate_chat_output_modes(params)
         self._validate_shared_extension_negotiation(params, context)
@@ -619,12 +645,13 @@ class OpencodeRequestHandler(LegacyRequestHandler):
         consumer = EventConsumer(queue)
         producer_task.add_done_callback(consumer.agent_task_callback)
         stream_completed = False
+        stream_detached = False
 
         try:
             async for event in result_aggregator.consume_and_emit(consumer):
                 if hasattr(event, "id") and event.id:
                     self._validate_task_id_match(task_id, event.id)
-                await self._send_push_notification_if_needed(task_id, result_aggregator)
+                await self._send_push_notification_if_needed(task_id, event)
                 yield event
             stream_completed = True
         except TaskStoreOperationError as exc:
@@ -640,16 +667,29 @@ class OpencodeRequestHandler(LegacyRequestHandler):
             ):
                 yield event
         except (asyncio.CancelledError, GeneratorExit):
-            logger.debug("Client disconnected. Cancelling producer task %s", task_id)
-            producer_task.cancel()
-            await queue.close(immediate=True)
+            logger.debug(
+                "Client disconnected from streaming task %s; continuing task in background",
+                task_id,
+            )
+            if not producer_task.done():
+                detached_task = asyncio.create_task(
+                    self._continue_stream_after_disconnect(
+                        task_id=task_id,
+                        result_aggregator=result_aggregator,
+                        queue=queue,
+                    )
+                )
+                detached_task.set_name(f"continue_stream_after_disconnect:{task_id}")
+                self._track_background_task(detached_task)
+                stream_detached = True
             raise
         finally:
             emit_stream_request_metrics(active_delta=-1.0)
             logger.debug(
-                "A2A stream request closed task_id=%s completed=%s",
+                "A2A stream request closed task_id=%s completed=%s detached=%s",
                 task_id,
                 stream_completed,
+                stream_detached,
             )
             cleanup_task = asyncio.create_task(self._cleanup_producer(producer_task, task_id))
             cleanup_task.set_name(f"cleanup_producer:{task_id}")

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -671,17 +671,16 @@ class OpencodeRequestHandler(LegacyRequestHandler):
                 "Client disconnected from streaming task %s; continuing task in background",
                 task_id,
             )
-            if not producer_task.done():
-                detached_task = asyncio.create_task(
-                    self._continue_stream_after_disconnect(
-                        task_id=task_id,
-                        result_aggregator=result_aggregator,
-                        queue=queue,
-                    )
+            detached_task = asyncio.create_task(
+                self._continue_stream_after_disconnect(
+                    task_id=task_id,
+                    result_aggregator=result_aggregator,
+                    queue=queue,
                 )
-                detached_task.set_name(f"continue_stream_after_disconnect:{task_id}")
-                self._track_background_task(detached_task)
-                stream_detached = True
+            )
+            detached_task.set_name(f"continue_stream_after_disconnect:{task_id}")
+            self._track_background_task(detached_task)
+            stream_detached = True
             raise
         finally:
             emit_stream_request_metrics(active_delta=-1.0)

--- a/tests/server/test_app_behaviors.py
+++ b/tests/server/test_app_behaviors.py
@@ -8,8 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
-from a2a.server.events import EventConsumer
+from a2a.server.context import ServerCallContext
+from a2a.server.events import EventConsumer, EventQueueLegacy
 from a2a.server.routes.rest_dispatcher import RestDispatcher
+from a2a.server.tasks import TaskManager
+from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.types import (
     AgentCapabilities,
     AgentCard,
@@ -17,9 +20,12 @@ from a2a.types import (
     GetTaskRequest,
     InternalError,
     Message,
+    Part,
+    Role,
     SendMessageRequest,
     SubscribeToTaskRequest,
     Task,
+    TaskArtifactUpdateEvent,
     TaskNotCancelableError,
     TaskNotFoundError,
     TaskState,
@@ -37,6 +43,7 @@ from opencode_a2a.contracts.extensions import (
     SESSION_METHODS,
     build_capability_snapshot,
 )
+from opencode_a2a.output_modes import NegotiatingResultAggregator
 from opencode_a2a.profile.runtime import build_runtime_profile
 from opencode_a2a.protocol_versions import A2A_PROTOCOL_VERSION
 from opencode_a2a.server.agent_card import (
@@ -985,6 +992,104 @@ async def test_on_message_send_stream_emits_stable_failure_events_for_task_store
             }
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_on_message_send_stream_keeps_running_after_client_disconnect() -> None:
+    class _Handler(OpencodeRequestHandler):
+        def __init__(self) -> None:
+            super().__init__(
+                agent_executor=MagicMock(),
+                task_store=InMemoryTaskStore(owner_resolver=lambda _context: "test-owner"),
+                agent_card=_agent_card(),
+            )
+            self.stream_queue: EventQueueLegacy | None = None
+            self.tracked_tasks: list[asyncio.Task] = []
+
+        async def _setup_message_execution(self, params, context=None):  # noqa: ANN001
+            task_id = "task-disconnect"
+            context_id = "ctx-disconnect"
+            task_manager = TaskManager(
+                task_store=self.task_store,
+                context=context or ServerCallContext(),
+                task_id=task_id,
+                context_id=context_id,
+                initial_message=params.message,
+            )
+            queue = EventQueueLegacy()
+            self.stream_queue = queue
+            result_aggregator = NegotiatingResultAggregator(task_manager, None)
+
+            async def _produce() -> None:
+                await queue.enqueue_event(
+                    Task(
+                        id=task_id,
+                        context_id=context_id,
+                        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+                    )
+                )
+                await asyncio.sleep(0)
+                await queue.enqueue_event(
+                    TaskArtifactUpdateEvent(
+                        task_id=task_id,
+                        context_id=context_id,
+                        artifact=app_module.Artifact(
+                            artifact_id=f"{task_id}:stream:text",
+                            parts=[Part(text="final answer")],
+                            metadata={"shared": {"stream": {"block_type": "text"}}},
+                        ),
+                        append=False,
+                        last_chunk=True,
+                    )
+                )
+                await queue.enqueue_event(
+                    app_module.TaskStatusUpdateEvent(
+                        task_id=task_id,
+                        context_id=context_id,
+                        status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+                    )
+                )
+
+            producer_task = asyncio.create_task(_produce())
+            return task_manager, task_id, queue, result_aggregator, producer_task
+
+        async def _cleanup_producer(self, producer_task, task_id):  # noqa: ANN001
+            del task_id
+            await producer_task
+            if self.stream_queue is not None:
+                await self.stream_queue.close()
+
+        async def _send_push_notification_if_needed(self, task_id, result_aggregator):  # noqa: ANN001
+            del task_id, result_aggregator
+
+        def _track_background_task(self, task):  # noqa: ANN001
+            self.tracked_tasks.append(task)
+            super()._track_background_task(task)
+
+    handler = _Handler()
+    params = SendMessageRequest(
+        message=Message(
+            message_id="msg-user-1",
+            role=Role.ROLE_USER,
+            parts=[Part(text="hello")],
+        )
+    )
+
+    stream = handler.on_message_send_stream(params, ServerCallContext())
+    first_event = await anext(stream)
+    assert isinstance(first_event, Task)
+    assert first_event.status.state == TaskState.TASK_STATE_WORKING
+
+    await stream.aclose()
+    await asyncio.sleep(0)
+    await asyncio.gather(*handler.tracked_tasks, return_exceptions=True)
+
+    result = await handler.on_get_task(GetTaskRequest(id="task-disconnect"))
+    assert result is not None
+    assert result.status.state == TaskState.TASK_STATE_COMPLETED
+    assert result.artifacts is not None
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0].parts[0].text == "final answer"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_app_behaviors.py
+++ b/tests/server/test_app_behaviors.py
@@ -1093,6 +1093,104 @@ async def test_on_message_send_stream_keeps_running_after_client_disconnect() ->
 
 
 @pytest.mark.asyncio
+async def test_on_message_send_stream_drains_buffered_events_after_disconnect() -> None:
+    class _Handler(OpencodeRequestHandler):
+        def __init__(self) -> None:
+            super().__init__(
+                agent_executor=MagicMock(),
+                task_store=InMemoryTaskStore(owner_resolver=lambda _context: "test-owner"),
+                agent_card=_agent_card(),
+            )
+            self.stream_queue: EventQueueLegacy | None = None
+            self.tracked_tasks: list[asyncio.Task] = []
+
+        async def _setup_message_execution(self, params, context=None):  # noqa: ANN001
+            task_id = "task-buffered-disconnect"
+            context_id = "ctx-buffered-disconnect"
+            task_manager = TaskManager(
+                task_store=self.task_store,
+                context=context or ServerCallContext(),
+                task_id=task_id,
+                context_id=context_id,
+                initial_message=params.message,
+            )
+            queue = EventQueueLegacy()
+            self.stream_queue = queue
+            result_aggregator = NegotiatingResultAggregator(task_manager, None)
+
+            async def _produce() -> None:
+                await queue.enqueue_event(
+                    Task(
+                        id=task_id,
+                        context_id=context_id,
+                        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+                    )
+                )
+                await queue.enqueue_event(
+                    TaskArtifactUpdateEvent(
+                        task_id=task_id,
+                        context_id=context_id,
+                        artifact=app_module.Artifact(
+                            artifact_id=f"{task_id}:stream:text",
+                            parts=[Part(text="buffered final answer")],
+                            metadata={"shared": {"stream": {"block_type": "text"}}},
+                        ),
+                        append=False,
+                        last_chunk=True,
+                    )
+                )
+                await queue.enqueue_event(
+                    app_module.TaskStatusUpdateEvent(
+                        task_id=task_id,
+                        context_id=context_id,
+                        status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+                    )
+                )
+
+            producer_task = asyncio.create_task(_produce())
+            await producer_task
+            return task_manager, task_id, queue, result_aggregator, producer_task
+
+        async def _cleanup_producer(self, producer_task, task_id):  # noqa: ANN001
+            del task_id
+            await producer_task
+            if self.stream_queue is not None:
+                await self.stream_queue.close()
+
+        async def _send_push_notification_if_needed(self, task_id, result_aggregator):  # noqa: ANN001
+            del task_id, result_aggregator
+
+        def _track_background_task(self, task):  # noqa: ANN001
+            self.tracked_tasks.append(task)
+            super()._track_background_task(task)
+
+    handler = _Handler()
+    params = SendMessageRequest(
+        message=Message(
+            message_id="msg-user-2",
+            role=Role.ROLE_USER,
+            parts=[Part(text="hello again")],
+        )
+    )
+
+    stream = handler.on_message_send_stream(params, ServerCallContext())
+    first_event = await anext(stream)
+    assert isinstance(first_event, Task)
+    assert first_event.status.state == TaskState.TASK_STATE_WORKING
+
+    await stream.aclose()
+    await asyncio.sleep(0)
+    await asyncio.gather(*handler.tracked_tasks, return_exceptions=True)
+
+    result = await handler.on_get_task(GetTaskRequest(id="task-buffered-disconnect"))
+    assert result is not None
+    assert result.status.state == TaskState.TASK_STATE_COMPLETED
+    assert result.artifacts is not None
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0].parts[0].text == "buffered final answer"
+
+
+@pytest.mark.asyncio
 async def test_on_message_send_covers_error_cleanup_and_internal_error(monkeypatch, caplog) -> None:
     class _Aggregator:
         def __init__(self, *, result=None, error: Exception | None = None) -> None:


### PR DESCRIPTION
## 背景
在审查 #455 时发现，当前 `SendStreamingMessage` 流式连接一旦断开，服务端会直接取消 producer task。这样任务可能在完成前被中止，导致下游后续无法稳定通过 `GetTask` 或 terminal replay 取回完整终态结果。

## 本次改动
- 在 streaming 断流分支中，不再取消 producer task 或立即关闭队列。
- 新增后台 drain 逻辑，断流后继续消费 queue，并沿用既有 result aggregator 持久化 task、artifact 和 terminal status。
- 保留既有 cleanup 路径，由 cleanup 在 producer 结束后关闭队列，避免遗留后台资源。
- 补充两条回归测试，分别覆盖 producer 仍在运行，以及 producer 已结束但队列仍有 buffered terminal events 时的断流场景。

## 与 Issues 的关系
- Closes #462
- Related #455
- 不关闭 #455：本 PR 修复的是实现层的 disconnect reliability 偏差，不涉及是否需要在 completed status 中补最终 message 的协议/产品决策。

## 验证
- `bash ./scripts/doctor.sh`
