### PR TITLE
feat: add OpenCode upstream auth, version line, and live integration smoke

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,6 +7,9 @@ This document defines the compatibility promises `opencode-a2a` currently uphold
 - Python versions: 3.11, 3.12, 3.13
 - A2A SDK line: `1.x.y`
 - Supported A2A protocol line: `1.0`
+- OpenCode runtime line: `1.18.x` (verified with `1.18.19`)
+
+This is the single canonical place where the supported upstream OpenCode version line is declared. Keep it updated together with the live integration smoke check (`./scripts/live_opencode_smoke.sh`) and do not duplicate the version line elsewhere.
 
 The repository currently pins one concrete SDK release in `pyproject.toml` within that v1 line. Upgrade the SDK deliberately rather than relying on floating dependency resolution. The SDK-owned core JSON-RPC method set follows that pinned release and is locked by repository tests so SDK upgrades trigger an explicit compatibility review.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -50,6 +50,7 @@ Key variables to understand protocol behavior:
 - `OPENCODE_TIMEOUT` / `OPENCODE_TIMEOUT_STREAM`: upstream request timeout and optional stream timeout override.
 - `OPENCODE_MAX_CONCURRENT_REQUESTS`: optional fast-fail concurrency limit for unary/control upstream calls. `0` disables the limit.
 - `OPENCODE_MAX_CONCURRENT_STREAMS`: optional fast-fail concurrency limit for long-lived upstream `/event` streams. `0` disables the limit.
+- `OPENCODE_AUTH_USERNAME` / `OPENCODE_AUTH_PASSWORD`: optional HTTP Basic credentials sent on every upstream OpenCode call. Set both when the upstream `opencode serve` is hardened with `OPENCODE_SERVER_PASSWORD`; the username defaults to `opencode` and must match `OPENCODE_SERVER_USERNAME` when that is overridden upstream. When unset, no `Authorization` header is sent.
 - `A2A_CLIENT_TIMEOUT_SECONDS`: outbound client timeout. Default: `30` seconds.
 - `A2A_CLIENT_CARD_FETCH_TIMEOUT_SECONDS`: outbound Agent Card fetch timeout. Default: `5` seconds.
 - `A2A_CLIENT_USE_CLIENT_PREFERENCE`: whether the outbound client prefers its own transport choices.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ Executable scripts live in this directory. This file is the entry index for the 
 
 - [`doctor.sh`](./doctor.sh): primary local development regression entrypoint with explicit fix/verify/package phases (uv sync + dependency compatibility + lint + mypy + tests + coverage + built-wheel smoke test)
 - [`conformance.sh`](./conformance.sh): local/manual external A2A conformance experiment entrypoint; caches the official TCK, can launch a dummy-backed local SUT, and preserves raw artifacts under `run/conformance/`
+- [`live_opencode_smoke.sh`](./live_opencode_smoke.sh): local/manual live integration smoke against a real OpenCode runtime; boots an isolated password-hardened `opencode serve` plus the opencode-a2a runtime in throwaway directories and verifies upstream auth, JSON-RPC extension reads, and a streaming prompt round-trip
 - [`dependency_health.sh`](./dependency_health.sh): development dependency review entrypoint (`sync`/`pip check` + outdated + dev audit), while blocking CI/publish audits focus on runtime dependencies
 - [`check_coverage.py`](./check_coverage.py): enforces the overall coverage floor and per-file minimums for critical modules
 - [`find_thin_wrappers.py`](./find_thin_wrappers.py): static analysis helper that reports local functions with low caller counts and flags likely thin forwarding wrappers for manual abstraction review

--- a/scripts/live_opencode_smoke.sh
+++ b/scripts/live_opencode_smoke.sh
@@ -29,7 +29,7 @@ Isolation:
 
 Requirements:
   - opencode CLI on PATH (or OPENCODE_BIN), any 1.18.x build
-  - uv, curl, python3
+  - uv, git, curl, python3
 
 Selected environment variables:
   OPENCODE_BIN                         Override the opencode binary path (default: opencode from PATH)
@@ -61,6 +61,16 @@ fi
 
 if ! command -v curl >/dev/null 2>&1; then
   echo "curl not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not found in PATH" >&2
   exit 1
 fi
 
@@ -152,18 +162,18 @@ OPENCODE_SERVER_PASSWORD="${upstream_password}" \
 upstream_pid="$!"
 
 upstream_ready=""
-for _ in $(seq 1 100); do
+for _ in $(seq 1 60); do
   if ! kill -0 "${upstream_pid}" >/dev/null 2>&1; then
     echo "[live-smoke] upstream opencode exited before becoming ready" >&2
     cat "${upstream_log}" >&2
     exit 1
   fi
-  if curl -fsS -u "${upstream_username}:${upstream_password}" \
+  if curl -fsS --max-time 5 -u "${upstream_username}:${upstream_password}" \
     "${upstream_url}/doc" >/dev/null 2>&1; then
     upstream_ready="1"
     break
   fi
-  sleep 0.2
+  sleep 0.5
 done
 if [[ -z "${upstream_ready}" ]]; then
   echo "[live-smoke] upstream opencode did not become ready at ${upstream_url}" >&2
@@ -173,33 +183,37 @@ fi
 echo "[live-smoke] upstream opencode ready (${opencode_version})"
 
 echo "[live-smoke] starting opencode-a2a on ${a2a_url}"
-(
-  cd "${adapter_dir}"
-  OPENCODE_BASE_URL="${upstream_url}" \
-  OPENCODE_WORKSPACE_ROOT="${workspace_dir}" \
-  OPENCODE_AUTH_USERNAME="${upstream_username}" \
-  OPENCODE_AUTH_PASSWORD="${upstream_password}" \
-  A2A_STATIC_AUTH_CREDENTIALS="[{\"scheme\":\"bearer\",\"token\":\"${a2a_bearer_token}\",\"principal\":\"automation\"}]" \
-  A2A_HOST="127.0.0.1" \
-  A2A_PORT="${a2a_port}" \
-  A2A_PUBLIC_URL="${a2a_url}" \
-  uv run --project "${ROOT_DIR}" opencode-a2a serve >"${adapter_log}" 2>&1
-) &
+adapter_bin="${ROOT_DIR}/.venv/bin/opencode-a2a"
+if [[ ! -x "${adapter_bin}" ]]; then
+  echo "[live-smoke] ${adapter_bin} not found; run without LIVE_SMOKE_SKIP_SYNC=1 (or sync the repository first)." >&2
+  exit 1
+fi
+
+OPENCODE_BASE_URL="${upstream_url}" \
+OPENCODE_WORKSPACE_ROOT="${workspace_dir}" \
+OPENCODE_AUTH_USERNAME="${upstream_username}" \
+OPENCODE_AUTH_PASSWORD="${upstream_password}" \
+A2A_STATIC_AUTH_CREDENTIALS="[{\"scheme\":\"bearer\",\"token\":\"${a2a_bearer_token}\",\"principal\":\"automation\"}]" \
+A2A_HOST="127.0.0.1" \
+A2A_PORT="${a2a_port}" \
+A2A_PUBLIC_URL="${a2a_url}" \
+A2A_TASK_STORE_DATABASE_URL="sqlite+aiosqlite:///${run_dir}/adapter/opencode-a2a.db" \
+"${adapter_bin}" serve >"${adapter_log}" 2>&1 &
 adapter_pid="$!"
 
 a2a_ready=""
-for _ in $(seq 1 100); do
+for _ in $(seq 1 60); do
   if ! kill -0 "${adapter_pid}" >/dev/null 2>&1; then
     echo "[live-smoke] adapter exited before becoming ready" >&2
     cat "${adapter_log}" >&2
     exit 1
   fi
-  if curl -fsS -H "Authorization: Bearer ${a2a_bearer_token}" \
+  if curl -fsS --max-time 5 -H "Authorization: Bearer ${a2a_bearer_token}" \
     "${a2a_url}/health" >/dev/null 2>&1; then
     a2a_ready="1"
     break
   fi
-  sleep 0.2
+  sleep 0.5
 done
 if [[ -z "${a2a_ready}" ]]; then
   echo "[live-smoke] adapter did not become ready at ${a2a_url}" >&2
@@ -213,14 +227,14 @@ extension_header="A2A-Extensions: urn:opencode-a2a:extension:session-management:
 
 jsonrpc_probe() {
   local payload="$1"
-  curl -sS -H "${auth_header}" -H "${extension_header}" \
+  curl -sS --max-time 30 -H "${auth_header}" -H "${extension_header}" \
     -H "Content-Type: application/json" \
     -d "${payload}" "${a2a_url}/"
 }
 
 echo "[live-smoke] probe: upstream auth is enforced"
 unauth_status="$(
-  curl -sS -o /dev/null -w '%{http_code}' \
+  curl -sS --max-time 10 -o /dev/null -w '%{http_code}' \
     "${upstream_url}/session/status?directory=${workspace_dir}"
 )"
 if [[ "${unauth_status}" != "401" ]]; then

--- a/scripts/live_opencode_smoke.sh
+++ b/scripts/live_opencode_smoke.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Run a live opencode-a2a integration smoke against a real OpenCode runtime.
+# Everything runs inside a temporary, isolated environment: a throwaway HOME/XDG
+# for the upstream OpenCode process, a throwaway workspace directory, and
+# ephemeral ports. No repository data directory or user OpenCode state is read
+# or written, and all artifacts are removed on exit.
+set -euo pipefail
+
+# shellcheck source=./health_common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash ./scripts/live_opencode_smoke.sh
+
+Purpose:
+  Boot a real `opencode serve` (hardened with a server password), start the
+  opencode-a2a runtime against it, and verify the adapter's upstream
+  adaptation end-to-end: authenticated upstream connectivity, JSON-RPC
+  extension read methods, a streaming prompt round-trip, and that upstream
+  auth is actually enforced.
+
+Isolation:
+  The script creates a fresh temporary root (mktemp -d) used for the OpenCode
+  process HOME/XDG directories, the OpenCode workspace, and the adapter's
+  working directory (SQLite state). Everything is removed on exit; no valid
+  data directory is touched.
+
+Requirements:
+  - opencode CLI on PATH (or OPENCODE_BIN), any 1.18.x build
+  - uv, curl, python3
+
+Selected environment variables:
+  OPENCODE_BIN                         Override the opencode binary path (default: opencode from PATH)
+  LIVE_SMOKE_UPSTREAM_PORT             Fixed upstream port (default: ephemeral)
+  LIVE_SMOKE_A2A_PORT                  Fixed adapter port (default: ephemeral)
+  LIVE_SMOKE_SKIP_PROMPT=1             Skip the streaming prompt round-trip (network/model dependent)
+  LIVE_SMOKE_SKIP_SYNC=1               Skip uv sync for this repository
+  LIVE_SMOKE_KEEP_ARTIFACTS=1          Keep the temporary root and print its path
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$#" -gt 0 ]]; then
+  echo "Expected no positional arguments" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl not found in PATH" >&2
+  exit 1
+fi
+
+opencode_bin="${OPENCODE_BIN:-}"
+if [[ -z "${opencode_bin}" ]]; then
+  if command -v opencode >/dev/null 2>&1; then
+    opencode_bin="$(command -v opencode)"
+  else
+    echo "opencode CLI not found in PATH; install the 1.18.x line or set OPENCODE_BIN." >&2
+    exit 1
+  fi
+fi
+
+opencode_version="$("${opencode_bin}" --version 2>/dev/null | tr -d '[:space:]')"
+if [[ -z "${opencode_version}" ]]; then
+  echo "Failed to read opencode version from ${opencode_bin}" >&2
+  exit 1
+fi
+echo "[live-smoke] opencode binary: ${opencode_bin} (${opencode_version})"
+
+if [[ "${LIVE_SMOKE_SKIP_SYNC:-0}" != "1" ]]; then
+  run_shared_repo_health_prerequisites "live-smoke"
+fi
+
+free_port() {
+  python3 - <<'PY'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+upstream_port="${LIVE_SMOKE_UPSTREAM_PORT:-$(free_port)}"
+a2a_port="${LIVE_SMOKE_A2A_PORT:-$(free_port)}"
+upstream_url="http://127.0.0.1:${upstream_port}"
+a2a_url="http://127.0.0.1:${a2a_port}"
+upstream_username="opencode"
+# Non-secret throwaway credential for the isolated smoke instance only.
+upstream_password="live-smoke-password"  # pragma: allowlist secret
+a2a_bearer_token="live-smoke-token"  # pragma: allowlist secret
+
+run_dir="$(mktemp -d)"
+opencode_home="${run_dir}/opencode-home"
+workspace_dir="${run_dir}/workspace"
+adapter_dir="${run_dir}/adapter"
+upstream_log="${run_dir}/opencode.log"
+adapter_log="${run_dir}/adapter.log"
+stream_result="${run_dir}/stream-result.jsonl"
+mkdir -p "${opencode_home}" "${workspace_dir}" "${adapter_dir}"
+
+cleanup() {
+  local exit_code="$1"
+  if [[ -n "${adapter_pid:-}" ]] && kill -0 "${adapter_pid}" >/dev/null 2>&1; then
+    kill "${adapter_pid}" >/dev/null 2>&1 || true
+    wait "${adapter_pid}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${upstream_pid:-}" ]] && kill -0 "${upstream_pid}" >/dev/null 2>&1; then
+    kill "${upstream_pid}" >/dev/null 2>&1 || true
+    wait "${upstream_pid}" >/dev/null 2>&1 || true
+  fi
+  if [[ "${LIVE_SMOKE_KEEP_ARTIFACTS:-0}" == "1" ]]; then
+    echo "[live-smoke] artifacts kept at ${run_dir}"
+  else
+    rm -rf "${run_dir}"
+  fi
+  exit "${exit_code}"
+}
+
+trap 'cleanup $?' EXIT
+
+(
+  cd "${workspace_dir}"
+  git init -q
+  printf 'live smoke workspace\n' > README.md
+  git add README.md
+  git -c user.name="live-smoke" -c user.email="live-smoke@localhost" commit -qm init
+)
+
+echo "[live-smoke] starting upstream opencode on ${upstream_url}"
+HOME="${opencode_home}" \
+XDG_CONFIG_HOME="${opencode_home}/.config" \
+XDG_DATA_HOME="${opencode_home}/.local/share" \
+XDG_CACHE_HOME="${opencode_home}/.cache" \
+OPENCODE_SERVER_PASSWORD="${upstream_password}" \
+"${opencode_bin}" serve --hostname 127.0.0.1 --port "${upstream_port}" \
+  >"${upstream_log}" 2>&1 &
+upstream_pid="$!"
+
+upstream_ready=""
+for _ in $(seq 1 100); do
+  if ! kill -0 "${upstream_pid}" >/dev/null 2>&1; then
+    echo "[live-smoke] upstream opencode exited before becoming ready" >&2
+    cat "${upstream_log}" >&2
+    exit 1
+  fi
+  if curl -fsS -u "${upstream_username}:${upstream_password}" \
+    "${upstream_url}/doc" >/dev/null 2>&1; then
+    upstream_ready="1"
+    break
+  fi
+  sleep 0.2
+done
+if [[ -z "${upstream_ready}" ]]; then
+  echo "[live-smoke] upstream opencode did not become ready at ${upstream_url}" >&2
+  cat "${upstream_log}" >&2
+  exit 1
+fi
+echo "[live-smoke] upstream opencode ready (${opencode_version})"
+
+echo "[live-smoke] starting opencode-a2a on ${a2a_url}"
+(
+  cd "${adapter_dir}"
+  OPENCODE_BASE_URL="${upstream_url}" \
+  OPENCODE_WORKSPACE_ROOT="${workspace_dir}" \
+  OPENCODE_AUTH_USERNAME="${upstream_username}" \
+  OPENCODE_AUTH_PASSWORD="${upstream_password}" \
+  A2A_STATIC_AUTH_CREDENTIALS="[{\"scheme\":\"bearer\",\"token\":\"${a2a_bearer_token}\",\"principal\":\"automation\"}]" \
+  A2A_HOST="127.0.0.1" \
+  A2A_PORT="${a2a_port}" \
+  A2A_PUBLIC_URL="${a2a_url}" \
+  uv run --project "${ROOT_DIR}" opencode-a2a serve >"${adapter_log}" 2>&1
+) &
+adapter_pid="$!"
+
+a2a_ready=""
+for _ in $(seq 1 100); do
+  if ! kill -0 "${adapter_pid}" >/dev/null 2>&1; then
+    echo "[live-smoke] adapter exited before becoming ready" >&2
+    cat "${adapter_log}" >&2
+    exit 1
+  fi
+  if curl -fsS -H "Authorization: Bearer ${a2a_bearer_token}" \
+    "${a2a_url}/health" >/dev/null 2>&1; then
+    a2a_ready="1"
+    break
+  fi
+  sleep 0.2
+done
+if [[ -z "${a2a_ready}" ]]; then
+  echo "[live-smoke] adapter did not become ready at ${a2a_url}" >&2
+  cat "${adapter_log}" >&2
+  exit 1
+fi
+echo "[live-smoke] adapter ready"
+
+auth_header="Authorization: Bearer ${a2a_bearer_token}"
+extension_header="A2A-Extensions: urn:opencode-a2a:extension:session-management:v1, urn:opencode-a2a:extension:workspace-control:v1, urn:opencode-a2a:extension:provider-discovery:v1"
+
+jsonrpc_probe() {
+  local payload="$1"
+  curl -sS -H "${auth_header}" -H "${extension_header}" \
+    -H "Content-Type: application/json" \
+    -d "${payload}" "${a2a_url}/"
+}
+
+echo "[live-smoke] probe: upstream auth is enforced"
+unauth_status="$(
+  curl -sS -o /dev/null -w '%{http_code}' \
+    "${upstream_url}/session/status?directory=${workspace_dir}"
+)"
+if [[ "${unauth_status}" != "401" ]]; then
+  echo "[live-smoke] FAIL: upstream /session/status without credentials returned ${unauth_status}, expected 401" >&2
+  exit 1
+fi
+echo "[live-smoke] PASS: upstream auth enforced (401 without credentials)"
+
+echo "[live-smoke] probe: opencode.projects.current"
+projects_result="$(jsonrpc_probe '{"jsonrpc":"2.0","id":1,"method":"opencode.projects.current","params":{}}')"
+if ! python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if isinstance(d.get("result", {}).get("item", {}).get("id"), str) else 1)' \
+  <<<"${projects_result}"; then
+  echo "[live-smoke] FAIL: opencode.projects.current returned unexpected result: ${projects_result}" >&2
+  exit 1
+fi
+echo "[live-smoke] PASS: opencode.projects.current"
+
+echo "[live-smoke] probe: opencode.sessions.status"
+sessions_result="$(jsonrpc_probe '{"jsonrpc":"2.0","id":2,"method":"opencode.sessions.status","params":{}}')"
+if ! python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if "items" in d.get("result", {}) else 1)' \
+  <<<"${sessions_result}"; then
+  echo "[live-smoke] FAIL: opencode.sessions.status returned unexpected result: ${sessions_result}" >&2
+  exit 1
+fi
+echo "[live-smoke] PASS: opencode.sessions.status"
+
+if [[ "${LIVE_SMOKE_SKIP_PROMPT:-0}" != "1" ]]; then
+  echo "[live-smoke] probe: streaming prompt round-trip"
+  curl -sS -N \
+    -H "${auth_header}" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":10,"method":"SendStreamingMessage","params":{"message":{"messageId":"live-smoke-msg","role":"ROLE_USER","parts":[{"text":"Reply with exactly: smoke-ok"}]}}}' \
+    "${a2a_url}/" --max-time 180 >"${stream_result}"
+  if ! grep -q '"TASK_STATE_COMPLETED"' "${stream_result}"; then
+    echo "[live-smoke] FAIL: streaming prompt did not reach TASK_STATE_COMPLETED" >&2
+    tail -c 2000 "${stream_result}" >&2
+    exit 1
+  fi
+  if ! grep -q 'smoke-ok' "${stream_result}"; then
+    echo "[live-smoke] FAIL: streaming prompt reply did not contain the expected text" >&2
+    tail -c 2000 "${stream_result}" >&2
+    exit 1
+  fi
+  echo "[live-smoke] PASS: streaming prompt round-trip"
+else
+  echo "[live-smoke] skip: streaming prompt round-trip (LIVE_SMOKE_SKIP_PROMPT=1)"
+fi
+
+echo "[live-smoke] ALL CHECKS PASSED (opencode ${opencode_version})"

--- a/src/opencode_a2a/config.py
+++ b/src/opencode_a2a/config.py
@@ -165,6 +165,8 @@ class Settings(BaseSettings):
         ge=0,
         alias="OPENCODE_MAX_CONCURRENT_STREAMS",
     )
+    opencode_auth_username: str = Field(default="opencode", alias="OPENCODE_AUTH_USERNAME")
+    opencode_auth_password: str | None = Field(default=None, alias="OPENCODE_AUTH_PASSWORD")
 
     # A2A settings
     a2a_public_url: str = Field(default="http://127.0.0.1:8000", alias="A2A_PUBLIC_URL")

--- a/src/opencode_a2a/config.py
+++ b/src/opencode_a2a/config.py
@@ -166,7 +166,11 @@ class Settings(BaseSettings):
         alias="OPENCODE_MAX_CONCURRENT_STREAMS",
     )
     opencode_auth_username: str = Field(default="opencode", alias="OPENCODE_AUTH_USERNAME")
-    opencode_auth_password: str | None = Field(default=None, alias="OPENCODE_AUTH_PASSWORD")
+    opencode_auth_password: str | None = Field(
+        default=None,
+        alias="OPENCODE_AUTH_PASSWORD",
+        repr=False,
+    )
 
     # A2A settings
     a2a_public_url: str = Field(default="http://127.0.0.1:8000", alias="A2A_PUBLIC_URL")

--- a/src/opencode_a2a/opencode_upstream_client.py
+++ b/src/opencode_a2a/opencode_upstream_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import time
@@ -131,10 +132,17 @@ class OpencodeUpstreamClient:
             category="stream",
             limit=settings.opencode_max_concurrent_streams,
         )
+        client_headers: dict[str, str] = {"Accept": "application/json"}
+        if settings.opencode_auth_password:
+            auth_credentials = (
+                f"{settings.opencode_auth_username}:{settings.opencode_auth_password}"
+            )
+            encoded_credentials = base64.b64encode(auth_credentials.encode("utf-8")).decode("ascii")
+            client_headers["Authorization"] = f"Basic {encoded_credentials}"
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
             timeout=self._settings.opencode_timeout,
-            headers={"Accept": "application/json"},
+            headers=client_headers,
         )
 
     def _sync_interrupt_clock(self) -> None:

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -117,6 +117,16 @@ def test_settings_opencode_auth_defaults_to_opencode_username_without_password()
     assert settings.opencode_auth_password is None
 
 
+def test_settings_opencode_auth_repr_hides_password() -> None:
+    settings = make_settings(
+        opencode_auth_username="opencode",
+        opencode_auth_password="hunter2-secret",  # pragma: allowlist secret
+    )
+
+    assert "hunter2-secret" not in repr(settings)
+    assert "opencode_auth_password" not in repr(settings)
+
+
 def test_make_settings_ignores_ambient_environment_sources(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".env").write_text(

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -50,6 +50,8 @@ def test_settings_valid():
         "A2A_ENABLE_SESSION_SHELL": "true",
         "OPENCODE_MAX_CONCURRENT_REQUESTS": "12",
         "OPENCODE_MAX_CONCURRENT_STREAMS": "3",
+        "OPENCODE_AUTH_USERNAME": "service",
+        "OPENCODE_AUTH_PASSWORD": "s3cret",  # pragma: allowlist secret
         "A2A_CLIENT_BASIC_AUTH": "user:pass",
         "A2A_SANDBOX_MODE": "danger-full-access",
         "A2A_SANDBOX_FILESYSTEM_SCOPE": "unrestricted",
@@ -76,6 +78,8 @@ def test_settings_valid():
         assert settings.a2a_cancel_abort_timeout_seconds == 0.75
         assert settings.opencode_max_concurrent_requests == 12
         assert settings.opencode_max_concurrent_streams == 3
+        assert settings.opencode_auth_username == "service"
+        assert settings.opencode_auth_password == "s3cret"  # pragma: allowlist secret
         assert settings.a2a_enable_session_shell is True
         assert settings.a2a_client_basic_auth == "user:pass"
         assert settings.a2a_sandbox_mode == "danger-full-access"
@@ -92,6 +96,25 @@ def test_settings_valid():
         assert settings.a2a_version == __version__
         assert A2A_PROTOCOL_VERSION == "1.0"
         assert A2A_SUPPORTED_PROTOCOL_VERSIONS == ("1.0",)
+
+
+def test_settings_opencode_auth_defaults_to_opencode_username_without_password() -> None:
+    env = {
+        "A2A_STATIC_AUTH_CREDENTIALS": json.dumps(
+            [
+                {
+                    "scheme": "bearer",
+                    "token": "test-token",
+                    "principal": "automation",
+                }
+            ]
+        ),
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        settings = Settings()
+
+    assert settings.opencode_auth_username == "opencode"
+    assert settings.opencode_auth_password is None
 
 
 def test_make_settings_ignores_ambient_environment_sources(tmp_path, monkeypatch) -> None:

--- a/tests/upstream/test_opencode_upstream_client_params.py
+++ b/tests/upstream/test_opencode_upstream_client_params.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json as json_module
 import logging
 
@@ -66,6 +67,97 @@ class _HoldingStreamContext:
     async def __aexit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001
         del exc_type, exc, tb
         return False
+
+
+@pytest.mark.asyncio
+async def test_upstream_client_configures_basic_auth_header_when_password_set() -> None:
+    client = OpencodeUpstreamClient(
+        make_settings(
+            test_bearer_token="t-1",
+            opencode_auth_username="opencode",
+            opencode_auth_password="smoke-pass",  # pragma: allowlist secret
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+        )
+    )
+    expected = "Basic " + base64.b64encode(b"opencode:smoke-pass").decode("ascii")
+    assert client._client.headers.get("Authorization") == expected
+    await client.close()
+
+    unauthenticated = OpencodeUpstreamClient(
+        make_settings(
+            test_bearer_token="t-1",
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+        )
+    )
+    assert "Authorization" not in unauthenticated._client.headers
+    await unauthenticated.close()
+
+
+@pytest.mark.asyncio
+async def test_upstream_requests_send_basic_auth_header_when_configured(monkeypatch) -> None:
+    captured_headers: list[str | None] = []
+
+    def capture_handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(capture_handler)
+    original_client_class = httpx.AsyncClient
+
+    def client_factory(*args, **kwargs):
+        return original_client_class(*args, **kwargs, transport=transport)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+
+    client = OpencodeUpstreamClient(
+        make_settings(
+            test_bearer_token="t-1",
+            opencode_auth_username="opencode",
+            opencode_auth_password="smoke-pass",  # pragma: allowlist secret
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+        )
+    )
+    await client.session_status()
+    await client.close()
+
+    expected = "Basic " + base64.b64encode(b"opencode:smoke-pass").decode("ascii")
+    assert captured_headers == [expected]
+
+
+@pytest.mark.asyncio
+async def test_upstream_requests_omit_auth_header_when_unset(monkeypatch) -> None:
+    captured_headers: list[str | None] = []
+
+    def capture_handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(capture_handler)
+    original_client_class = httpx.AsyncClient
+
+    def client_factory(*args, **kwargs):
+        return original_client_class(*args, **kwargs, transport=transport)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+
+    client = OpencodeUpstreamClient(
+        make_settings(
+            test_bearer_token="t-1",
+            opencode_timeout=1.0,
+            a2a_log_level="DEBUG",
+            a2a_log_payloads=False,
+        )
+    )
+    await client.session_status()
+    await client.close()
+
+    assert captured_headers == [None]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概述

支持对上游 opencode 运行时进行 Basic 鉴权、单点声明支持的上游版本线，并新增真实集成冒烟测试。由 #495 跟踪。

## 改动内容

1. **上游鉴权支持**
   - 新增设置 `OPENCODE_AUTH_USERNAME`（默认 `opencode`）与 `OPENCODE_AUTH_PASSWORD`（默认未设置）。
   - 配置密码后，所有上游调用（含 SSE `/event` 流）携带 `Authorization: Basic <base64(user:pass)>`，与上游 `opencode serve` 的 `OPENCODE_SERVER_PASSWORD` / `OPENCODE_SERVER_USERNAME` 契约对齐；未配置时不发送该头（默认行为不变）。
   - 密码字段设置 `repr=False`，避免意外出现在 `Settings` 的 repr 中。
   - `docs/guide.md` 环境变量清单同步补充说明。

2. **上游版本线单点声明**
   - `docs/compatibility.md` Runtime Support 新增 `OpenCode runtime line: 1.18.x (verified with 1.18.19)`，并注明该处为唯一规范位置，不再于其他文档重复维护。

3. **真实集成冒烟 `scripts/live_opencode_smoke.sh`**
   - 启动真实（密码加固）`opencode serve` + opencode-a2a，验证：上游鉴权强制（无凭据 401）、适配器 `/health`、JSON-RPC 扩展读方法（`opencode.projects.current` / `opencode.sessions.status`）、流式对话端到端（`SendStreamingMessage` → `TASK_STATE_COMPLETED`）。
   - 全部运行于 `mktemp -d` 临时根：隔离的 opencode HOME/XDG、临时 workspace、显式临时 SQLite URL、随机端口；`trap` 退出即清理，不触碰任何有效数据目录。
   - 所有就绪/探测请求带 `--max-time`，服务器启动窗口异常时快速失败而非无限挂起；适配器直接使用 `.venv/bin/opencode-a2a` 启动（`$!` 即真实服务进程，清理可靠）。
   - 手动/本地入口，与 `conformance.sh` 同级，**不接入** doctor/CI 默认回归基线（按仓库互操作实验策略）。

## 相关 commits

- `6082774` feat: support authenticated OpenCode upstream and add live integration smoke
- `1e26b2f` fix: harden live smoke robustness and hide upstream password from repr

## 验证

- `./scripts/doctor.sh` 全绿：706 tests passed，coverage 93.01%（门槛 ≥90%），pre-commit / mypy / 构建 / wheel 冒烟均通过。
- `./scripts/live_opencode_smoke.sh` 对安装版 opencode 1.18.19 实测全绿（含密码加固上游下的流式对话）。
- GitHub Actions（Default Toolchain、Runtime Matrix 3.11/3.12）全部通过。

## Issue 关联

- Closes #495（本 PR 完整实现该 issue 范围）。
