### PR TITLE
fix: lock provider-private contract builders to A2A 1.0

### DIFF
--- a/src/opencode_a2a/contracts/extensions/compatibility.py
+++ b/src/opencode_a2a/contracts/extensions/compatibility.py
@@ -26,7 +26,7 @@ def _normalize_provider_private_protocol_version(
 ) -> str:
     try:
         normalized_version = normalize_protocol_version(value)
-    except ValueError as exc:
+    except (AttributeError, ValueError) as exc:
         raise ValueError(
             f"{field_name} must resolve to provider-private A2A protocol version "
             f"{A2A_PROTOCOL_VERSION!r}; got {value!r}."

--- a/src/opencode_a2a/contracts/extensions/compatibility.py
+++ b/src/opencode_a2a/contracts/extensions/compatibility.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from ...profile.runtime import RuntimeProfile
+from ...protocol_versions import A2A_PROTOCOL_VERSION, normalize_protocol_version
 from . import catalog, identifiers
 from .capabilities import JsonRpcCapabilitySnapshot, build_capability_snapshot
 
@@ -18,17 +19,53 @@ DECLARED_EXTENSION_URIS: tuple[str, ...] = (
 )
 
 
-def _build_declared_protocol_versions(
+def _normalize_provider_private_protocol_version(
+    value: str,
+    *,
+    field_name: str,
+) -> str:
+    try:
+        normalized_version = normalize_protocol_version(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must resolve to provider-private A2A protocol version "
+            f"{A2A_PROTOCOL_VERSION!r}; got {value!r}."
+        ) from exc
+    if normalized_version != A2A_PROTOCOL_VERSION:
+        raise ValueError(
+            f"{field_name} must resolve to provider-private A2A protocol version "
+            f"{A2A_PROTOCOL_VERSION!r}; got {value!r}."
+        )
+    return normalized_version
+
+
+def _build_provider_private_protocol_versions(
     *,
     protocol_version: str,
     supported_protocol_versions: tuple[str, ...] | list[str] | None,
     default_protocol_version: str | None,
-) -> tuple[str, list[str]]:
-    declared_default_protocol_version = default_protocol_version or protocol_version
-    declared_supported_protocol_versions = list(
-        supported_protocol_versions or (declared_default_protocol_version,)
+) -> tuple[str, str, list[str]]:
+    normalized_protocol_version = _normalize_provider_private_protocol_version(
+        protocol_version,
+        field_name="protocol_version",
     )
-    return declared_default_protocol_version, declared_supported_protocol_versions
+    normalized_default_protocol_version = _normalize_provider_private_protocol_version(
+        default_protocol_version or normalized_protocol_version,
+        field_name="default_protocol_version",
+    )
+    declared_supported_protocol_versions = supported_protocol_versions or (
+        normalized_default_protocol_version,
+    )
+    for index, version in enumerate(declared_supported_protocol_versions):
+        _normalize_provider_private_protocol_version(
+            version,
+            field_name=f"supported_protocol_versions[{index}]",
+        )
+    return (
+        normalized_protocol_version,
+        normalized_default_protocol_version,
+        [A2A_PROTOCOL_VERSION],
+    )
 
 
 def _build_core_contract_surface() -> dict[str, list[str]]:
@@ -188,12 +225,14 @@ def build_compatibility_profile_params(
     supported_protocol_versions: tuple[str, ...] | list[str] | None = None,
     default_protocol_version: str | None = None,
 ) -> dict[str, Any]:
-    declared_default_protocol_version, declared_supported_protocol_versions = (
-        _build_declared_protocol_versions(
-            protocol_version=protocol_version,
-            supported_protocol_versions=supported_protocol_versions,
-            default_protocol_version=default_protocol_version,
-        )
+    (
+        declared_protocol_version,
+        declared_default_protocol_version,
+        declared_supported_protocol_versions,
+    ) = _build_provider_private_protocol_versions(
+        protocol_version=protocol_version,
+        supported_protocol_versions=supported_protocol_versions,
+        default_protocol_version=default_protocol_version,
     )
     protocol_compatibility = build_protocol_compatibility_params(
         supported_protocol_versions=declared_supported_protocol_versions,
@@ -202,7 +241,7 @@ def build_compatibility_profile_params(
     capability_snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
     service_behaviors = build_service_behavior_contract_params()
     return {
-        **runtime_profile.summary_dict(protocol_version=protocol_version),
+        **runtime_profile.summary_dict(protocol_version=declared_protocol_version),
         "default_protocol_version": declared_default_protocol_version,
         "supported_protocol_versions": declared_supported_protocol_versions,
         "protocol_compatibility": protocol_compatibility,
@@ -312,12 +351,14 @@ def build_wire_contract_params(
     supported_protocol_versions: tuple[str, ...] | list[str] | None = None,
     default_protocol_version: str | None = None,
 ) -> dict[str, Any]:
-    declared_default_protocol_version, declared_supported_protocol_versions = (
-        _build_declared_protocol_versions(
-            protocol_version=protocol_version,
-            supported_protocol_versions=supported_protocol_versions,
-            default_protocol_version=default_protocol_version,
-        )
+    (
+        declared_protocol_version,
+        declared_default_protocol_version,
+        declared_supported_protocol_versions,
+    ) = _build_provider_private_protocol_versions(
+        protocol_version=protocol_version,
+        supported_protocol_versions=supported_protocol_versions,
+        default_protocol_version=default_protocol_version,
     )
     protocol_compatibility = build_protocol_compatibility_params(
         supported_protocol_versions=declared_supported_protocol_versions,
@@ -327,11 +368,11 @@ def build_wire_contract_params(
     service_behaviors = build_service_behavior_contract_params()
 
     return {
-        "protocol_version": protocol_version,
+        "protocol_version": declared_protocol_version,
         "default_protocol_version": declared_default_protocol_version,
         "supported_protocol_versions": declared_supported_protocol_versions,
         "protocol_compatibility": protocol_compatibility,
-        "profile": runtime_profile.summary_dict(protocol_version=protocol_version),
+        "profile": runtime_profile.summary_dict(protocol_version=declared_protocol_version),
         "preferred_transport": "HTTP+JSON",
         "additional_transports": ["JSON-RPC"],
         "core": _build_core_contract_surface(),

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -60,6 +61,11 @@ from tests.support.session_extensions import _extension_headers
         ),
         pytest.param(
             build_compatibility_profile_params,
+            {"protocol_version": "invalid"},
+            id="compatibility-profile-invalid-protocol-version",
+        ),
+        pytest.param(
+            build_compatibility_profile_params,
             {"default_protocol_version": "2.0"},
             id="compatibility-profile-default-protocol-version",
         ),
@@ -72,6 +78,11 @@ from tests.support.session_extensions import _extension_headers
             build_wire_contract_params,
             {"protocol_version": "2.0"},
             id="wire-contract-protocol-version",
+        ),
+        pytest.param(
+            build_wire_contract_params,
+            {"protocol_version": "invalid"},
+            id="wire-contract-invalid-protocol-version",
         ),
         pytest.param(
             build_wire_contract_params,
@@ -486,12 +497,20 @@ async def test_extension_notification_contracts_return_204(
 
 def test_server_application_imports_in_fresh_interpreter() -> None:
     repo_root = Path(__file__).resolve().parents[2]
+    existing_pythonpath = os.environ.get("PYTHONPATH")
+    pythonpath_entries = [str(repo_root / "src")]
+    if existing_pythonpath:
+        pythonpath_entries.append(existing_pythonpath)
     result = subprocess.run(
         [sys.executable, "-c", "import opencode_a2a.server.application"],
         cwd=repo_root,
         capture_output=True,
         text=True,
         check=False,
+        env={
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(pythonpath_entries),
+        },
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from pathlib import Path
 
 import httpx
@@ -46,6 +48,82 @@ from tests.support.helpers import (
 )
 from tests.support.helpers import make_settings
 from tests.support.session_extensions import _extension_headers
+
+
+@pytest.mark.parametrize(
+    ("builder", "kwargs"),
+    [
+        pytest.param(
+            build_compatibility_profile_params,
+            {"protocol_version": "2.0"},
+            id="compatibility-profile-protocol-version",
+        ),
+        pytest.param(
+            build_compatibility_profile_params,
+            {"default_protocol_version": "2.0"},
+            id="compatibility-profile-default-protocol-version",
+        ),
+        pytest.param(
+            build_compatibility_profile_params,
+            {"supported_protocol_versions": ["1.0", "2.0"]},
+            id="compatibility-profile-supported-protocol-versions",
+        ),
+        pytest.param(
+            build_wire_contract_params,
+            {"protocol_version": "2.0"},
+            id="wire-contract-protocol-version",
+        ),
+        pytest.param(
+            build_wire_contract_params,
+            {"default_protocol_version": "2.0"},
+            id="wire-contract-default-protocol-version",
+        ),
+        pytest.param(
+            build_wire_contract_params,
+            {"supported_protocol_versions": ["1.0", "2.0"]},
+            id="wire-contract-supported-protocol-versions",
+        ),
+    ],
+)
+def test_provider_private_contract_builders_reject_non_1_0_protocol_lines(
+    builder,
+    kwargs: dict[str, object],
+) -> None:
+    runtime_profile = build_runtime_profile(make_settings(test_bearer_token="test-token"))
+    call_kwargs = {
+        "protocol_version": A2A_PROTOCOL_VERSION,
+        "runtime_profile": runtime_profile,
+        **kwargs,
+    }
+
+    with pytest.raises(ValueError, match="provider-private A2A protocol version '1\\.0'"):
+        builder(**call_kwargs)
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        build_compatibility_profile_params,
+        build_wire_contract_params,
+    ],
+)
+def test_provider_private_contract_builders_canonicalize_1_0_protocol_inputs(builder) -> None:
+    runtime_profile = build_runtime_profile(make_settings(test_bearer_token="test-token"))
+
+    params = builder(
+        protocol_version="1.0.0",
+        default_protocol_version="1.0.0",
+        supported_protocol_versions=["1.0.0"],
+        runtime_profile=runtime_profile,
+    )
+
+    assert params["default_protocol_version"] == A2A_PROTOCOL_VERSION
+    assert params["supported_protocol_versions"] == [A2A_PROTOCOL_VERSION]
+    if builder is build_wire_contract_params:
+        assert params["protocol_version"] == A2A_PROTOCOL_VERSION
+        assert params["profile"]["protocol_version"] == A2A_PROTOCOL_VERSION
+    else:
+        assert params["protocol_version"] == A2A_PROTOCOL_VERSION
 
 
 def test_extension_uris_map_to_repository_spec_documents() -> None:
@@ -404,3 +482,16 @@ async def test_extension_notification_contracts_return_204(
             json={"jsonrpc": "2.0", "method": method, "params": params},
         )
     assert response.status_code == 204
+
+
+def test_server_application_imports_in_fresh_interpreter() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-c", "import opencode_a2a.server.application"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## 摘要
- 将 provider-private contract builder 的协议线显式锁定到 canonical `1.0`
- 补齐非 `1.0`、非法格式输入与 cold import 路径的回归证明
- 消除 provider-private contract 继续依赖调用方“恰好传对值”的隐式约束

## 变更说明
- 在 `src/opencode_a2a/contracts/extensions/compatibility.py` 中新增 provider-private 协议版本收紧逻辑
- `build_compatibility_profile_params(...)` 与 `build_wire_contract_params(...)` 现在都会校验 `protocol_version`、`default_protocol_version`、`supported_protocol_versions`
- 非 `1.0` 或非法格式输入现在会稳定失败；可归一化到 `1.0` 的输入会统一输出 canonical `1.0`
- 在 `tests/contracts/test_extension_contract_consistency.py` 中补充了：
  - builder 对非 `1.0` 输入的负向测试
  - builder 对非法格式协议版本输入的负向测试
  - `1.0.0` 输入被归一化为 `1.0` 的测试
  - `opencode_a2a.server.application` 的 fresh-interpreter import smoke test
- fresh-import smoke test 现在显式从工作树 `src/` 导入，避免测试结果依赖当前环境里的已安装包路径

## 提交说明
- `fix: enforce provider-private 1.0 contract invariants`
- `test: harden provider-private 1.0 regression coverage`
- 上述提交均围绕 `#470`，没有额外引入需要一并关闭的其它 issue

## 验证
- `uv run pytest --no-cov tests/contracts/test_extension_contract_consistency.py tests/server/test_agent_card.py`
- `./scripts/doctor.sh`

## 关联
Closes #470
