### PR TITLE
fix(http-json): serve A2A REST routes at root path (drop /v1 prefix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ curl http://127.0.0.1:8000/.well-known/agent-card.json
 
 ## Capabilities
 
-- A2A HTTP+JSON endpoints such as `/v1/message:send` and `/v1/message:stream`
+- A2A HTTP+JSON endpoints such as `/message:send` and `/message:stream`
 - A2A JSON-RPC support on `POST /`
-- SDK-owned A2A task surfaces such as `GET /v1/tasks`, task push notification config routes, JSON-RPC `GetExtendedAgentCard`, and HTTP `GET /extendedAgentCard`
+- SDK-owned A2A task surfaces such as `GET /tasks`, task push notification config routes, JSON-RPC `GetExtendedAgentCard`, and HTTP `GET /extendedAgentCard`
 - Peering capabilities: can act as a client via `opencode-a2a call`
 - Autonomous tool execution: supports `a2a_call` tool for outbound agent-to-agent communication
 - SSE streaming with normalized `text`, `reasoning`, and `tool_call` blocks

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -5,7 +5,7 @@ This guide covers configuration, authentication, API behavior, streaming re-subs
 ## Transport Contracts
 
 - The service supports both transports:
-  - HTTP+JSON (REST endpoints such as `/v1/message:send`)
+  - HTTP+JSON (REST endpoints such as `/message:send`)
   - JSON-RPC (`POST /`)
 - Agent Card exposes both HTTP+JSON and JSON-RPC through `supportedInterfaces`.
 - The public Agent Card is intentionally slimmed to the minimum discovery surface; per-extension disclosure policy is defined in [`extension-specifications.md`](./extension-specifications.md).
@@ -224,7 +224,7 @@ If one deployment works while another fails against the same upstream provider, 
 ## Streaming Contract
 
 - Streaming is always enabled in this server profile; `message:stream` is part of the stable runtime baseline.
-- Streaming (`/v1/message:stream`) emits an initial working `Task`, then incremental `TaskArtifactUpdateEvent` / `TaskStatusUpdateEvent` updates, and finally a terminal `TaskStatusUpdateEvent(final=true)`.
+- Streaming (`/message:stream`) emits an initial working `Task`, then incremental `TaskArtifactUpdateEvent` / `TaskStatusUpdateEvent` updates, and finally a terminal `TaskStatusUpdateEvent(final=true)`.
 - Stream artifacts carry `artifact.metadata.shared.stream.block_type` with values `text` / `reasoning` / `tool_call`.
 - Stream artifacts are scoped to logical output lanes rather than one shared catch-all artifact:
   - text chunks use a stable text artifact ID
@@ -286,7 +286,7 @@ Current behavior:
 - Shared metadata extension URIs such as session binding and streaming are listed under `extensions.extension_uris`.
 - `all_jsonrpc_methods` is the runtime truth for the current deployment.
 - The current SDK-owned core JSON-RPC surface includes `GetExtendedAgentCard` and `tasks/pushNotificationConfig/*`.
-- The current SDK-owned REST surface also includes `GET /v1/tasks` and the task push notification config routes.
+- The current SDK-owned REST surface also includes `GET /tasks` and the task push notification config routes.
 - The SDK-owned core JSON-RPC method set follows the pinned `a2a-sdk` release and is locked by repository tests; review that surface deliberately when upgrading the SDK.
 - Push notification config routes/methods are currently exposed only because they are part of the SDK-owned core surface. This runtime does not configure a push config store or push sender, so push notification operations remain unsupported. REST routes currently return HTTP `501`, while JSON-RPC methods surface SDK-owned unsupported error envelopes.
 
@@ -484,7 +484,7 @@ Consumer guidance:
 Minimal example:
 
 ```bash
-curl -sS http://127.0.0.1:8000/v1/message:send \
+curl -sS http://127.0.0.1:8000/message:send \
   -H 'content-type: application/json' \
   -H 'Authorization: Bearer <your-token>' \
   -d '{
@@ -536,7 +536,7 @@ Consumer guidance:
 Minimal example:
 
 ```bash
-curl -sS http://127.0.0.1:8000/v1/message:send \
+curl -sS http://127.0.0.1:8000/message:send \
   -H 'content-type: application/json' \
   -H 'Authorization: Bearer <your-token>' \
   -d '{
@@ -1223,7 +1223,7 @@ curl -sS http://127.0.0.1:8000/ \
 ## Authentication Example (curl)
 
 ```bash
-curl -sS http://127.0.0.1:8000/v1/message:send \
+curl -sS http://127.0.0.1:8000/message:send \
   -H 'content-type: application/json' \
   -H 'Authorization: Bearer <your-token>' \
   -d '{
@@ -1257,7 +1257,7 @@ curl -sS http://127.0.0.1:8000/ \
 
 ## Streaming Re-Subscription (`SubscribeToTask`)
 
-If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscribe while the task is still non-terminal.
+If an SSE connection drops, use `GET /tasks/{task_id}:subscribe` to re-subscribe while the task is still non-terminal.
 
 ## Cancellation Semantics (`CancelTask`)
 
@@ -1265,7 +1265,7 @@ If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscr
 - For running tasks, the service attempts upstream OpenCode `POST /session/{sessionID}/abort` to stop generation.
 - Upstream interruption is best-effort: if upstream returns 404, network errors, or other HTTP errors, A2A cancellation still completes with `TaskState.TASK_STATE_CANCELED`.
 - Idempotency contract: repeated `CancelTask` on an already `canceled` task returns the current terminal task state without error.
-- Terminal subscribe contract: calling `SubscribeToTask` or `GET /v1/tasks/{task_id}:subscribe` on a terminal task replays one terminal `Task` snapshot and then closes the stream.
+- Terminal subscribe contract: calling `SubscribeToTask` or `GET /tasks/{task_id}:subscribe` on a terminal task replays one terminal `Task` snapshot and then closes the stream.
 - Terminal persistence contract: once a terminal task snapshot is persisted, this service treats it as immutable. Producers must emit final text and artifact updates before the terminal event, and any final usage or stream metadata must be attached to that terminal event itself. Late terminal-state mutations are rejected by the task-store write policy.
 - These two semantics are also declared as machine-readable `service_behaviors` in the compatibility profile and wire contract extensions.
 - At `A2A_LOG_LEVEL=DEBUG`, the service emits lightweight metric log records (`logger=opencode_a2a.execution.executor`):

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -8,6 +8,8 @@ This guide covers configuration, authentication, API behavior, streaming re-subs
   - HTTP+JSON (REST endpoints such as `/message:send`)
   - JSON-RPC (`POST /`)
 - Agent Card exposes both HTTP+JSON and JSON-RPC through `supportedInterfaces`.
+- HTTP+JSON REST endpoints are served at the root path (e.g. `/message:send`, `/tasks`). A2A 1.0 negotiates protocol version via the `A2A-Version` header, not a URL prefix, so the URL path carries no version segment.
+- Breaking change for earlier releases: versions through v1.1.2 served the HTTP+JSON surface under a `/v1` prefix. Deployments upgrading from those releases must repoint clients, reverse proxies, and any `/v1`-prefixed routes to the root paths.
 - The public Agent Card is intentionally slimmed to the minimum discovery surface; per-extension disclosure policy is defined in [`extension-specifications.md`](./extension-specifications.md).
 - Detailed provider-private contracts are served through the authenticated extended card endpoint `/extendedAgentCard`.
 - Agent Card responses emit weak `ETag` and `Cache-Control`; clients should revalidate cached cards instead of repeatedly fetching full payloads.

--- a/src/opencode_a2a/contracts/extensions/catalog.py
+++ b/src/opencode_a2a/contracts/extensions/catalog.py
@@ -377,15 +377,15 @@ SESSION_MUTATION_METHODS: dict[str, str] = {
 
 CORE_JSONRPC_METHODS: tuple[str, ...] = tuple(DECLARED_CORE_JSONRPC_METHODS)
 CORE_HTTP_ENDPOINTS: tuple[str, ...] = (
-    "POST /v1/message:send",
-    "POST /v1/message:stream",
-    "GET /v1/tasks",
-    "GET /v1/tasks/{id}",
-    "POST /v1/tasks/{id}:cancel",
-    "GET /v1/tasks/{id}:subscribe",
-    "GET /v1/tasks/{id}/pushNotificationConfigs",
-    "POST /v1/tasks/{id}/pushNotificationConfigs",
-    "GET /v1/tasks/{id}/pushNotificationConfigs/{push_id}",
+    "POST /message:send",
+    "POST /message:stream",
+    "GET /tasks",
+    "GET /tasks/{id}",
+    "POST /tasks/{id}:cancel",
+    "GET /tasks/{id}:subscribe",
+    "GET /tasks/{id}/pushNotificationConfigs",
+    "POST /tasks/{id}/pushNotificationConfigs",
+    "GET /tasks/{id}/pushNotificationConfigs/{push_id}",
     f"GET {EXTENDED_AGENT_CARD_PATH}",
 )
 WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS: tuple[str, ...] = (

--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -93,7 +93,7 @@ def _build_agent_card_description(
         "(GetExtendedAgentCard), task APIs (GetTask, CancelTask, "
         "SubscribeToTask; SDK-owned push notification config surfaces remain "
         "exposed but currently return unsupported; REST mappings include GET "
-        "/v1/tasks and GET /v1/tasks/{id}:subscribe), shared "
+        "/tasks and GET /tasks/{id}:subscribe), shared "
         "session-binding/model-selection/streaming contracts, provider-private "
         "OpenCode session/provider/model/workspace-control/interrupt recovery "
         "extensions, and shared interrupt callback extensions."

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -789,10 +789,10 @@ class IdentityAwareCallContextBuilder(DefaultServerCallContextBuilder):
         if isinstance(raw_path, (bytes, bytearray)):
             raw_value = raw_path.decode(errors="ignore")
         is_stream = (
-            path.endswith("/v1/message:stream")
-            or path.endswith("/v1/message%3Astream")
-            or raw_value.endswith("/v1/message:stream")
-            or raw_value.endswith("/v1/message%3Astream")
+            path.endswith("/message:stream")
+            or path.endswith("/message%3Astream")
+            or raw_value.endswith("/message:stream")
+            or raw_value.endswith("/message%3Astream")
         )
         if is_stream:
             context.state["a2a_streaming_request"] = True
@@ -955,22 +955,22 @@ def create_app(settings: Settings) -> FastAPI:
             )
 
     app.add_api_route(AGENT_CARD_WELL_KNOWN_PATH, public_agent_card_route, methods=["GET"])
-    app.add_api_route("/v1/message:send", rest_message_send_route, methods=["POST"])
-    app.add_api_route("/v1/message:stream", rest_message_send_stream_route, methods=["POST"])
-    app.add_api_route("/v1/tasks/{id}:cancel", rest_dispatcher.on_cancel_task, methods=["POST"])
+    app.add_api_route("/message:send", rest_message_send_route, methods=["POST"])
+    app.add_api_route("/message:stream", rest_message_send_stream_route, methods=["POST"])
+    app.add_api_route("/tasks/{id}:cancel", rest_dispatcher.on_cancel_task, methods=["POST"])
     app.add_api_route(
-        "/v1/tasks/{id}:subscribe",
+        "/tasks/{id}:subscribe",
         rest_dispatcher.on_subscribe_to_task,
         methods=["GET"],
         operation_id="subscribe_to_task_get",
     )
     app.add_api_route(
-        "/v1/tasks/{id}:subscribe",
+        "/tasks/{id}:subscribe",
         rest_dispatcher.on_subscribe_to_task,
         methods=["POST"],
         operation_id="subscribe_to_task_post",
     )
-    app.add_api_route("/v1/tasks/{id}", rest_dispatcher.on_get_task, methods=["GET"])
+    app.add_api_route("/tasks/{id}", rest_dispatcher.on_get_task, methods=["GET"])
 
     async def push_notifications_unsupported_route(request: Request) -> JSONResponse:
         del request
@@ -985,27 +985,27 @@ def create_app(settings: Settings) -> FastAPI:
         )
 
     app.add_api_route(
-        "/v1/tasks/{id}/pushNotificationConfigs/{push_id}",
+        "/tasks/{id}/pushNotificationConfigs/{push_id}",
         push_notifications_unsupported_route,
         methods=["GET"],
     )
     app.add_api_route(
-        "/v1/tasks/{id}/pushNotificationConfigs/{push_id}",
+        "/tasks/{id}/pushNotificationConfigs/{push_id}",
         push_notifications_unsupported_route,
         methods=["DELETE"],
     )
     app.add_api_route(
-        "/v1/tasks/{id}/pushNotificationConfigs",
+        "/tasks/{id}/pushNotificationConfigs",
         push_notifications_unsupported_route,
         methods=["POST"],
     )
     app.add_api_route(
-        "/v1/tasks/{id}/pushNotificationConfigs",
+        "/tasks/{id}/pushNotificationConfigs",
         push_notifications_unsupported_route,
         methods=["GET"],
     )
     app.add_api_route(
-        "/v1/tasks",
+        "/tasks",
         build_list_tasks_route(
             task_store=task_store,
             context_builder=context_builder.build,

--- a/src/opencode_a2a/server/middleware.py
+++ b/src/opencode_a2a/server/middleware.py
@@ -60,6 +60,17 @@ _REQUEST_BODY_BYTES: ContextVar[bytes | None] = ContextVar(
 )
 
 
+def _is_http_json_rest_path(path: str) -> bool:
+    """Return True for root-based A2A HTTP+JSON REST paths.
+
+    A2A 1.0 resolves REST paths relative to the advertised interface URL
+    (spec sections 8.5/8.6), so this service serves the HTTP+JSON surface at
+    the root: no version prefix in the URL path, with protocol versioning
+    carried in the A2A-Version header instead.
+    """
+    return path.startswith("/message:") or path.startswith("/tasks")
+
+
 def add_auth_middleware(app: FastAPI, settings) -> None:  # noqa: ANN001
     configured_credentials = build_static_auth_credentials(settings)
     advertised_schemes = {credential.auth_scheme for credential in configured_credentials}
@@ -127,7 +138,7 @@ def install_runtime_middlewares(
     def _requires_protocol_negotiation(request: Request) -> bool:
         if request.url.path == "/" and request.method == "POST":
             return True
-        if request.url.path.startswith("/v1/"):
+        if _is_http_json_rest_path(request.url.path):
             return True
         return False
 
@@ -291,7 +302,7 @@ def install_runtime_middlewares(
             supported_extensions = PUBLIC_EXTENSION_URIS
         elif path == EXTENDED_AGENT_CARD_PATH:
             supported_extensions = ALL_EXTENSION_URIS
-        elif path == "/" or path.startswith("/v1/"):
+        elif path == "/" or _is_http_json_rest_path(path):
             supported_extensions = PUBLIC_EXTENSION_URIS
         else:
             return ()
@@ -381,8 +392,8 @@ def install_runtime_middlewares(
     async def guard_rest_payload_shape(request: Request, call_next):
         token: Token | None = None
         if request.method != "POST" or request.url.path not in {
-            "/v1/message:send",
-            "/v1/message:stream",
+            "/message:send",
+            "/message:stream",
         }:
             return await call_next(request)
 

--- a/src/opencode_a2a/server/openapi.py
+++ b/src/opencode_a2a/server/openapi.py
@@ -326,7 +326,7 @@ def _patch_jsonrpc_openapi_contract(
                                 app_json["examples"] = _build_jsonrpc_extension_openapi_examples()
 
             rest_post_contracts: dict[str, dict[str, Any]] = {
-                "/v1/message:send": {
+                "/message:send": {
                     "summary": "Send Message (HTTP+JSON)",
                     "description": (
                         "A2A HTTP+JSON message send endpoint. "
@@ -335,7 +335,7 @@ def _patch_jsonrpc_openapi_contract(
                     ),
                     "schema_ref": "#/components/schemas/SendMessageRequest",
                 },
-                "/v1/message:stream": {
+                "/message:stream": {
                     "summary": "Stream Message (HTTP+JSON)",
                     "description": (
                         "A2A HTTP+JSON streaming endpoint. "

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -772,11 +772,10 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     assert INTERRUPT_RECOVERY_EXTENSION_URI in wire_contract.params["extensions"]["extension_uris"]
     assert "GetExtendedAgentCard" in wire_contract.params["all_jsonrpc_methods"]
     assert "GetTaskPushNotificationConfig" in wire_contract.params["all_jsonrpc_methods"]
-    assert "GET /v1/tasks" in wire_contract.params["core"]["http_endpoints"]
+    assert "GET /tasks" in wire_contract.params["core"]["http_endpoints"]
     assert "GET /extendedAgentCard" in wire_contract.params["core"]["http_endpoints"]
     assert (
-        "GET /v1/tasks/{id}/pushNotificationConfigs"
-        in wire_contract.params["core"]["http_endpoints"]
+        "GET /tasks/{id}/pushNotificationConfigs" in wire_contract.params["core"]["http_endpoints"]
     )
     assert "opencode.sessions.shell" not in wire_contract.params["all_jsonrpc_methods"]
     assert wire_contract.params["service_behaviors"] == expected_service_behaviors

--- a/tests/server/test_app_behaviors.py
+++ b/tests/server/test_app_behaviors.py
@@ -176,11 +176,11 @@ def test_request_payload_helpers_cover_edge_cases() -> None:
 
 
 def test_rest_message_parsing_helpers_cover_upgrade_paths() -> None:
-    request_v1 = _request("/v1/message:send")
+    request_v1 = _request("/message:send")
     request_v1.state.a2a_protocol_version = "1.0"
     v1_error = _rest_error_response(
         request=request_v1,
-        error=InvalidRequestError(message="bad payload", data={"path": "/v1/message:send"}),
+        error=InvalidRequestError(message="bad payload", data={"path": "/message:send"}),
     )
     assert v1_error.status_code == 400
     assert json.loads(v1_error.body) == {
@@ -193,17 +193,17 @@ def test_rest_message_parsing_helpers_cover_upgrade_paths() -> None:
                     "@type": "type.googleapis.com/google.rpc.ErrorInfo",
                     "reason": "INVALID_REQUEST",
                     "domain": "a2a-protocol.org",
-                    "metadata": {"path": "/v1/message:send"},
+                    "metadata": {"path": "/message:send"},
                 },
                 {
                     "@type": "type.googleapis.com/opencode_a2a.HttpErrorContext",
-                    "path": "/v1/message:send",
+                    "path": "/message:send",
                 },
             ],
         }
     }
 
-    request_default = _request("/v1/message:send")
+    request_default = _request("/message:send")
     parse_error = _rest_error_response(
         request=request_default,
         error=ParseError("bad parse"),
@@ -636,7 +636,7 @@ async def test_rest_adapter_routes_and_preconsume_error() -> None:
 
     handler.on_subscribe_to_task = _stream
     response = await adapter.on_subscribe_to_task(
-        _request("/v1/tasks/x:subscribe", method="GET", path_params={"id": "x"})
+        _request("/tasks/x:subscribe", method="GET", path_params={"id": "x"})
     )
     assert response is not None
 
@@ -665,7 +665,7 @@ async def test_push_notification_routes_are_explicitly_unsupported(monkeypatch) 
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            "/v1/tasks/task-1/pushNotificationConfigs",
+            "/tasks/task-1/pushNotificationConfigs",
             headers={"Authorization": "Bearer test-token"},
             json={"pushNotificationConfig": {"url": "https://example.com/hook"}},
         )
@@ -841,8 +841,8 @@ async def test_rest_message_routes_cover_message_and_error_wrappers(monkeypatch)
     }
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        send_response = await client.post("/v1/message:send", headers=headers, json=payload)
-        stream_response = await client.post("/v1/message:stream", headers=headers, json=payload)
+        send_response = await client.post("/message:send", headers=headers, json=payload)
+        stream_response = await client.post("/message:stream", headers=headers, json=payload)
 
     assert send_response.status_code == 200
     assert send_response.json() == {

--- a/tests/server/test_call_context_builder.py
+++ b/tests/server/test_call_context_builder.py
@@ -46,7 +46,7 @@ def test_builder_sets_identity_for_non_stream_request():
 
 def test_builder_marks_rest_stream_request():
     builder = IdentityAwareCallContextBuilder()
-    context = builder.build(_request("/v1/message:stream"))
+    context = builder.build(_request("/message:stream"))
     assert context.state.get("identity") == "opaque:test-id"
     assert context.user.is_authenticated is True
     assert context.user.user_name == "opaque:test-id"
@@ -62,7 +62,7 @@ def test_builder_marks_rest_stream_request():
 
 def test_builder_marks_encoded_stream_request():
     builder = IdentityAwareCallContextBuilder()
-    context = builder.build(_request("/v1/message%3Astream", raw_path=b"/v1/message%3Astream"))
+    context = builder.build(_request("/message%3Astream", raw_path=b"/message%3Astream"))
     assert context.state.get("identity") == "opaque:test-id"
     assert context.user.is_authenticated is True
     assert context.user.user_name == "opaque:test-id"

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -174,8 +174,8 @@ def test_rest_subscription_route_matches_current_sdk_contract() -> None:
     app = create_app(make_settings(test_bearer_token="test-token"))
     route_paths = {route.path for route in app.router.routes if hasattr(route, "path")}
 
-    assert "/v1/tasks/{id}:subscribe" in route_paths
-    assert "/v1/tasks/{id}:resubscribe" not in route_paths
+    assert "/tasks/{id}:subscribe" in route_paths
+    assert "/tasks/{id}:resubscribe" not in route_paths
 
 
 def test_rest_subscription_route_registers_distinct_get_and_post_operations() -> None:
@@ -183,7 +183,7 @@ def test_rest_subscription_route_registers_distinct_get_and_post_operations() ->
     subscribe_routes = [
         route
         for route in app.router.routes
-        if getattr(route, "path", None) == "/v1/tasks/{id}:subscribe"
+        if getattr(route, "path", None) == "/tasks/{id}:subscribe"
     ]
 
     assert len(subscribe_routes) == 2
@@ -251,7 +251,7 @@ async def test_list_tasks_route_returns_paginated_results(monkeypatch) -> None:
     headers = {"Authorization": "Bearer test-token"}
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         first_page = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={"contextId": "ctx-list", "pageSize": "1"},
         )
@@ -266,7 +266,7 @@ async def test_list_tasks_route_returns_paginated_results(monkeypatch) -> None:
         assert first_payload["nextPageToken"]
 
         second_page = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={
                 "contextId": "ctx-list",
@@ -316,7 +316,7 @@ async def test_list_tasks_route_respects_authenticated_owner_scope(monkeypatch) 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers={"Authorization": "Bearer test-token"},
             params={"contextId": "ctx-owner-scope"},
         )
@@ -371,7 +371,7 @@ async def test_list_tasks_route_cursor_stays_stable_when_newer_task_is_inserted(
     headers = {"Authorization": "Bearer test-token"}
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         first_page = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={"contextId": "ctx-cursor", "pageSize": "1"},
         )
@@ -388,7 +388,7 @@ async def test_list_tasks_route_cursor_stays_stable_when_newer_task_is_inserted(
         )
 
         second_page = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={
                 "contextId": "ctx-cursor",
@@ -442,7 +442,7 @@ async def test_list_tasks_route_supports_history_artifacts_and_filters(monkeypat
     headers = {"Authorization": "Bearer test-token"}
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={
                 "contextId": "ctx-filtered",
@@ -501,7 +501,7 @@ async def test_list_tasks_route_applies_persisted_output_negotiation(monkeypatch
     headers = {"Authorization": "Bearer test-token"}
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={
                 "contextId": "ctx-negotiated-list",
@@ -555,12 +555,12 @@ async def test_list_tasks_route_filters_unnegotiated_shared_extension_metadata(m
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         without_extensions = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers={"Authorization": "Bearer test-token"},
             params={"contextId": "ctx-shared-list"},
         )
         with_extensions = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers={
                 "Authorization": "Bearer test-token",
                 "A2A-Extensions": ",".join(
@@ -605,7 +605,7 @@ async def test_rest_message_route_echoes_only_activated_shared_extensions_header
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            "/v1/message:send",
+            "/message:send",
             headers={
                 "Authorization": "Bearer test-token",
                 "A2A-Extensions": ",".join(
@@ -701,7 +701,7 @@ async def test_list_tasks_route_tolerates_invalid_stored_status_timestamp(monkey
     headers = {"Authorization": "Bearer test-token"}
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={"contextId": "ctx-invalid-ts"},
         )
@@ -728,17 +728,17 @@ async def test_list_tasks_route_validates_query_parameters(monkeypatch) -> None:
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         page_size_error = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={"pageSize": "0"},
         )
         page_token_error = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={"pageToken": "invalid-token"},
         )
         status_error = await client.get(
-            "/v1/tasks",
+            "/tasks",
             headers=headers,
             params={"status": "completed"},
         )
@@ -811,8 +811,8 @@ def test_openapi_rest_message_routes_include_schema_and_examples() -> None:
     paths = openapi["paths"]
 
     expected: dict[str, str] = {
-        "/v1/message:send": "#/components/schemas/SendMessageRequest",
-        "/v1/message:stream": "#/components/schemas/SendStreamingMessageRequest",
+        "/message:send": "#/components/schemas/SendMessageRequest",
+        "/message:stream": "#/components/schemas/SendStreamingMessageRequest",
     }
     for path, expected_schema_ref in expected.items():
         post = paths[path]["post"]
@@ -953,7 +953,7 @@ async def test_rest_endpoints_reject_unsupported_protocol_version() -> None:
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            "/v1/message:send",
+            "/message:send",
             headers={
                 "Authorization": "Bearer test-token",
                 "A2A-Version": "2.0",
@@ -1002,7 +1002,7 @@ async def test_rest_endpoints_return_v1_status_body_for_v1_protocol_errors() -> 
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            "/v1/message:send?A2A-Version=1.1",
+            "/message:send?A2A-Version=1.1",
             headers={"Authorization": "Bearer test-token"},
             json={
                 "message": {
@@ -1124,7 +1124,7 @@ async def test_streaming_responses_remain_outside_gzip_middleware(monkeypatch) -
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         async with client.stream(
             "POST",
-            "/v1/message:stream",
+            "/message:stream",
             headers={
                 "Authorization": "Bearer test-token",
                 "Accept-Encoding": "gzip",
@@ -1172,7 +1172,7 @@ async def test_dual_stack_send_accepts_transport_native_payloads(monkeypatch) ->
     }
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        rest_resp = await client.post("/v1/message:send", headers=headers, json=rest_payload)
+        rest_resp = await client.post("/message:send", headers=headers, json=rest_payload)
         assert rest_resp.status_code == 200
 
         rpc_resp = await client.post("/", headers=headers, json=rpc_payload)
@@ -1255,7 +1255,7 @@ async def test_dual_stack_send_rejects_cross_transport_payload_shapes(monkeypatc
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         rest_resp = await client.post(
-            "/v1/message:send",
+            "/message:send",
             headers=headers,
             json=rest_with_jsonrpc_shape,
         )
@@ -1276,7 +1276,7 @@ async def test_dual_stack_send_rejects_cross_transport_payload_shapes(monkeypatc
         }
 
         rest_envelope_resp = await client.post(
-            "/v1/message:send",
+            "/message:send",
             headers=headers,
             json=full_jsonrpc_envelope,
         )
@@ -1296,18 +1296,18 @@ async def test_dual_stack_send_rejects_cross_transport_payload_shapes(monkeypatc
                         "@type": "type.googleapis.com/google.rpc.ErrorInfo",
                         "reason": "INVALID_HTTP_JSON_PAYLOAD",
                         "domain": "a2a-protocol.org",
-                        "metadata": {"path": "/v1/message:send"},
+                        "metadata": {"path": "/message:send"},
                     },
                     {
                         "@type": "type.googleapis.com/opencode_a2a.HttpErrorContext",
-                        "path": "/v1/message:send",
+                        "path": "/message:send",
                     },
                 ],
             }
         }
 
         v1_rest_resp = await client.post(
-            "/v1/message:send",
+            "/message:send",
             headers={**headers, "A2A-Version": "1.0"},
             json=rest_with_jsonrpc_shape,
         )
@@ -1372,7 +1372,7 @@ async def test_log_payloads_keeps_body_for_rest_handler(monkeypatch, caplog) -> 
     with caplog.at_level(logging.DEBUG, logger="opencode_a2a.server.application"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
-                "/v1/message:send",
+                "/message:send",
                 headers=headers,
                 json=_rest_message_payload(),
             )
@@ -1380,7 +1380,7 @@ async def test_log_payloads_keeps_body_for_rest_handler(monkeypatch, caplog) -> 
             assert resp.status_code == 200
 
     assert any(
-        "A2A request POST /v1/message:send body=" in record.message for record in caplog.records
+        "A2A request POST /message:send body=" in record.message for record in caplog.records
     )
 
 
@@ -1398,7 +1398,7 @@ async def test_log_payloads_streaming_response_path(monkeypatch, caplog) -> None
     with caplog.at_level(logging.DEBUG, logger="opencode_a2a.server.application"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             async with client.stream(
-                "POST", "/v1/message:stream", headers=headers, json=_rest_message_payload()
+                "POST", "/message:stream", headers=headers, json=_rest_message_payload()
             ) as resp:
                 assert resp.status_code == 200
                 assert "text/event-stream" in resp.headers.get("content-type", "")
@@ -1407,8 +1407,8 @@ async def test_log_payloads_streaming_response_path(monkeypatch, caplog) -> None
                         break
 
     assert any(
-        "A2A response /v1/message:stream status=200" in record.message
-        or "A2A response /v1/message:stream streaming" in record.message
+        "A2A response /message:stream status=200" in record.message
+        or "A2A response /message:stream streaming" in record.message
         for record in caplog.records
     )
 


### PR DESCRIPTION
Closes #496

## 背景

A2A 1.0 中 `supportedInterfaces[].url` 是 binding 的基准 URL，客户端相对它解析 REST 路径（spec §8.5/§8.6）；协议版本通过 `A2A-Version` header 协商，不在 URL 路径中。Python a2a-sdk 默认 `create_rest_routes(path_prefix='')`，即根路径注册。

本仓库自早期版本起在 `server/application.py` 硬编码 `/v1/...` 路由（v1.1.2 及更早版本均如此），属于 adapter 自选前缀：与 a2a-sdk 默认布局及生态不一致，且本服务只运行 v1-only，前缀并未承担任何版本分发职能。符合规范的客户端（如官方 @a2a-js/sdk）基于卡片广告的 URL 解析路径，此前因卡片广告裸 URL 而服务端只服务 `/v1` 导致 404。

## 变更

- HTTP+JSON 路由改为根路径：`/message:send`、`/message:stream`、`/tasks`、`/tasks/{id}`、`/tasks/{id}:cancel`、`/tasks/{id}:subscribe`、push notification config 路由。
- `server/middleware.py`：REST 路径识别（协议协商、扩展激活、REST payload 守卫）改为根路径判定（`_is_http_json_rest_path`）。
- `server/openapi.py` 与 `contracts/extensions/catalog.py`：端点声明同步去掉 `/v1`。
- Agent Card 的 HTTP+JSON interface URL 保持裸 `public_url`（无 `/v1`）。
- README、`docs/guide.md`（含根路径契约与 `/v1` 迁移说明）、相关测试同步更新。

## 验证

`./scripts/doctor.sh` 全部通过：

- pre-commit 各检查通过
- mypy 无问题
- 706 个测试全部通过（含根路径 REST 路由、OpenAPI、Agent Card 契约）
- 覆盖率 93.03%，满足策略
- wheel 构建与 CLI 冒烟测试通过

## 兼容性说明

`/v1` 前缀自 v1.1.2 及更早版本即存在；本 PR 将 REST 路径改为根路径属于破坏性变更。升级时需将客户端、反向代理及任何 `/v1` 前缀路由切换到根路径（见 `docs/guide.md` Transport Contracts 说明）。

## 相关

- Closes #496
- 取代已关闭的 #497（该 PR 方向错误：把 `/v1` 写进卡片，而非移除 `/v1`）
- commits：`89f64ce`、`426f2d2`
