### PR TITLE
fix(agent-card): advertise HTTP+JSON interface URL with /v1 prefix

### DIFF
--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -516,7 +516,14 @@ def build_agent_card(
         version=settings.a2a_version,
         supported_interfaces=[
             AgentInterface(
-                url=public_url,
+                # The HTTP+JSON surface lives under /v1 (see application.py
+                # route registration), so the advertised interface URL must
+                # carry that prefix: A2A clients resolve REST paths relative
+                # to the advertised URL (e.g. the official JS SDK appends
+                # `/message:send` to it). Advertising the bare base URL made
+                # conforming clients call the root path, which this server
+                # does not serve.
+                url=public_url + "/v1",
                 protocol_binding="HTTP+JSON",
                 protocol_version=A2A_PROTOCOL_VERSION,
             ),


### PR DESCRIPTION
Closes #496

## 变更

将 Agent Card 中 HTTP+JSON interface 的 URL 从裸 base URL 改为 `public_url + "/v1"`，与服务端实际路由注册保持一致（见 `src/opencode_a2a/server/application.py`）。

## 原因

A2A 客户端会基于 Agent Card 公布的 interface URL 解析 REST 路径（例如官方 JS SDK 会向 `{url}/message:send` 发起请求）。此前公布的是裸 base URL，导致请求命中根路径并返回 404。

## 验证

`./scripts/doctor.sh` 全部通过：

- pre-commit 各检查通过
- `mypy src/opencode_a2a` 无问题
- 706 个测试全部通过
- 覆盖率策略通过
- wheel 构建与 CLI 冒烟测试通过

## 涉及文件

- `src/opencode_a2a/server/agent_card.py`
