### PR TITLE
feat: add inbound core A2A 0.3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ curl http://127.0.0.1:8000/.well-known/agent-card.json
 
 ## A2A Protocol Support
 
-- Supported A2A protocol line: `1.0`
-- The runtime is now v1-only across HTTP+JSON, JSON-RPC, Agent Card discovery, and protocol-aware error contracts.
-- Legacy `0.3` method aliases and payload shapes are rejected instead of being normalized at runtime.
+- Supported A2A protocol lines:
+  - `1.0` as the default and discovery-first line
+  - `0.3` compatibility for SDK-backed core HTTP+JSON / JSON-RPC methods
+- Public discovery remains v1-first through `/.well-known/agent-card.json`; provider-private `opencode.*` methods remain part of the current v1 contract surface.
 - The detailed runtime contract and machine-readable support boundary are documented in [`docs/guide.md`](docs/guide.md) and [`docs/compatibility.md`](docs/compatibility.md).
 
 ## Peering Node / Outbound Access

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -6,7 +6,9 @@ This document defines the compatibility promises `opencode-a2a` currently uphold
 
 - Python versions: 3.11, 3.12, 3.13
 - A2A SDK line: `1.x.y`
-- Supported A2A protocol line: `1.0`
+- Supported A2A protocol lines:
+  - `1.0` default / discovery-first
+  - `0.3` compatibility for SDK-backed core transport methods
 
 The repository currently pins one concrete SDK release in `pyproject.toml` within that v1 line. Upgrade the SDK deliberately rather than relying on floating dependency resolution.
 
@@ -25,6 +27,7 @@ If runtime support is not implemented, do not publish it as a supported machine-
 Consumer guidance:
 
 - Treat the v1 core A2A methods (`SendMessage`, `SendStreamingMessage`, `GetTask`, `CancelTask`, `SubscribeToTask`) as the portable baseline.
+- Treat `0.3` support in this repository as a compatibility layer over that same core baseline, not as a promise that every discovery or extension surface is dual-stacked.
 - Treat `urn:opencode-a2a:extension:...` entries in this repository as repository-governed extension identifiers, not as a claim that they are part of the A2A core baseline.
 - Treat `opencode.*` methods and `metadata.opencode.*` fields as provider-private OpenCode control and discovery surfaces layered on top of the portable A2A baseline.
 - Treat [extension-specifications.md](./extension-specifications.md) as the stable URI/spec index, not as the main usage guide.
@@ -44,7 +47,7 @@ External TCK runs and local conformance experiments are investigation inputs. Th
 This repository still ships as an alpha project. Within that alpha line, these declared surfaces should not drift silently:
 
 - core A2A send / stream / task methods
-- v1-only request/response payloads and enum values
+- default v1 request/response payloads plus the declared `0.3` compatibility envelope for core methods
 - v1 protocol-aware JSON-RPC and REST error shaping
 - shared session-binding metadata
 - shared model-selection metadata
@@ -142,6 +145,6 @@ This repository does not currently promise:
 
 - hard multi-tenant isolation inside one instance
 - generic provider-auth orchestration on behalf of OpenCode
-- compatibility with legacy A2A `0.3` method aliases or payload shapes
+- `0.3` compatibility for provider-private `opencode.*` methods or every machine-readable discovery surface
 
 Those areas may evolve later, but they should not be implied by current machine-readable discovery output.

--- a/docs/conformance-triage.md
+++ b/docs/conformance-triage.md
@@ -5,16 +5,16 @@ This document summarizes the current interpretation rules for external TCK runs 
 ## Current Runtime Baseline
 
 - `opencode-a2a` now targets the `a2a-sdk 1.x.y` line
-- the runtime is v1-only
+- the runtime defaults to `1.0` and also exposes SDK-backed `0.3` compatibility for core methods
 - canonical JSON-RPC core methods are `SendMessage`, `SendStreamingMessage`, `GetTask`, `CancelTask`, and `SubscribeToTask`
-- legacy `0.3` aliases and payload shapes are intentionally rejected rather than normalized
+- provider-private `opencode.*` methods remain v1-only and are not part of the `0.3` compatibility promise
 
 ## How To Read TCK Failures
 
 When a TCK run fails, classify the result before changing the runtime:
 
 - `Runtime gap`
-  - the failure reproduces against the current v1-only runtime and contradicts the repository's declared machine-readable contract
+  - the failure reproduces against the current declared runtime contract and contradicts the repository's machine-readable discovery or docs
 - `TCK assumption mismatch`
   - the failure depends on method names, payload shapes, or schema expectations that do not match the current A2A v1 SDK/runtime contract
 - `Local experiment artifact`
@@ -24,7 +24,7 @@ When a TCK run fails, classify the result before changing the runtime:
 
 - Re-run conformance against the current runtime before using any historical triage note.
 - Treat Agent Card, authenticated extended card, OpenAPI, and runtime tests as the repository's declared source of truth.
-- Do not reopen removed `0.3` compatibility behavior just to satisfy an outdated TCK assumption.
+- Do not widen `0.3` compatibility beyond the declared core surface just to satisfy an outdated TCK assumption.
 - If a TCK gap is real, document it against the current v1 contract with the exact request/response payloads that failed.
 
 ## Historical Note

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -16,7 +16,9 @@ This guide covers configuration, authentication, API behavior, streaming re-subs
 - Payload schema is transport-specific and should not be mixed:
   - REST and JSON-RPC both use v1 `message.parts` payloads and enum values such as `ROLE_USER`
   - JSON-RPC uses canonical PascalCase core methods such as `SendMessage` and `SubscribeToTask`
-  - legacy `message.content`, lowercase roles, `{kind: ...}` wrappers, and `message/send` aliases are rejected
+  - core `0.3` compatibility is available for SDK-backed send / stream / get / cancel / subscribe methods
+  - provider-private `opencode.*` methods remain v1-only
+  - non-SDK envelopes such as `{kind: ...}` wrappers are still rejected
 
 ## Runtime Environment Variables
 
@@ -310,25 +312,25 @@ Consumer guidance:
 ## Protocol Version Negotiation
 
 - The runtime accepts `A2A-Version` from either the HTTP header or the query parameter of A2A transport requests.
-- If both are omitted, the runtime uses the fixed v1 protocol version `1.0`.
-- Machine-readable discovery still declares `default_protocol_version=1.0` and `supported_protocol_versions=["1.0"]`, but those values are runtime constants rather than operator-configurable settings.
+- If both are omitted, the runtime defaults to `1.0`. For JSON-RPC `0.3` method aliases and selected legacy REST send payload shapes, the runtime may infer `0.3` compatibility when the request is otherwise unambiguous.
+- Machine-readable discovery declares `default_protocol_version=1.0` and `supported_protocol_versions=["1.0","0.3"]`; those values are runtime constants rather than operator-configurable settings.
 - Unsupported or invalid versions are rejected before request routing:
   - JSON-RPC returns a unified `VERSION_NOT_SUPPORTED` error envelope.
   - REST returns HTTP `400` with the same contract fields.
 - Error shaping follows the v1 contract:
   - JSON-RPC keeps standard JSON-RPC error codes for standard failures and uses `google.rpc.ErrorInfo`-style `error.data[]` details for A2A-specific failures.
   - REST uses AIP-193 style `error.details[]`.
-- The runtime does not normalize legacy `0.3` method aliases or payload shapes.
+- The runtime accepts SDK-backed `0.3` compatibility for core send / stream / get / cancel / subscribe methods, but it does not extend that promise to provider-private `opencode.*` methods.
 
 Current compatibility matrix:
 
 | Area | `1.0` | Current note |
 | --- | --- | --- |
 | Version negotiation | Supported | The runtime accepts `A2A-Version` and routes requests before handler dispatch. |
-| Agent Card / interface version discovery | Supported | Agent Card publishes v1 `supportedInterfaces` entries for HTTP+JSON and JSON-RPC. |
-| Transport payloads and enums | Supported | Request/response payloads, enums, and schema details follow the current SDK-owned v1 baseline. |
+| Agent Card / interface version discovery | Supported | Agent Card publishes `1.0` as the discovery-first surface and also declares `0.3` core transport compatibility. |
+| Transport payloads and enums | Supported | `1.0` remains the default baseline; SDK-backed `0.3` compatibility is accepted on the declared core methods. |
 | Error model | Supported | JSON-RPC and REST both use the v1 protocol-aware error shapes. |
-| Pagination and list semantics | Supported | Cursor/list behavior follows the current SDK baseline. |
+| Pagination and list semantics | Supported with scope limits | v1 cursor/list behavior follows the current SDK baseline; `0.3` REST ListTasks parity is not declared. |
 | Push notification surfaces | Unsupported | SDK-owned task push-notification routes are still exposed, but this runtime does not enable push sender/config-store support. REST routes return HTTP `501`, while JSON-RPC methods remain unsupported via SDK-owned error envelopes. |
 | Signatures and authenticated data | Supported | Security schemes and authenticated extended card discovery follow the shipped SDK schema. |
 

--- a/src/opencode_a2a/cli.py
+++ b/src/opencode_a2a/cli.py
@@ -27,7 +27,7 @@ HELP_FLAGS = frozenset({"-h", "--help"})
 
 ROOT_DESCRIPTION = (
     "OpenCode A2A runtime for explicit service startup and peer calls. "
-    "A2A Protocol 1.0 only.\n"
+    "Inbound core A2A supports 1.0 plus 0.3 compatibility; outbound peer calls remain 1.0.\n"
     "  opencode-a2a <command> [arguments] [options]"
 )
 
@@ -248,7 +248,9 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser(
         "serve",
         help="Run the A2A service.",
-        description="Run the OpenCode A2A service. A2A Protocol 1.0 only.",
+        description=(
+            "Run the OpenCode A2A service. Inbound core A2A supports 1.0 plus 0.3 compatibility."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=SERVE_HELP_EPILOG,
     )
@@ -256,7 +258,10 @@ def build_parser() -> argparse.ArgumentParser:
     call_parser = subparsers.add_parser(
         "call",
         help="Call an A2A agent.",
-        description="Call an A2A agent using the A2A protocol. A2A Protocol 1.0 only.",
+        description=(
+            "Call an A2A agent using the A2A protocol. "
+            "Outbound peer calls currently use the 1.0 contract."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=CALL_HELP_EPILOG,
     )

--- a/src/opencode_a2a/contracts/extensions/compatibility.py
+++ b/src/opencode_a2a/contracts/extensions/compatibility.py
@@ -280,6 +280,33 @@ def build_protocol_compatibility_params(
             ],
             "known_gaps": [],
         },
+        "0.3": {
+            "enabled": "0.3" in declared_supported_versions,
+            "default": default_protocol_version == "0.3",
+            "status": "compatibility",
+            "supported_features": [
+                "SDK-backed JSON-RPC legacy method aliases on the shared root endpoint.",
+                (
+                    "SDK-backed REST compatibility for the portable "
+                    "send/get/cancel/subscribe baseline."
+                ),
+                (
+                    "Shared runtime can preserve the v1.0 default path "
+                    "while accepting explicit 0.3 requests."
+                ),
+            ],
+            "known_gaps": [
+                (
+                    "Portable compatibility is limited to the SDK-owned "
+                    "core surface, not provider-private opencode.* methods."
+                ),
+                (
+                    "REST compatibility for ambiguous routes may require "
+                    "an explicit A2A-Version=0.3 signal."
+                ),
+                "SDK-owned 0.3 REST ListTasks parity is not declared by this deployment.",
+            ],
+        },
     }
 
     for version in declared_supported_versions:

--- a/src/opencode_a2a/jsonrpc/application.py
+++ b/src/opencode_a2a/jsonrpc/application.py
@@ -358,6 +358,18 @@ class OpencodeSessionManagementJSONRPCApplication(JsonRpcDispatcher):
         except Exception:
             return await super().handle_requests(request)
 
+        if (
+            self.enable_v0_3_compat
+            and self._v03_adapter is not None
+            and self._v03_adapter.supports_method(base_request.method)
+        ):
+            return await self._v03_adapter.handle_request(
+                request_id=base_request.id,
+                method=base_request.method,
+                body=body,
+                request=request,
+            )
+
         extension_spec = self._extension_method_registry.resolve(base_request.method)
         if extension_spec is None:
             return await self._handle_core_request(

--- a/src/opencode_a2a/jsonrpc/application.py
+++ b/src/opencode_a2a/jsonrpc/application.py
@@ -22,6 +22,7 @@ from ..extension_negotiation import (
     requested_extensions_from_call_context,
 )
 from ..opencode_upstream_client import OpencodeUpstreamClient
+from ..protocol_versions import A2A_PROTOCOL_VERSION
 from .dispatch import (
     ExtensionHandlerContext,
     build_extension_method_registry,
@@ -34,6 +35,15 @@ from .error_responses import (
 from .models import JSONRPCError, JSONRPCRequest
 
 logger = logging.getLogger(__name__)
+_SUPPORTED_V03_JSONRPC_METHODS = frozenset(
+    {
+        "message/send",
+        "message/stream",
+        "tasks/get",
+        "tasks/cancel",
+        "tasks/resubscribe",
+    }
+)
 _PUSH_NOTIFICATION_METHODS = frozenset(
     {
         "CreateTaskPushNotificationConfig",
@@ -311,6 +321,11 @@ class OpencodeSessionManagementJSONRPCApplication(JsonRpcDispatcher):
                 method_not_supported_error(
                     method=base_request.method,
                     supported_methods=self._supported_methods,
+                    protocol_version=getattr(
+                        request.state,
+                        "a2a_protocol_version",
+                        A2A_PROTOCOL_VERSION,
+                    ),
                 ),
             )
 
@@ -361,7 +376,7 @@ class OpencodeSessionManagementJSONRPCApplication(JsonRpcDispatcher):
         if (
             self.enable_v0_3_compat
             and self._v03_adapter is not None
-            and self._v03_adapter.supports_method(base_request.method)
+            and base_request.method in _SUPPORTED_V03_JSONRPC_METHODS
         ):
             return await self._v03_adapter.handle_request(
                 request_id=base_request.id,

--- a/src/opencode_a2a/jsonrpc/error_responses.py
+++ b/src/opencode_a2a/jsonrpc/error_responses.py
@@ -190,6 +190,7 @@ def method_not_supported_error(
     *,
     method: str,
     supported_methods: list[str],
+    protocol_version: str = A2A_PROTOCOL_VERSION,
 ) -> JSONRPCError:
     return JSONRPCError(
         code=-32601,
@@ -198,7 +199,7 @@ def method_not_supported_error(
             "type": "METHOD_NOT_SUPPORTED",
             "method": method,
             "supported_methods": supported_methods,
-            "protocol_version": A2A_PROTOCOL_VERSION,
+            "protocol_version": protocol_version,
         },
     )
 

--- a/src/opencode_a2a/protocol_versions.py
+++ b/src/opencode_a2a/protocol_versions.py
@@ -3,18 +3,20 @@ from __future__ import annotations
 import re
 
 _PROTOCOL_VERSION_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?$")
+A2A_PROTOCOL_VERSION_V0_3 = "0.3"
 A2A_PROTOCOL_VERSION = "1.0"
-A2A_SUPPORTED_PROTOCOL_VERSIONS = (A2A_PROTOCOL_VERSION,)
+A2A_DEFAULT_PROTOCOL_VERSION = A2A_PROTOCOL_VERSION
+A2A_SUPPORTED_PROTOCOL_VERSIONS = (A2A_PROTOCOL_VERSION, A2A_PROTOCOL_VERSION_V0_3)
 
 
 class UnsupportedProtocolVersionError(ValueError):
     def __init__(self, requested_version: str) -> None:
         self.requested_version = requested_version
         self.supported_protocol_versions = A2A_SUPPORTED_PROTOCOL_VERSIONS
-        self.default_protocol_version = A2A_PROTOCOL_VERSION
+        self.default_protocol_version = A2A_DEFAULT_PROTOCOL_VERSION
         super().__init__(
             f"Unsupported A2A protocol version {requested_version!r}. "
-            f"Supported versions: {A2A_PROTOCOL_VERSION}."
+            f"Supported versions: {', '.join(A2A_SUPPORTED_PROTOCOL_VERSIONS)}."
         )
 
 
@@ -32,17 +34,18 @@ def negotiate_protocol_version(
     *,
     header_value: str | None,
     query_value: str | None,
+    default_version: str = A2A_DEFAULT_PROTOCOL_VERSION,
 ) -> str:
     raw_header = (header_value or "").strip()
     raw_query = (query_value or "").strip()
-    raw_requested = raw_header or raw_query or A2A_PROTOCOL_VERSION
+    raw_requested = raw_header or raw_query or default_version
 
     try:
         normalized_requested = normalize_protocol_version(raw_requested)
     except ValueError as exc:
         raise UnsupportedProtocolVersionError(raw_requested) from exc
 
-    if normalized_requested != A2A_PROTOCOL_VERSION:
+    if normalized_requested not in A2A_SUPPORTED_PROTOCOL_VERSIONS:
         raise UnsupportedProtocolVersionError(normalized_requested)
 
     return normalized_requested

--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -48,7 +48,11 @@ from ..contracts.extensions import (
 )
 from ..jsonrpc.methods import SESSION_CONTEXT_PREFIX
 from ..profile.runtime import RuntimeProfile, build_runtime_profile
-from ..protocol_versions import A2A_PROTOCOL_VERSION
+from ..protocol_versions import (
+    A2A_PROTOCOL_VERSION,
+    A2A_PROTOCOL_VERSION_V0_3,
+    A2A_SUPPORTED_PROTOCOL_VERSIONS,
+)
 
 _CHAT_INPUT_MODES = ["text/plain", "application/octet-stream"]
 _CHAT_OUTPUT_MODES = ["text/plain", "application/json"]
@@ -203,10 +207,14 @@ def _build_agent_extensions(
     compatibility_profile_params = build_compatibility_profile_params(
         protocol_version=A2A_PROTOCOL_VERSION,
         runtime_profile=runtime_profile,
+        supported_protocol_versions=A2A_SUPPORTED_PROTOCOL_VERSIONS,
+        default_protocol_version=A2A_PROTOCOL_VERSION,
     )
     wire_contract_params = build_wire_contract_params(
         protocol_version=A2A_PROTOCOL_VERSION,
         runtime_profile=runtime_profile,
+        supported_protocol_versions=A2A_SUPPORTED_PROTOCOL_VERSIONS,
+        default_protocol_version=A2A_PROTOCOL_VERSION,
     )
 
     public_extensions = [
@@ -524,6 +532,16 @@ def build_agent_card(
                 url=public_url,
                 protocol_binding="JSONRPC",
                 protocol_version=A2A_PROTOCOL_VERSION,
+            ),
+            AgentInterface(
+                url=public_url,
+                protocol_binding="HTTP+JSON",
+                protocol_version=A2A_PROTOCOL_VERSION_V0_3,
+            ),
+            AgentInterface(
+                url=public_url,
+                protocol_binding="JSONRPC",
+                protocol_version=A2A_PROTOCOL_VERSION_V0_3,
             ),
         ],
         default_input_modes=list(_CHAT_INPUT_MODES),

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from collections.abc import Mapping
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import uvicorn
-from a2a.compat.v0_3.rest_adapter import REST03Adapter
+from a2a.compat.v0_3.context_builders import V03ServerCallContextBuilder
+from a2a.compat.v0_3.rest_handler import REST03Handler
 from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventConsumer, EventQueueLegacy
 from a2a.server.request_handlers.default_request_handler import (
@@ -41,10 +43,17 @@ from a2a.types import (
     UnsupportedOperationError,
 )
 from a2a.utils import proto_utils
+from a2a.utils.error_handlers import (
+    rest_error_handler,
+    rest_stream_error_handler,
+)
 from a2a.utils.errors import (
     A2A_REST_ERROR_MAPPING,
     A2AError,
     RestErrorMap,
+)
+from a2a.utils.errors import (
+    InvalidRequestError as UtilsInvalidRequestError,
 )
 from a2a.utils.task import apply_history_length, validate_history_length
 from fastapi import FastAPI, Request
@@ -52,6 +61,7 @@ from fastapi.responses import JSONResponse, Response
 from google.protobuf.json_format import MessageToDict, ParseDict, ParseError
 from google.protobuf.message import Message as ProtoMessage
 from pydantic_settings import BaseSettings
+from sse_starlette.sse import EventSourceResponse
 from starlette.middleware.gzip import GZipMiddleware
 
 from ..a2a_protocol import (
@@ -120,6 +130,82 @@ from .task_store import (
 logger = logging.getLogger(__name__)
 TASK_STORE_ERROR_TYPE = "TASK_STORE_UNAVAILABLE"
 PUSH_NOTIFICATIONS_UNSUPPORTED_MESSAGE = "Push notifications are not supported by the agent"
+
+
+def _build_rest03_routes(
+    *,
+    http_handler: LegacyRequestHandler,
+    context_builder: DefaultServerCallContextBuilder,
+) -> dict[tuple[str, str], Any]:
+    rest03_handler = REST03Handler(request_handler=http_handler)
+    rest03_context_builder = V03ServerCallContextBuilder(context_builder)
+
+    @rest_error_handler
+    async def _handle_request(method: Any, request: Request) -> Response:
+        call_context = rest03_context_builder.build(request)
+        response = await method(request, call_context)
+        return JSONResponse(content=response)
+
+    @rest_stream_error_handler
+    async def _handle_streaming_request(method: Any, request: Request) -> EventSourceResponse:
+        try:
+            await request.body()
+        except (ValueError, RuntimeError, OSError) as error:
+            raise UtilsInvalidRequestError(
+                message=f"Failed to pre-consume request body: {error}"
+            ) from error
+
+        call_context = rest03_context_builder.build(request)
+
+        async def event_generator(stream: Any):
+            async for item in stream:
+                yield json.dumps(item)
+
+        return EventSourceResponse(event_generator(method(request, call_context)))
+
+    return {
+        ("/v1/message:send", "POST"): partial(_handle_request, rest03_handler.on_message_send),
+        ("/v1/message:stream", "POST"): partial(
+            _handle_streaming_request,
+            rest03_handler.on_message_send_stream,
+        ),
+        ("/v1/tasks/{id}:cancel", "POST"): partial(
+            _handle_request,
+            rest03_handler.on_cancel_task,
+        ),
+        ("/v1/tasks/{id}:subscribe", "GET"): partial(
+            _handle_streaming_request,
+            rest03_handler.on_subscribe_to_task,
+        ),
+        ("/v1/tasks/{id}:subscribe", "POST"): partial(
+            _handle_streaming_request,
+            rest03_handler.on_subscribe_to_task,
+        ),
+        ("/v1/tasks/{id}", "GET"): partial(
+            _handle_request,
+            rest03_handler.on_get_task,
+        ),
+        ("/v1/tasks/{id}/pushNotificationConfigs/{push_id}", "GET"): partial(
+            _handle_request,
+            rest03_handler.get_push_notification,
+        ),
+        ("/v1/tasks/{id}/pushNotificationConfigs", "POST"): partial(
+            _handle_request,
+            rest03_handler.set_push_notification,
+        ),
+        ("/v1/tasks/{id}/pushNotificationConfigs", "GET"): partial(
+            _handle_request,
+            rest03_handler.list_push_notifications,
+        ),
+        ("/v1/tasks", "GET"): partial(
+            _handle_request,
+            rest03_handler.list_tasks,
+        ),
+        ("/v1/card", "GET"): partial(
+            _handle_request,
+            rest03_handler.on_get_extended_agent_card,
+        ),
+    }
 
 
 def _rest_error_response(
@@ -894,11 +980,10 @@ def create_app(settings: Settings) -> FastAPI:
         request_handler=handler,
         context_builder=context_builder,
     )
-    rest03_adapter = REST03Adapter(
+    rest03_routes = _build_rest03_routes(
         http_handler=handler,
         context_builder=context_builder,
     )
-    rest03_routes = rest03_adapter.routes()
     public_card_etag = build_agent_card_etag(agent_card)
     extended_card_etag = build_agent_card_etag(extended_agent_card)
     persistence_summary = describe_lightweight_persistence_backend(settings)

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -7,6 +7,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import uvicorn
+from a2a.compat.v0_3.rest_adapter import REST03Adapter
 from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventConsumer, EventQueueLegacy
 from a2a.server.request_handlers.default_request_handler import (
@@ -47,7 +48,7 @@ from a2a.utils.errors import (
 )
 from a2a.utils.task import apply_history_length, validate_history_length
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from google.protobuf.json_format import MessageToDict, ParseDict, ParseError
 from google.protobuf.message import Message as ProtoMessage
 from pydantic_settings import BaseSettings
@@ -85,7 +86,7 @@ from ..output_modes import (
     normalize_accepted_output_modes,
 )
 from ..profile.runtime import build_runtime_profile
-from ..protocol_versions import A2A_PROTOCOL_VERSION
+from ..protocol_versions import A2A_PROTOCOL_VERSION, A2A_PROTOCOL_VERSION_V0_3
 from ..trace_context import install_log_record_factory
 from .agent_card import (
     _CHAT_OUTPUT_MODES,
@@ -869,6 +870,7 @@ def create_app(settings: Settings) -> FastAPI:
     jsonrpc_app = OpencodeSessionManagementJSONRPCApplication(
         http_handler=handler,
         context_builder=context_builder,
+        enable_v0_3_compat=True,
         upstream_client=upstream_client,
         supported_methods=capability_snapshot.supported_jsonrpc_methods(),
         directory_resolver=(
@@ -892,6 +894,11 @@ def create_app(settings: Settings) -> FastAPI:
         request_handler=handler,
         context_builder=context_builder,
     )
+    rest03_adapter = REST03Adapter(
+        http_handler=handler,
+        context_builder=context_builder,
+    )
+    rest03_routes = rest03_adapter.routes()
     public_card_etag = build_agent_card_etag(agent_card)
     extended_card_etag = build_agent_card_etag(extended_agent_card)
     persistence_summary = describe_lightweight_persistence_backend(settings)
@@ -918,7 +925,17 @@ def create_app(settings: Settings) -> FastAPI:
     async def authenticated_extended_agent_card_route() -> JSONResponse:
         return JSONResponse(agent_card_to_dict(extended_agent_card))
 
+    def _is_v03_request(request: Request) -> bool:
+        return getattr(request.state, "a2a_protocol_version", A2A_PROTOCOL_VERSION) == (
+            A2A_PROTOCOL_VERSION_V0_3
+        )
+
+    def _rest03_route(path: str, method: str):
+        return rest03_routes[(path, method)]
+
     async def rest_message_send_route(request: Request) -> JSONResponse:
+        if _is_v03_request(request):
+            return cast(JSONResponse, await _rest03_route("/v1/message:send", "POST")(request))
         try:
 
             async def _handler(context) -> SendMessageResponse:  # noqa: ANN001
@@ -937,6 +954,8 @@ def create_app(settings: Settings) -> FastAPI:
             )
 
     async def rest_message_send_stream_route(request: Request):
+        if _is_v03_request(request):
+            return await _rest03_route("/v1/message:stream", "POST")(request)
         try:
 
             async def _handler(context):  # noqa: ANN001
@@ -951,23 +970,59 @@ def create_app(settings: Settings) -> FastAPI:
                 error=error,
             )
 
+    async def rest_cancel_task_route(request: Request) -> Response:
+        if _is_v03_request(request):
+            return cast(Response, await _rest03_route("/v1/tasks/{id}:cancel", "POST")(request))
+        return await rest_dispatcher.on_cancel_task(request)
+
+    async def rest_subscribe_task_route(request: Request) -> Response:
+        if _is_v03_request(request):
+            return cast(
+                Response,
+                await _rest03_route("/v1/tasks/{id}:subscribe", request.method)(request),
+            )
+        return cast(Response, await rest_dispatcher.on_subscribe_to_task(request))
+
+    async def rest_get_task_route(request: Request) -> Response:
+        if _is_v03_request(request):
+            return cast(Response, await _rest03_route("/v1/tasks/{id}", "GET")(request))
+        return await rest_dispatcher.on_get_task(request)
+
+    list_tasks_v1_route = build_list_tasks_route(
+        task_store=task_store,
+        context_builder=context_builder.build,
+    )
+
+    async def list_tasks_route(request: Request) -> JSONResponse:
+        if _is_v03_request(request):
+            return JSONResponse(
+                build_http_error_body(
+                    status_code=501,
+                    status="UNIMPLEMENTED",
+                    message="ListTasks is not supported for A2A 0.3 compatibility mode.",
+                    reason="LIST_TASKS_V03_UNSUPPORTED",
+                ),
+                status_code=501,
+            )
+        return cast(JSONResponse, await list_tasks_v1_route(request))
+
     app.add_api_route(AGENT_CARD_WELL_KNOWN_PATH, public_agent_card_route, methods=["GET"])
     app.add_api_route("/v1/message:send", rest_message_send_route, methods=["POST"])
     app.add_api_route("/v1/message:stream", rest_message_send_stream_route, methods=["POST"])
-    app.add_api_route("/v1/tasks/{id}:cancel", rest_dispatcher.on_cancel_task, methods=["POST"])
+    app.add_api_route("/v1/tasks/{id}:cancel", rest_cancel_task_route, methods=["POST"])
     app.add_api_route(
         "/v1/tasks/{id}:subscribe",
-        rest_dispatcher.on_subscribe_to_task,
+        rest_subscribe_task_route,
         methods=["GET"],
         operation_id="subscribe_to_task_get",
     )
     app.add_api_route(
         "/v1/tasks/{id}:subscribe",
-        rest_dispatcher.on_subscribe_to_task,
+        rest_subscribe_task_route,
         methods=["POST"],
         operation_id="subscribe_to_task_post",
     )
-    app.add_api_route("/v1/tasks/{id}", rest_dispatcher.on_get_task, methods=["GET"])
+    app.add_api_route("/v1/tasks/{id}", rest_get_task_route, methods=["GET"])
 
     async def push_notifications_unsupported_route(request: Request) -> JSONResponse:
         del request
@@ -1003,12 +1058,10 @@ def create_app(settings: Settings) -> FastAPI:
     )
     app.add_api_route(
         "/v1/tasks",
-        build_list_tasks_route(
-            task_store=task_store,
-            context_builder=context_builder.build,
-        ),
+        list_tasks_route,
         methods=["GET"],
     )
+    app.add_api_route("/v1/card", _rest03_route("/v1/card", "GET"), methods=["GET"])
     app.add_api_route(
         EXTENDED_AGENT_CARD_PATH,
         authenticated_extended_agent_card_route,

--- a/src/opencode_a2a/server/middleware.py
+++ b/src/opencode_a2a/server/middleware.py
@@ -62,12 +62,7 @@ _V03_JSONRPC_METHODS = frozenset(
         "message/stream",
         "tasks/get",
         "tasks/cancel",
-        "tasks/pushNotificationConfig/set",
-        "tasks/pushNotificationConfig/get",
-        "tasks/pushNotificationConfig/list",
-        "tasks/pushNotificationConfig/delete",
         "tasks/resubscribe",
-        "agent/getAuthenticatedExtendedCard",
     }
 )
 _REQUEST_BODY_BYTES: ContextVar[bytes | None] = ContextVar(

--- a/src/opencode_a2a/server/middleware.py
+++ b/src/opencode_a2a/server/middleware.py
@@ -29,6 +29,8 @@ from ..jsonrpc.error_responses import (
 )
 from ..jsonrpc.models import JSONRPCError
 from ..protocol_versions import (
+    A2A_DEFAULT_PROTOCOL_VERSION,
+    A2A_PROTOCOL_VERSION_V0_3,
     UnsupportedProtocolVersionError,
     negotiate_protocol_version,
 )
@@ -54,6 +56,20 @@ from .request_parsing import (
 logger = logging.getLogger("opencode_a2a.server.application")
 PUBLIC_AGENT_CARD_CACHE_CONTROL = "public, max-age=300"
 AUTHENTICATED_EXTENDED_CARD_CACHE_CONTROL = "private, max-age=300"
+_V03_JSONRPC_METHODS = frozenset(
+    {
+        "message/send",
+        "message/stream",
+        "tasks/get",
+        "tasks/cancel",
+        "tasks/pushNotificationConfig/set",
+        "tasks/pushNotificationConfig/get",
+        "tasks/pushNotificationConfig/list",
+        "tasks/pushNotificationConfig/delete",
+        "tasks/resubscribe",
+        "agent/getAuthenticatedExtendedCard",
+    }
+)
 _REQUEST_BODY_BYTES: ContextVar[bytes | None] = ContextVar(
     "_REQUEST_BODY_BYTES",
     default=None,
@@ -139,6 +155,45 @@ def install_runtime_middlewares(
             return request_id
         return None
 
+    def _looks_like_v03_jsonrpc_method(payload: object) -> bool:
+        if not isinstance(payload, dict):
+            return False
+        method = payload.get("method")
+        return isinstance(method, str) and method in _V03_JSONRPC_METHODS
+
+    def _looks_like_v03_rest_message_payload(payload: object) -> bool:
+        if not isinstance(payload, dict):
+            return False
+        message = payload.get("message")
+        if not isinstance(message, dict):
+            return False
+        if "content" in message:
+            return True
+        parts = message.get("parts")
+        if not isinstance(parts, list):
+            return False
+        return any(isinstance(part, dict) and "file" in part for part in parts)
+
+    async def _infer_default_protocol_version(request: Request) -> tuple[str, Token | None]:
+        if request.url.path == "/v1/card":
+            return A2A_PROTOCOL_VERSION_V0_3, None
+        if request.url.path == "/" and request.method == "POST":
+            body, token = await _get_request_body(request)
+            payload = _parse_json_body(body)
+            if _looks_like_v03_jsonrpc_method(payload):
+                return A2A_PROTOCOL_VERSION_V0_3, token
+            return A2A_DEFAULT_PROTOCOL_VERSION, token
+        if request.method == "POST" and request.url.path in {
+            "/v1/message:send",
+            "/v1/message:stream",
+        }:
+            body, token = await _get_request_body(request)
+            payload = _parse_json_body(body)
+            if _looks_like_v03_rest_message_payload(payload):
+                return A2A_PROTOCOL_VERSION_V0_3, token
+            return A2A_DEFAULT_PROTOCOL_VERSION, token
+        return A2A_DEFAULT_PROTOCOL_VERSION, None
+
     @app.middleware("http")
     async def bind_trace_context(request: Request, call_next):
         trace_context = resolve_trace_context(
@@ -164,9 +219,16 @@ def install_runtime_middlewares(
             return await call_next(request)
 
         try:
+            explicit_version = request.headers.get("A2A-Version") or request.query_params.get(
+                "A2A-Version"
+            )
+            default_version = A2A_DEFAULT_PROTOCOL_VERSION
+            if not explicit_version:
+                default_version, token = await _infer_default_protocol_version(request)
             negotiated_version = negotiate_protocol_version(
                 header_value=request.headers.get("A2A-Version"),
                 query_value=request.query_params.get("A2A-Version"),
+                default_version=default_version,
             )
         except UnsupportedProtocolVersionError as error:
             if request.url.path == "/" and request.method == "POST":

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -90,7 +90,7 @@ def test_settings_valid():
         assert settings.a2a_task_store_database_url == "sqlite+aiosqlite:///./opencode-a2a.db"
         assert settings.a2a_version == __version__
         assert A2A_PROTOCOL_VERSION == "1.0"
-        assert A2A_SUPPORTED_PROTOCOL_VERSIONS == ("1.0",)
+        assert A2A_SUPPORTED_PROTOCOL_VERSIONS == ("1.0", "0.3")
 
 
 def test_settings_allow_explicit_memory_backend() -> None:

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -38,7 +38,7 @@ from opencode_a2a.contracts.extensions import (
 )
 from opencode_a2a.jsonrpc.methods import SESSION_CONTEXT_PREFIX
 from opencode_a2a.profile.runtime import build_runtime_profile
-from opencode_a2a.protocol_versions import A2A_PROTOCOL_VERSION
+from opencode_a2a.protocol_versions import A2A_PROTOCOL_VERSION, A2A_SUPPORTED_PROTOCOL_VERSIONS
 from opencode_a2a.server.agent_card import build_agent_card
 from opencode_a2a.server.application import create_app
 from tests.support.helpers import (
@@ -114,10 +114,14 @@ def test_extension_ssot_matches_agent_card_contracts() -> None:
     expected_compatibility_profile = build_compatibility_profile_params(
         protocol_version=A2A_PROTOCOL_VERSION,
         runtime_profile=runtime_profile,
+        supported_protocol_versions=A2A_SUPPORTED_PROTOCOL_VERSIONS,
+        default_protocol_version=A2A_PROTOCOL_VERSION,
     )
     expected_wire_contract = build_wire_contract_params(
         protocol_version=A2A_PROTOCOL_VERSION,
         runtime_profile=runtime_profile,
+        supported_protocol_versions=A2A_SUPPORTED_PROTOCOL_VERSIONS,
+        default_protocol_version=A2A_PROTOCOL_VERSION,
     )
 
     assert session_binding.params == expected_session_binding, (

--- a/tests/jsonrpc/test_jsonrpc_unsupported_method.py
+++ b/tests/jsonrpc/test_jsonrpc_unsupported_method.py
@@ -65,6 +65,36 @@ async def test_unsupported_method_uses_requested_protocol_version() -> None:
 
 
 @pytest.mark.asyncio
+async def test_v03_push_notification_alias_returns_method_not_found() -> None:
+    settings = make_settings(test_bearer_token="test-token")
+    app = create_app(settings)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/",
+            headers={
+                "Authorization": "Bearer test-token",
+                "A2A-Version": "0.3",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 124,
+                "method": "tasks/pushNotificationConfig/list",
+                "params": {"id": "task-1"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["A2A-Version"] == "0.3"
+    body = response.json()
+    assert body["error"]["code"] == -32601
+    assert body["error"]["message"] == "Method not found"
+    assert body["error"]["data"]["method"] == "tasks/pushNotificationConfig/list"
+    assert body["error"]["data"]["protocolVersion"] == "0.3"
+
+
+@pytest.mark.asyncio
 async def test_sendmessage_uses_canonical_v1_method_dispatch() -> None:
     settings = make_settings(test_bearer_token="test-token")
     app = create_app(settings)

--- a/tests/jsonrpc/test_jsonrpc_unsupported_method.py
+++ b/tests/jsonrpc/test_jsonrpc_unsupported_method.py
@@ -107,7 +107,7 @@ async def test_unsupported_v1_minor_version_returns_v1_error_details() -> None:
         "domain": "a2a-protocol.org",
         "metadata": {
             "requestedVersion": "1.1",
-            "supportedProtocolVersions": '["1.0"]',
+            "supportedProtocolVersions": '["1.0","0.3"]',
             "defaultProtocolVersion": "1.0",
         },
     }
@@ -137,7 +137,7 @@ async def test_unsupported_version_returns_version_error() -> None:
         "domain": "a2a-protocol.org",
         "metadata": {
             "requestedVersion": "2.0",
-            "supportedProtocolVersions": '["1.0"]',
+            "supportedProtocolVersions": '["1.0","0.3"]',
             "defaultProtocolVersion": "1.0",
         },
     }

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -21,6 +21,7 @@ from opencode_a2a.contracts.extensions import (
     build_service_behavior_contract_params,
 )
 from opencode_a2a.jsonrpc.methods import SESSION_CONTEXT_PREFIX
+from opencode_a2a.protocol_versions import A2A_SUPPORTED_PROTOCOL_VERSIONS
 from opencode_a2a.server.agent_card import (
     build_agent_card,
 )
@@ -48,7 +49,12 @@ def test_agent_card_description_reflects_actual_transport_capabilities() -> None
     ] == [
         ("HTTP+JSON", "1.0"),
         ("JSONRPC", "1.0"),
+        ("HTTP+JSON", "0.3"),
+        ("JSONRPC", "0.3"),
     ]
+    assert {iface.protocol_version for iface in card.supported_interfaces} == set(
+        A2A_SUPPORTED_PROTOCOL_VERSIONS
+    )
     assert card.default_input_modes == ["text/plain", "application/octet-stream"]
     assert card.default_output_modes == ["text/plain", "application/json"]
     assert set(card.security_schemes.keys()) == {"bearerAuth"}
@@ -675,7 +681,7 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
     expected_service_behaviors = build_service_behavior_contract_params()
     expected_protocol_compatibility = build_protocol_compatibility_params(
-        supported_protocol_versions=["1.0"],
+        supported_protocol_versions=["1.0", "0.3"],
         default_protocol_version="1.0",
     )
     assert compatibility.params["extension_retention"][MODEL_SELECTION_EXTENSION_URI] == {
@@ -769,7 +775,7 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     wire_contract = ext_by_uri[WIRE_CONTRACT_EXTENSION_URI]
     assert wire_contract.params["profile"]["profile_id"] == "opencode-a2a-single-tenant-coding-v1"
     assert wire_contract.params["default_protocol_version"] == "1.0"
-    assert wire_contract.params["supported_protocol_versions"] == ["1.0"]
+    assert wire_contract.params["supported_protocol_versions"] == ["1.0", "0.3"]
     assert wire_contract.params["protocol_compatibility"] == expected_protocol_compatibility
     assert MODEL_SELECTION_EXTENSION_URI in wire_contract.params["extensions"]["extension_uris"]
     assert PROVIDER_DISCOVERY_EXTENSION_URI in wire_contract.params["extensions"]["extension_uris"]

--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -15,7 +15,8 @@ def test_cli_help_does_not_require_runtime_settings(capsys: pytest.CaptureFixtur
     assert excinfo.value.code == 0
     help_text = capsys.readouterr().out
     assert (
-        "OpenCode A2A runtime for explicit service startup and peer calls. A2A Protocol 1.0 only."
+        "OpenCode A2A runtime for explicit service startup and peer calls. "
+        "Inbound core A2A supports 1.0 plus 0.3 compatibility; outbound peer calls remain 1.0."
     ) in help_text
     assert "___                    ____" in help_text
     assert "| | | | '_ \\ / _ \\ '_ \\| |   / _ \\ / _` |/ _ \\_____ / _ \\" in help_text
@@ -78,7 +79,9 @@ def test_cli_serve_subcommand_with_invalid_configuration_prints_help(
             assert cli.main(["serve"]) == 0
 
     help_text = capsys.readouterr().out
-    assert "Run the OpenCode A2A service. A2A Protocol 1.0 only." in help_text
+    assert (
+        "Run the OpenCode A2A service. Inbound core A2A supports 1.0 plus 0.3 compatibility."
+    ) in help_text
     assert "configuration errors:" in help_text
     assert "Configure runtime authentication via A2A_STATIC_AUTH_CREDENTIALS" in help_text
     serve_mock.assert_not_called()
@@ -91,7 +94,10 @@ def test_cli_call_without_required_arguments_prints_help(
         assert cli.main(["call"]) == 0
 
     help_text = capsys.readouterr().out
-    assert "Call an A2A agent using the A2A protocol. A2A Protocol 1.0 only." in help_text
+    assert (
+        "Call an A2A agent using the A2A protocol. "
+        "Outbound peer calls currently use the 1.0 contract."
+    ) in help_text
     assert "A2A_CLIENT_BEARER_TOKEN=peer-token" in help_text
     assert "Service base URLs also work, but card URLs are the preferred example form." in help_text
     serve_mock.assert_not_called()

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -120,6 +120,8 @@ def test_agent_card_declares_dual_stack_with_http_json_preferred() -> None:
     }
     assert ("HTTP+JSON", "1.0") in interfaces
     assert ("JSONRPC", "1.0") in interfaces
+    assert ("HTTP+JSON", "0.3") in interfaces
+    assert ("JSONRPC", "0.3") in interfaces
 
 
 def test_normalize_log_level_falls_back_to_warning_for_invalid_value() -> None:
@@ -980,14 +982,14 @@ async def test_rest_endpoints_reject_unsupported_protocol_version() -> None:
                     "domain": "a2a-protocol.org",
                     "metadata": {
                         "requestedVersion": "2.0",
-                        "supportedProtocolVersions": '["1.0"]',
+                        "supportedProtocolVersions": '["1.0","0.3"]',
                         "defaultProtocolVersion": "1.0",
                     },
                 },
                 {
                     "@type": "type.googleapis.com/opencode_a2a.HttpErrorContext",
                     "requestedVersion": "2.0",
-                    "supportedProtocolVersions": ["1.0"],
+                    "supportedProtocolVersions": ["1.0", "0.3"],
                     "defaultProtocolVersion": "1.0",
                 },
             ],
@@ -1026,14 +1028,14 @@ async def test_rest_endpoints_return_v1_status_body_for_v1_protocol_errors() -> 
                     "domain": "a2a-protocol.org",
                     "metadata": {
                         "requestedVersion": "1.1",
-                        "supportedProtocolVersions": '["1.0"]',
+                        "supportedProtocolVersions": '["1.0","0.3"]',
                         "defaultProtocolVersion": "1.0",
                     },
                 },
                 {
                     "@type": "type.googleapis.com/opencode_a2a.HttpErrorContext",
                     "requestedVersion": "1.1",
-                    "supportedProtocolVersions": ["1.0"],
+                    "supportedProtocolVersions": ["1.0", "0.3"],
                     "defaultProtocolVersion": "1.0",
                 },
             ],
@@ -1210,6 +1212,77 @@ async def test_v1_pascalcase_sendmessage_alias_is_accepted(monkeypatch) -> None:
     assert rpc_resp.status_code == 200
     assert rpc_resp.headers["A2A-Version"] == "1.0"
     assert rpc_resp.json().get("error") is None
+
+
+@pytest.mark.asyncio
+async def test_v03_jsonrpc_send_alias_is_accepted_without_explicit_version_header(
+    monkeypatch,
+) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = app_module.create_app(make_settings(test_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 8,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "m-rpc-v03",
+                "role": "user",
+                "parts": [{"text": "hello from v0.3 dispatch"}],
+            }
+        },
+    }
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        rpc_resp = await client.post("/", headers=headers, json=payload)
+
+    assert rpc_resp.status_code == 200
+    assert rpc_resp.headers["A2A-Version"] == "0.3"
+    assert rpc_resp.json()["result"]["status"]["state"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_v03_rest_send_accepts_legacy_message_content_shape(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = app_module.create_app(make_settings(test_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "message": {
+            "role": "ROLE_USER",
+            "content": [{"text": "hello from v0.3 rest"}],
+        }
+    }
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        rest_resp = await client.post("/v1/message:send", headers=headers, json=payload)
+
+    assert rest_resp.status_code == 200
+    assert rest_resp.headers["A2A-Version"] == "0.3"
+    assert rest_resp.json()["task"]["status"]["state"] == "TASK_STATE_WORKING"
+
+
+@pytest.mark.asyncio
+async def test_v03_rest_card_endpoint_is_available(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = app_module.create_app(make_settings(test_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        card_resp = await client.get("/v1/card", headers=headers)
+
+    assert card_resp.status_code == 200
+    assert card_resp.headers["A2A-Version"] == "0.3"
+    assert card_resp.json()["protocolVersion"] == "0.3"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

当前仓库在升级到 `a2a-sdk 1.0.2` 后，仍保留了若干 `v1-only` 的前置拦截与声明，导致无法直接复用 SDK 自带的 `0.3 compatibility` 能力。

本 PR 的目标是：
- 保持 `1.0` 作为默认与主声明版本
- 为入站 core A2A surface 打通 `0.3 compatibility`
- 明确区分“SDK 已兼容的 core 能力”与“项目自定义扩展或未实现 surface”的边界

## 变更说明

- 放开入站协议协商，支持 `1.0` 与 `0.3`，默认仍为 `1.0`
- 在 JSON-RPC 入口接入 SDK 的 `v0.3` core method compatibility
- 在 REST 入口按协商版本分流，复用 SDK `REST03Handler` / `V03ServerCallContextBuilder` 组装 `0.3` core 路由
- 更新 Agent Card / compatibility profile / CLI / 文档，使对外声明与运行时行为一致
- 增加回归测试，覆盖 `0.3` JSON-RPC alias、legacy REST send payload、`/v1/card`、unsupported alias fallback 等关键路径

## 审查后补正

本 PR 创建后又补做了一轮独立审查，并收紧了两处不合适的 `0.3` 路径：

- 不再把 `pushNotificationConfig/*` 这类当前未支持的 `0.3 JSON-RPC` alias 误送进 SDK adapter，避免返回 `-32603 internal error`
- 不再直接 import SDK 的 `REST03Adapter`，改为在本仓库内围绕 SDK `REST03Handler` 组装轻量路由，规避其冷启动循环导入风险
- 修正 unsupported-method 响应中的 `protocolVersion`，使其反映当前协商版本，而不是固定写成 `1.0`

## 范围边界

- 已支持：入站 core A2A `1.0` + `0.3 compatibility`
- 保持不变：`opencode.*` 扩展仍为 `v1` 契约
- 保持不变：outbound peer call 仍使用 `1.0`
- 保持不变：push notifications 仍不在本仓库的支持面内，也不属于本 PR 的 `0.3` 兼容承诺
- 已知缺口：`0.3 REST GET /v1/tasks` 仍未声明支持；这是上游 SDK `compat/v0_3` REST 适配层未实现的缺口，见 https://github.com/a2aproject/a2a-python/issues/1043
- 使用约束：对于 `GET /v1/tasks/{id}`、`POST /v1/tasks/{id}:cancel`、`GET|POST /v1/tasks/{id}:subscribe` 这类与 `1.0` 路径同名的 `0.3` 请求，若请求形状本身不带显式旧版特征，则仍需要通过 `A2A-Version=0.3` 明确协商

## 验证

- `uv run pytest --no-cov`
- `./scripts/doctor.sh`
  - lint / mypy / full tests / coverage 已通过
  - 最后一阶段 isolated build 在当前环境偶发受 `pypi.org` DNS 解析失败影响

Closes #468
Related to https://github.com/a2aproject/a2a-python/issues/1043
