### PR TITLE
refactor: isolate task-store sdk compat and terminal immutability

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1261,6 +1261,7 @@ If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscr
 - Upstream interruption is best-effort: if upstream returns 404, network errors, or other HTTP errors, A2A cancellation still completes with `TaskState.TASK_STATE_CANCELED`.
 - Idempotency contract: repeated `CancelTask` on an already `canceled` task returns the current terminal task state without error.
 - Terminal subscribe contract: calling `SubscribeToTask` or `GET /v1/tasks/{task_id}:subscribe` on a terminal task replays one terminal `Task` snapshot and then closes the stream.
+- Terminal persistence contract: once a terminal task snapshot is persisted, this service treats it as immutable. Producers must emit final text and artifact updates before the terminal event, and any final usage or stream metadata must be attached to that terminal event itself. Late terminal-state mutations are rejected by the task-store write policy.
 - These two semantics are also declared as machine-readable `service_behaviors` in the compatibility profile and wire contract extensions.
 - At `A2A_LOG_LEVEL=DEBUG`, the service emits lightweight metric log records
   (`logger=opencode_a2a.execution.executor`):

--- a/src/opencode_a2a/execution/coordinator.py
+++ b/src/opencode_a2a/execution/coordinator.py
@@ -415,6 +415,8 @@ class ExecutionCoordinator:
                 ),
             )
 
+        # Terminal task snapshots are immutable after persistence. Final text artifacts must be
+        # emitted before the completed status event, and final usage belongs on that terminal event.
         await self._event_queue.enqueue_event(
             TaskStatusUpdateEvent(
                 task_id=self._task_id,

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -17,7 +17,6 @@ from sqlalchemy.engine import make_url
 from ..a2a_utils import proto_equals
 from ..config import Settings
 from ..task_states import TERMINAL_TASK_STATES
-from . import task_store_sdk_compat as _task_store_sdk_compat
 from .context_helpers import normalize_server_call_context
 from .database import build_database_engine
 from .task_store_sdk_compat import DatabaseTaskStoreCompat
@@ -26,8 +25,6 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
 logger = logging.getLogger(__name__)
-
-TaskStoreSchemaCompatibilityError = _task_store_sdk_compat.TaskStoreSchemaCompatibilityError
 
 
 class TaskStoreOperationError(RuntimeError):

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -17,6 +17,7 @@ from sqlalchemy.engine import make_url
 from ..a2a_utils import proto_equals
 from ..config import Settings
 from ..task_states import TERMINAL_TASK_STATES
+from . import task_store_sdk_compat as _task_store_sdk_compat
 from .context_helpers import normalize_server_call_context
 from .database import build_database_engine
 from .task_store_sdk_compat import DatabaseTaskStoreCompat
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
 logger = logging.getLogger(__name__)
+
+TaskStoreSchemaCompatibilityError = _task_store_sdk_compat.TaskStoreSchemaCompatibilityError
 
 
 class TaskStoreOperationError(RuntimeError):

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -11,11 +11,7 @@ from a2a.server.context import ServerCallContext
 from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_store import TaskStore
-from a2a.types import ListTasksRequest, ListTasksResponse, Task, TaskState
-from google.protobuf.json_format import MessageToDict
-from sqlalchemy import inspect, or_, select
-from sqlalchemy.dialects.postgresql import insert as postgresql_insert
-from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from a2a.types import ListTasksRequest, ListTasksResponse, Task
 from sqlalchemy.engine import make_url
 
 from ..a2a_utils import proto_equals
@@ -23,17 +19,12 @@ from ..config import Settings
 from ..task_states import TERMINAL_TASK_STATES
 from .context_helpers import normalize_server_call_context
 from .database import build_database_engine
+from .task_store_sdk_compat import DatabaseTaskStoreCompat
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
 logger = logging.getLogger(__name__)
-
-_TERMINAL_TASK_STATE_VALUES = tuple(TaskState.Name(int(state)) for state in TERMINAL_TASK_STATES)
-_ATOMIC_TERMINAL_GUARD_DIALECTS = frozenset({"postgresql", "sqlite"})
-_SDK_TASKS_TABLE_NAME = "tasks"
-_SDK_TASKS_REQUIRED_COLUMNS = frozenset({"owner", "last_updated", "protocol_version"})
-_SDK_TASKS_REQUIRED_INDEXES = frozenset({"idx_tasks_owner_last_updated"})
 
 
 class TaskStoreOperationError(RuntimeError):
@@ -48,10 +39,6 @@ class TaskStoreOperationError(RuntimeError):
 class TaskPersistenceDecision:
     persist: bool
     reason: str | None = None
-
-
-class TaskStoreSchemaCompatibilityError(RuntimeError):
-    pass
 
 
 class TaskWritePolicy(ABC):
@@ -222,22 +209,22 @@ class PolicyAwareTaskStore(TaskStoreDecorator):
         task: Task,
         context: ServerCallContext,
     ) -> None:
-        dialect_name = task_store.engine.dialect.name
-        if dialect_name not in _ATOMIC_TERMINAL_GUARD_DIALECTS:
+        compat = DatabaseTaskStoreCompat(task_store)
+        if not compat.supports_atomic_terminal_guard():
             if not self._atomic_guard_fallback_logged:
                 logger.warning(
                     "Database-backed task store dialect does not support atomic terminal guard; "
                     "falling back to read-before-write policy dialect=%s",
-                    dialect_name,
+                    compat.dialect_name,
                 )
                 self._atomic_guard_fallback_logged = True
             await self._save_with_read_before_write(task, context)
             return
 
         try:
-            if await self._persist_with_atomic_terminal_guard(task_store, task, context):
+            if await compat.atomic_save(task, context):
                 return
-            existing = await self._load_task_from_database(task_store, task.id)
+            existing = await compat.load_task(task.id, context)
             decision = self._write_policy.evaluate(existing=existing, incoming=task)
             self._log_terminal_persistence_decision(
                 existing=existing,
@@ -259,37 +246,6 @@ class PolicyAwareTaskStore(TaskStoreDecorator):
             raise
         except Exception as exc:
             raise TaskStoreOperationError("save", task.id) from exc
-
-    async def _persist_with_atomic_terminal_guard(
-        self,
-        task_store: DatabaseTaskStore,
-        task: Task,
-        context: ServerCallContext,
-    ) -> bool:
-        await task_store.initialize()
-        statement = _build_atomic_task_save_statement(
-            task=task,
-            owner=task_store.owner_resolver(context),
-            task_table=task_store.task_model.__table__,
-            dialect_name=task_store.engine.dialect.name,
-        )
-        async with task_store.async_session_maker.begin() as session:
-            result = await session.execute(statement)
-        return result.scalar_one_or_none() is not None
-
-    async def _load_task_from_database(
-        self,
-        task_store: DatabaseTaskStore,
-        task_id: str,
-    ) -> Task | None:
-        await task_store.initialize()
-        async with task_store.async_session_maker() as session:
-            stmt = select(task_store.task_model).where(task_store.task_model.id == task_id)
-            result = await session.execute(stmt)
-            task_model = result.scalar_one_or_none()
-        if task_model is None:
-            return None
-        return task_store._from_orm(task_model)
 
     def _log_terminal_persistence_decision(
         self,
@@ -352,8 +308,9 @@ def build_task_store_runtime(
     task_store = GuardedTaskStore(raw_task_store)
 
     async def _startup() -> None:
-        await _ensure_sdk_task_store_schema_compatible(raw_task_store)
-        await raw_task_store.initialize()
+        compat = DatabaseTaskStoreCompat(raw_task_store)
+        await compat.validate_schema()
+        await compat.initialize()
 
     async def _shutdown() -> None:
         if engine is None:
@@ -402,105 +359,13 @@ def _normalize_task_store_context(
     return normalize_server_call_context(context)
 
 
-def _build_atomic_task_save_statement(
-    *,
-    task: Task,
-    owner: str | None,
-    task_table: Any,
-    dialect_name: str,
-):
-    insert = _resolve_atomic_insert_factory(dialect_name)
-    values = _task_row_values(task, owner=owner)
-    status_state = task_table.c.status["state"].as_string()
-    persist_guard = or_(
-        task_table.c.status.is_(None),
-        status_state.is_(None),
-        status_state.not_in(_TERMINAL_TASK_STATE_VALUES),
-    )
-    return (
-        insert(task_table)
-        .values(**values)
-        .on_conflict_do_update(
-            index_elements=[task_table.c.id],
-            set_={key: value for key, value in values.items() if key != "id"},
-            where=persist_guard,
-        )
-        .returning(task_table.c.id)
-    )
-
-
-def _resolve_atomic_insert_factory(dialect_name: str):
-    if dialect_name == "sqlite":
-        return sqlite_insert
-    if dialect_name == "postgresql":
-        return postgresql_insert
-    raise ValueError(f"Unsupported atomic task persistence dialect: {dialect_name}")
-
-
-def _task_row_values(task: Task, *, owner: str | None) -> dict[str, Any]:
-    return {
-        "id": task.id,
-        "context_id": task.context_id,
-        "kind": "task",
-        "owner": owner,
-        "last_updated": (
-            task.status.timestamp.ToDatetime() if task.status.HasField("timestamp") else None
-        ),
-        "status": MessageToDict(task.status),
-        "artifacts": [MessageToDict(artifact) for artifact in task.artifacts],
-        "history": [MessageToDict(message) for message in task.history],
-        "metadata": MessageToDict(task.metadata),
-        "protocol_version": "1.0",
-    }
-
-
 async def initialize_task_store(task_store: TaskStore) -> None:
     raw_task_store = unwrap_task_store(task_store)
     if isinstance(raw_task_store, DatabaseTaskStore):
-        await _ensure_sdk_task_store_schema_compatible(raw_task_store)
-        await raw_task_store.initialize()
+        compat = DatabaseTaskStoreCompat(raw_task_store)
+        await compat.validate_schema()
+        await compat.initialize()
         return
     initialize = getattr(task_store, "initialize", None)
     if callable(initialize):
         await initialize()
-
-
-async def _ensure_sdk_task_store_schema_compatible(task_store: DatabaseTaskStore) -> None:
-    database_url = task_store.engine.url.render_as_string(hide_password=True)
-    async with task_store.engine.begin() as conn:
-        await conn.run_sync(
-            lambda sync_conn: _validate_sdk_task_table_schema(
-                sync_conn,
-                database_url=database_url,
-            )
-        )
-
-
-def _validate_sdk_task_table_schema(
-    connection: Any,
-    *,
-    database_url: str,
-) -> None:
-    inspector = inspect(connection)
-    if _SDK_TASKS_TABLE_NAME not in inspector.get_table_names():
-        return
-
-    existing_columns = {column["name"] for column in inspector.get_columns(_SDK_TASKS_TABLE_NAME)}
-    existing_indexes = {index["name"] for index in inspector.get_indexes(_SDK_TASKS_TABLE_NAME)}
-    missing_columns = sorted(_SDK_TASKS_REQUIRED_COLUMNS - existing_columns)
-    missing_indexes = sorted(_SDK_TASKS_REQUIRED_INDEXES - existing_indexes)
-    if not missing_columns and not missing_indexes:
-        return
-
-    details: list[str] = []
-    if missing_columns:
-        details.append(f"missing columns: {', '.join(missing_columns)}")
-    if missing_indexes:
-        details.append(f"missing indexes: {', '.join(missing_indexes)}")
-
-    raise TaskStoreSchemaCompatibilityError(
-        "Legacy SDK task table schema detected for 'tasks' "
-        f"({'; '.join(details)}). Run "
-        f"`a2a-db --database-url {database_url}` before starting the service. "
-        "If `a2a-db` is unavailable, install the `a2a-sdk[db-cli]` extra first."
-    )

--- a/src/opencode_a2a/server/task_store.py
+++ b/src/opencode_a2a/server/task_store.py
@@ -52,6 +52,8 @@ class TaskWritePolicy(ABC):
 
 
 class FirstTerminalStateWinsPolicy(TaskWritePolicy):
+    """Treat terminal task snapshots as immutable once persisted."""
+
     def evaluate(
         self,
         *,

--- a/src/opencode_a2a/server/task_store_sdk_compat.py
+++ b/src/opencode_a2a/server/task_store_sdk_compat.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, cast
+
+from a2a.compat.v0_3.model_conversions import compat_task_model_to_core
+from a2a.server.context import ServerCallContext
+from a2a.server.tasks.database_task_store import DatabaseTaskStore
+from a2a.types import Task, TaskState
+from google.protobuf.json_format import MessageToDict, ParseDict
+from sqlalchemy import inspect, or_, select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from ..task_states import TERMINAL_TASK_STATES
+
+_ATOMIC_TERMINAL_GUARD_DIALECTS = frozenset({"postgresql", "sqlite"})
+_TERMINAL_TASK_STATE_VALUES = tuple(TaskState.Name(int(state)) for state in TERMINAL_TASK_STATES)
+_REQUIRED_TASK_MODEL_COLUMNS = frozenset(
+    {
+        "id",
+        "context_id",
+        "kind",
+        "owner",
+        "last_updated",
+        "status",
+        "artifacts",
+        "history",
+        "metadata",
+        "protocol_version",
+    }
+)
+_REQUIRED_SCHEMA_COLUMNS = frozenset({"owner", "last_updated", "protocol_version"})
+
+
+class TaskStoreSchemaCompatibilityError(RuntimeError):
+    pass
+
+
+class TaskStoreSdkCompatibilityError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class _DatabaseTaskStoreShape:
+    session_maker: Any
+    task_model: type[Any]
+    owner_resolver: Callable[[ServerCallContext], str | None]
+    model_to_core_conversion: Callable[[Any], Task] | None
+
+
+class DatabaseTaskStoreCompat:
+    def __init__(self, task_store: DatabaseTaskStore) -> None:
+        self._task_store = task_store
+        self._shape = _resolve_database_task_store_shape(task_store)
+
+    @property
+    def dialect_name(self) -> str:
+        return self._task_store.engine.dialect.name
+
+    def supports_atomic_terminal_guard(self) -> bool:
+        return self.dialect_name in _ATOMIC_TERMINAL_GUARD_DIALECTS
+
+    async def initialize(self) -> None:
+        await self._task_store.initialize()
+
+    async def validate_schema(self) -> None:
+        database_url = self._task_store.engine.url.render_as_string(hide_password=True)
+        table_name = self._shape.task_model.__table__.name
+        required_indexes = frozenset({f"idx_{table_name}_owner_last_updated"})
+        async with self._task_store.engine.begin() as conn:
+            await conn.run_sync(
+                lambda sync_conn: _validate_sdk_task_table_schema(
+                    sync_conn,
+                    table_name=table_name,
+                    required_indexes=required_indexes,
+                    database_url=database_url,
+                )
+            )
+
+    async def atomic_save(
+        self,
+        task: Task,
+        context: ServerCallContext,
+    ) -> bool:
+        await self.initialize()
+        statement = _build_atomic_task_save_statement(
+            task=task,
+            owner=self._shape.owner_resolver(context),
+            task_table=self._shape.task_model.__table__,
+            dialect_name=self.dialect_name,
+        )
+        async with self._shape.session_maker.begin() as session:
+            result = await session.execute(statement)
+        return result.scalar_one_or_none() is not None
+
+    async def load_task(
+        self,
+        task_id: str,
+        context: ServerCallContext,
+    ) -> Task | None:
+        await self.initialize()
+        owner = self._shape.owner_resolver(context)
+        async with self._shape.session_maker() as session:
+            stmt = select(self._shape.task_model).where(
+                self._shape.task_model.id == task_id,
+                self._shape.task_model.owner == owner,
+            )
+            result = await session.execute(stmt)
+            task_model = result.scalar_one_or_none()
+        if task_model is None:
+            return None
+        return _task_model_to_core(
+            task_model,
+            model_to_core_conversion=self._shape.model_to_core_conversion,
+        )
+
+
+def _resolve_database_task_store_shape(
+    task_store: DatabaseTaskStore,
+) -> _DatabaseTaskStoreShape:
+    missing: list[str] = []
+    session_maker = getattr(task_store, "async_session_maker", None)
+    if session_maker is None:
+        missing.append("async_session_maker")
+
+    task_model = getattr(task_store, "task_model", None)
+    task_table = getattr(task_model, "__table__", None)
+    if task_model is None or task_table is None:
+        missing.append("task_model.__table__")
+    elif missing_columns := sorted(_REQUIRED_TASK_MODEL_COLUMNS - set(task_table.columns.keys())):
+        missing.append(f"task_model columns ({', '.join(missing_columns)})")
+
+    owner_resolver = getattr(task_store, "owner_resolver", None)
+    if not callable(owner_resolver):
+        missing.append("owner_resolver")
+
+    if missing:
+        details = ", ".join(missing)
+        raise TaskStoreSdkCompatibilityError(
+            "DatabaseTaskStore shape drift detected; compat layer requires "
+            f"{details}. Update src/opencode_a2a/server/task_store_sdk_compat.py "
+            "for the installed a2a-sdk version."
+        )
+
+    model_to_core_conversion = getattr(task_store, "model_to_core_conversion", None)
+    if model_to_core_conversion is not None and not callable(model_to_core_conversion):
+        raise TaskStoreSdkCompatibilityError(
+            "DatabaseTaskStore shape drift detected; model_to_core_conversion must be callable."
+        )
+
+    return _DatabaseTaskStoreShape(
+        session_maker=session_maker,
+        task_model=cast(type[Any], task_model),
+        owner_resolver=cast(Callable[[ServerCallContext], str | None], owner_resolver),
+        model_to_core_conversion=model_to_core_conversion,
+    )
+
+
+def _build_atomic_task_save_statement(
+    *,
+    task: Task,
+    owner: str | None,
+    task_table: Any,
+    dialect_name: str,
+):
+    insert = _resolve_atomic_insert_factory(dialect_name)
+    values = _task_row_values(task, owner=owner)
+    status_state = task_table.c.status["state"].as_string()
+    persist_guard = or_(
+        task_table.c.status.is_(None),
+        status_state.is_(None),
+        status_state.not_in(_TERMINAL_TASK_STATE_VALUES),
+    )
+    return (
+        insert(task_table)
+        .values(**values)
+        .on_conflict_do_update(
+            index_elements=[task_table.c.id],
+            set_={key: value for key, value in values.items() if key != "id"},
+            where=persist_guard,
+        )
+        .returning(task_table.c.id)
+    )
+
+
+def _resolve_atomic_insert_factory(dialect_name: str):
+    if dialect_name == "sqlite":
+        return sqlite_insert
+    if dialect_name == "postgresql":
+        return postgresql_insert
+    raise ValueError(f"Unsupported atomic task persistence dialect: {dialect_name}")
+
+
+def _task_row_values(task: Task, *, owner: str | None) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "context_id": task.context_id,
+        "kind": "task",
+        "owner": owner,
+        "last_updated": (
+            task.status.timestamp.ToDatetime() if task.status.HasField("timestamp") else None
+        ),
+        "status": MessageToDict(task.status),
+        "artifacts": [MessageToDict(artifact) for artifact in task.artifacts],
+        "history": [MessageToDict(message) for message in task.history],
+        "metadata": MessageToDict(task.metadata) if task.metadata.fields else None,
+        "protocol_version": "1.0",
+    }
+
+
+def _task_model_to_core(
+    task_model: Any,
+    *,
+    model_to_core_conversion: Callable[[Any], Task] | None,
+) -> Task:
+    if model_to_core_conversion is not None:
+        return model_to_core_conversion(task_model)
+
+    if getattr(task_model, "protocol_version", None) == "1.0":
+        task = Task(
+            id=task_model.id,
+            context_id=task_model.context_id,
+        )
+        if task_model.status:
+            ParseDict(task_model.status, task.status)
+        if task_model.artifacts:
+            for artifact_dict in task_model.artifacts:
+                artifact = task.artifacts.add()
+                ParseDict(artifact_dict, artifact)
+        if task_model.history:
+            for message_dict in task_model.history:
+                message = task.history.add()
+                ParseDict(message_dict, message)
+        if task_model.task_metadata:
+            task.metadata.update(task_model.task_metadata)
+        return task
+
+    return compat_task_model_to_core(task_model)
+
+
+def _validate_sdk_task_table_schema(
+    connection: Any,
+    *,
+    table_name: str,
+    required_indexes: frozenset[str],
+    database_url: str,
+) -> None:
+    inspector = inspect(connection)
+    if table_name not in inspector.get_table_names():
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns(table_name)}
+    existing_indexes = {index["name"] for index in inspector.get_indexes(table_name)}
+    missing_columns = sorted(_REQUIRED_SCHEMA_COLUMNS - existing_columns)
+    missing_indexes = sorted(required_indexes - existing_indexes)
+    if not missing_columns and not missing_indexes:
+        return
+
+    details: list[str] = []
+    if missing_columns:
+        details.append(f"missing columns: {', '.join(missing_columns)}")
+    if missing_indexes:
+        details.append(f"missing indexes: {', '.join(missing_indexes)}")
+
+    raise TaskStoreSchemaCompatibilityError(
+        f"Legacy SDK task table schema detected for '{table_name}' "
+        f"({'; '.join(details)}). Run "
+        f"`a2a-db --database-url {database_url}` before starting the service. "
+        "If `a2a-db` is unavailable, install the `a2a-sdk[db-cli]` extra first."
+    )

--- a/tests/execution/test_streaming_output_contract_core.py
+++ b/tests/execution/test_streaming_output_contract_core.py
@@ -607,6 +607,53 @@ async def test_streaming_includes_usage_in_final_status_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_emits_final_text_artifact_before_terminal_status() -> None:
+    client = DummyStreamingClient(
+        stream_events_payload=[
+            _event(session_id="ses-1", role="assistant", part_type="text", delta="partial "),
+            _step_finish_usage_event(
+                session_id="ses-1",
+                input_tokens=9,
+                output_tokens=3,
+                total_tokens=12,
+                cost=0.0007,
+            ),
+        ],
+        response_text="partial final answer",
+    )
+    executor = OpencodeAgentExecutor(client, streaming_enabled=True)
+    executor._should_stream = lambda context: True  # type: ignore[method-assign]
+    queue = DummyEventQueue()
+
+    await executor.execute(
+        make_request_context(
+            task_id="task-terminal-order",
+            context_id="ctx-terminal-order",
+            text="hello",
+        ),
+        queue,
+    )
+
+    final_text_index = max(
+        index
+        for index, event in enumerate(queue.events)
+        if event in _artifact_updates(queue)
+        and _artifact_stream_meta(event)["block_type"] == "text"
+        and _part_text(event) == "partial final answer"
+    )
+    final_status_index = next(
+        index
+        for index, event in enumerate(queue.events)
+        if isinstance(event, TaskStatusUpdateEvent) and _is_terminal_status_event(event)
+    )
+
+    assert final_text_index < final_status_index
+    final_status = queue.events[final_status_index]
+    assert isinstance(final_status, TaskStatusUpdateEvent)
+    assert _status_shared_meta(final_status)["usage"]["total_tokens"] == 12
+
+
+@pytest.mark.asyncio
 async def test_streaming_ignores_non_step_finish_usage_like_part_payloads() -> None:
     client = DummyStreamingClient(
         stream_events_payload=[

--- a/tests/server/test_output_negotiation.py
+++ b/tests/server/test_output_negotiation.py
@@ -288,6 +288,71 @@ async def test_negotiating_result_aggregator_compacts_stream_artifacts_for_persi
 
 
 @pytest.mark.asyncio
+async def test_negotiating_result_aggregator_persists_terminal_usage_with_final_artifact() -> None:
+    store = _store()
+    task_manager = TaskManager(
+        context=ServerCallContext(),
+        task_id="task-stream-terminal-contract",
+        context_id="ctx-stream-terminal-contract",
+        task_store=store,
+        initial_message=None,
+    )
+    aggregator = NegotiatingResultAggregator(task_manager, None)
+    queue = EventQueue()
+    stream_metadata = {
+        "shared": {
+            "stream": {
+                "block_type": "text",
+                "message_id": "msg-stream-usage-1",
+            }
+        }
+    }
+
+    await queue.enqueue_event(
+        TaskArtifactUpdateEvent(
+            task_id="task-stream-terminal-contract",
+            context_id="ctx-stream-terminal-contract",
+            artifact=Artifact(
+                artifact_id="task-stream-terminal-contract:stream:text",
+                parts=[Part(text="final answer")],
+                metadata=stream_metadata,
+            ),
+            append=False,
+            last_chunk=True,
+        )
+    )
+    await queue.enqueue_event(
+        TaskStatusUpdateEvent(
+            task_id="task-stream-terminal-contract",
+            context_id="ctx-stream-terminal-contract",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+            metadata={
+                "shared": {
+                    "usage": {
+                        "input_tokens": 9,
+                        "output_tokens": 3,
+                        "total_tokens": 12,
+                    }
+                }
+            },
+        )
+    )
+
+    result = await aggregator.consume_all(EventConsumer(queue))
+
+    assert isinstance(result, Task)
+    assert result.artifacts is not None
+    assert result.artifacts[0].parts[0].text == "final answer"
+    assert result.metadata["shared"]["usage"]["total_tokens"] == 12
+
+    stored = await store.get("task-stream-terminal-contract", ServerCallContext())
+    assert stored is not None
+    assert stored.artifacts is not None
+    assert stored.artifacts[0].parts[0].text == "final answer"
+    assert stored.metadata["shared"]["usage"]["total_tokens"] == 12
+
+
+@pytest.mark.asyncio
 async def test_on_get_task_applies_persisted_output_negotiation() -> None:
     store = _store()
     task = _task_with_negotiated_outputs(task_id="task-get", context_id="ctx-get")

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -8,7 +8,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from a2a.server.context import ServerCallContext
 from a2a.server.tasks.database_task_store import DatabaseTaskStore
-from a2a.types import Task, TaskState, TaskStatus
+from a2a.types import Artifact, Message, Part, Role, Task, TaskState, TaskStatus
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.timestamp_pb2 import Timestamp
 from sqlalchemy import text
 
 from opencode_a2a.server.database import build_database_engine
@@ -30,6 +32,8 @@ from opencode_a2a.server.task_store import (
 from opencode_a2a.server.task_store_sdk_compat import (
     DatabaseTaskStoreCompat,
     TaskStoreSdkCompatibilityError,
+    _task_model_to_core,
+    _task_row_values,
 )
 from tests.support.helpers import make_request_context_mock, make_settings
 
@@ -51,6 +55,49 @@ def _set_metadata(task: Task, metadata: dict) -> Task:
     task.ClearField("metadata")
     task.metadata.update(metadata)
     return task
+
+
+def _rich_task(task_id: str, *, context_id: str = "ctx-1") -> Task:
+    timestamp = Timestamp()
+    timestamp.FromJsonString("2026-05-03T12:34:56Z")
+    return Task(
+        id=task_id,
+        context_id=context_id,
+        status=TaskStatus(
+            state=TaskState.TASK_STATE_COMPLETED,
+            timestamp=timestamp,
+            message=Message(
+                message_id=f"{task_id}:status",
+                role=Role.ROLE_AGENT,
+                parts=[Part(text="done")],
+                task_id=task_id,
+                context_id=context_id,
+            ),
+        ),
+        artifacts=[
+            Artifact(
+                artifact_id=f"{task_id}:artifact",
+                parts=[Part(text="plain result")],
+            )
+        ],
+        history=[
+            Message(
+                message_id=f"{task_id}:history",
+                role=Role.ROLE_AGENT,
+                parts=[Part(text="history item")],
+                task_id=task_id,
+                context_id=context_id,
+            )
+        ],
+        metadata={
+            "opencode": {"directory": "/workspace"},
+            "shared": {"usage": {"input_tokens": 12, "output_tokens": 8}},
+        },
+    )
+
+
+def _task_to_dict(task: Task) -> dict:
+    return MessageToDict(task)
 
 
 def test_build_task_store_defaults_to_database_backend(tmp_path: Path) -> None:
@@ -346,6 +393,65 @@ async def test_database_task_store_compat_fails_fast_on_sdk_shape_drift(
 
     with pytest.raises(TaskStoreSdkCompatibilityError, match="async_session_maker"):
         DatabaseTaskStoreCompat(raw_store)
+
+    await store.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_database_task_store_compat_matches_sdk_to_orm_semantics(
+    tmp_path: Path,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'to-orm-parity.db'}",
+    )
+    store = build_task_store(settings)
+    raw_store = unwrap_task_store(store)
+    assert isinstance(raw_store, DatabaseTaskStore)
+
+    task = _rich_task("task-parity")
+    sdk_model = raw_store._to_orm(task, "owner-1")
+
+    compat_values = _task_row_values(task, owner="owner-1")
+    sdk_values = {
+        "id": sdk_model.id,
+        "context_id": sdk_model.context_id,
+        "kind": sdk_model.kind,
+        "owner": sdk_model.owner,
+        "last_updated": sdk_model.last_updated,
+        "status": sdk_model.status,
+        "artifacts": sdk_model.artifacts,
+        "history": sdk_model.history,
+        "metadata": sdk_model.task_metadata,
+        "protocol_version": sdk_model.protocol_version,
+    }
+
+    assert compat_values == sdk_values
+
+    await store.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_database_task_store_compat_matches_sdk_from_orm_semantics(
+    tmp_path: Path,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'from-orm-parity.db'}",
+    )
+    store = build_task_store(settings)
+    raw_store = unwrap_task_store(store)
+    assert isinstance(raw_store, DatabaseTaskStore)
+
+    sdk_model = raw_store._to_orm(_rich_task("task-parity"), "owner-1")
+
+    compat_task = _task_model_to_core(
+        sdk_model,
+        model_to_core_conversion=raw_store.model_to_core_conversion,
+    )
+    sdk_task = raw_store._from_orm(sdk_model)
+
+    assert _task_to_dict(compat_task) == _task_to_dict(sdk_task)
 
     await store.engine.dispose()
 

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -27,6 +27,10 @@ from opencode_a2a.server.task_store import (
     initialize_task_store,
     unwrap_task_store,
 )
+from opencode_a2a.server.task_store_sdk_compat import (
+    DatabaseTaskStoreCompat,
+    TaskStoreSdkCompatibilityError,
+)
 from tests.support.helpers import make_request_context_mock, make_settings
 
 
@@ -325,6 +329,27 @@ async def test_policy_aware_task_store_uses_public_initialize_for_atomic_paths(
     assert called >= 3
 
 
+@pytest.mark.asyncio
+async def test_database_task_store_compat_fails_fast_on_sdk_shape_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'shape-drift.db'}",
+    )
+    store = build_task_store(settings)
+    raw_store = unwrap_task_store(store)
+    assert isinstance(raw_store, DatabaseTaskStore)
+
+    monkeypatch.delattr(raw_store, "async_session_maker", raising=True)
+
+    with pytest.raises(TaskStoreSdkCompatibilityError, match="async_session_maker"):
+        DatabaseTaskStoreCompat(raw_store)
+
+    await store.engine.dispose()
+
+
 def test_make_request_context_mock_uses_normalized_call_context() -> None:
     context = make_request_context_mock(
         task_id="task-1",
@@ -537,6 +562,47 @@ async def test_database_task_store_atomic_guard_does_not_depend_on_stale_read(
         monkeypatch.setattr(raw_second, "get", _stale_get)
         await second.save(late_completed)
         monkeypatch.setattr(raw_second, "get", original_get)
+
+        restored = await first.get("task-1")
+    finally:
+        await first.engine.dispose()
+        await second.engine.dispose()
+
+    assert restored is not None
+    assert restored.status.state == TaskState.TASK_STATE_COMPLETED
+    assert not restored.metadata
+
+
+@pytest.mark.asyncio
+async def test_database_task_store_atomic_guard_does_not_depend_on_private_from_orm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'from-orm.db'}",
+    )
+    first = build_task_store(settings)
+    second = build_task_store(settings)
+    await initialize_task_store(first)
+    await initialize_task_store(second)
+
+    try:
+        completed = _set_status(_task("task-1"), TaskState.TASK_STATE_COMPLETED)
+        await first.save(completed)
+
+        late_completed = _set_status(_task("task-1"), TaskState.TASK_STATE_COMPLETED)
+        _set_metadata(late_completed, {"opencode": {"late_mutation": True}})
+
+        raw_second = unwrap_task_store(second)
+        assert isinstance(raw_second, DatabaseTaskStore)
+
+        def _fail_private_from_orm(task_model):  # noqa: ANN001
+            del task_model
+            raise AssertionError("_from_orm should not be used by compat authoritative reload")
+
+        monkeypatch.setattr(raw_second, "_from_orm", _fail_private_from_orm)
+        await second.save(late_completed)
 
         restored = await first.get("task-1")
     finally:


### PR DESCRIPTION
## Summary
- 收敛 `task persistence` 对 `a2a-sdk` 形状的依赖：新增 `task_store_sdk_compat.py`，集中封装 `DatabaseTaskStore` 的 schema 校验、SDK shape assertion、atomic save 与 authoritative reload。
- 收敛 `task_store.py` 中分散的 SDK 依赖，让主文件只保留 terminal write policy orchestration。
- 显式固化 terminal task immutability contract：terminal task 一旦持久化即视为不可变，最终 artifact 必须先于 terminal status 发出，最终 usage / stream metadata 必须附着在 terminal event 本身。
- 补充回归测试，覆盖 SDK shape drift fail-fast、authoritative reload 不再依赖 `_from_orm()`、直接对照当前 `a2a-sdk` `_to_orm()` / `_from_orm()` 语义的 parity tests、streaming 最终 artifact 先于 terminal status 发出，以及 persisted terminal snapshot 已包含最终 artifact 与 usage metadata。

## Validation
- `bash ./scripts/doctor.sh`

## Issue Relation
- Closes #446
- Closes #444

## Review Notes
- `#446` 的目标是隔离 task persistence 热路径对 `a2a-sdk` 内部/半内部形状的耦合；本 PR 通过 compat 层集中承接该风险，并用 parity tests 约束当前 SDK 语义漂移。
- `#444` 的目标是把 terminal task immutability contract 显式化并用测试固化；本 PR 已在 coordinator、task-store policy 与英文文档中同步收口。
- 当前实现不保留旧模块导出路径兼容层，符合本服务不考虑向旧版兼容的边界。
