### PR TITLE
ci: ignore unsatisfiable protobuf major updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # a2a-sdk still constrains protobuf to <7, so major protobuf bumps are unsatisfiable.
+      - dependency-name: "protobuf"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 1
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
## 背景
最近一次 Dependabot `uv` 更新任务失败。失败点不在主验证工作流，而在 Dependabot 尝试对 `protobuf` 发起 major 升级时触发了解算冲突。

## 根因分析
当前项目依赖仍要求 `protobuf < 7`，而 Dependabot 在 grouped update 中尝试将 `protobuf` 升级到 `7.x`。这会与 `a2a-sdk` 的版本约束共同导致依赖不可解，因此更新任务稳定失败。

## 本次改动
- 在 `.github/dependabot.yml` 中忽略 `protobuf` 的 `version-update:semver-major`
- 保留现有 weekly 调度、分组更新和其它依赖的自动更新能力

## 审查结论
- 改动方向合理：直接约束当前不可满足的更新路径，命中失败根因
- 改动边界收敛：只屏蔽 `protobuf` major 更新，不影响 patch / minor 更新，也不扩大其它自动化行为
- 风险可控：后续当 `a2a-sdk` 或项目自身支持 `protobuf 7` 后，可以移除该忽略规则

## 验证
- 已运行 `bash ./scripts/doctor.sh`
- 本地验证通过：701 个测试通过，coverage gate、build、built wheel smoke test 全部通过

## 备注
- 本次任务按要求未新建 issue
