### PR TITLE
fix(client): enforce outbound A2A network policy and credential binding

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -59,6 +59,8 @@ Key variables to understand protocol behavior:
 - `A2A_CLIENT_BEARER_TOKEN`: optional bearer token attached to outbound peer calls made by the embedded A2A client and `a2a_call` tool path.
 - `A2A_CLIENT_BASIC_AUTH`: optional Basic auth credential attached to outbound peer calls made by the embedded A2A client and `a2a_call` tool path.
 - `A2A_CLIENT_SUPPORTED_TRANSPORTS`: ordered outbound transport preference list.
+- `A2A_CLIENT_ALLOWED_HOSTS`: comma-separated allowlist of outbound target hosts for the embedded A2A client and `a2a_call` tool path (exact names or `*.example.com` wildcards). When configured, outbound calls are restricted to matching hosts, and outbound credentials (`A2A_CLIENT_BEARER_TOKEN` / `A2A_CLIENT_BASIC_AUTH`) are only sent to allowlisted hosts.
+- `A2A_CLIENT_ALLOW_PRIVATE_HOSTS`: default `false`. When `false`, outbound `a2a_call(...)` targets that resolve to private, loopback, link-local, reserved, or multicast addresses are rejected (SSRF / DNS-rebinding guard). Set to `true` only when the deployment intentionally targets A2A peers on the local network.
 - `A2A_TASK_STORE_BACKEND`: unified lightweight persistence backend for SDK task rows plus adapter-managed session / interrupt state. Supported values: `database`, `memory`. Default: `database`.
 - `A2A_TASK_STORE_DATABASE_URL`: database URL used by the unified durable backend when `A2A_TASK_STORE_BACKEND=database`. Default: `sqlite+aiosqlite:///./opencode-a2a.db`.
 - On startup, the runtime only auto-migrates adapter-owned state tables; existing SDK-owned task tables must be upgraded explicitly with upstream `a2a-db`.
@@ -102,6 +104,14 @@ Current client facade API:
 - `A2AClient.subscribe_to_task()`
 
 Server-side outbound peer calls read outbound credentials from environment variables. Configure `A2A_CLIENT_BEARER_TOKEN` or `A2A_CLIENT_BASIC_AUTH` when the remote agent protects its runtime surface. CLI outbound calls follow the same environment-only model.
+
+The embedded `a2a_call(...)` tool lets the upstream model choose the target URL, so the adapter applies a fail-closed network policy before opening any connection:
+
+- only `http`/`https` schemes are accepted, and URLs carrying userinfo credentials are rejected;
+- when `A2A_CLIENT_ALLOWED_HOSTS` is set, the target host must match the allowlist (exact or `*.example.com` wildcard);
+- unless `A2A_CLIENT_ALLOW_PRIVATE_HOSTS=true`, the resolved addresses must be public; private/loopback/link-local/reserved addresses are rejected even when the hostname matches the allowlist (DNS rebinding defense);
+- outbound credentials are only attached to allowlisted hosts. If credentials are configured without an allowlist, they are never sent and a warning is logged;
+- the `opencode-a2a call` CLI remains a manual operator action and is not subject to the allowlist, but still rejects non-http(s) schemes through the shared client URL handling.
 
 CLI outbound example:
 

--- a/src/opencode_a2a/client/network_policy.py
+++ b/src/opencode_a2a/client/network_policy.py
@@ -1,0 +1,155 @@
+"""Outbound A2A client network policy (SSRF guard and credential binding).
+
+The embedded ``a2a_call`` tool lets the upstream model choose the target URL,
+so without an explicit policy the adapter could connect to private/loopback/
+link-local addresses (cloud metadata, internal services) and would attach
+globally configured outbound credentials to any endpoint.
+
+This module centralizes the checks:
+
+- only ``http``/``https`` schemes are accepted;
+- userinfo credentials in the URL are rejected;
+- when ``A2A_CLIENT_ALLOWED_HOSTS`` is configured, the host must match the
+  allowlist (exact or ``*.example.com`` wildcard);
+- unless ``A2A_CLIENT_ALLOW_PRIVATE_HOSTS`` is set, DNS resolution results are
+  validated and private/loopback/link-local/reserved addresses are rejected
+  (DNS-rebinding defense);
+- outbound credentials may only be attached to hosts that match the allowlist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from collections.abc import Sequence
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+_Address = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+class A2ANetworkPolicyError(ValueError):
+    """Raised when an outbound agent URL violates the network policy."""
+
+
+@dataclass(frozen=True)
+class NetworkPolicyDecision:
+    """Outcome of validating an outbound agent URL."""
+
+    host: str
+    allowed_host: bool
+    credentials_allowed: bool
+
+
+def matches_allowed_host(host: str, allowed_hosts: Sequence[str]) -> bool:
+    """Return whether ``host`` matches an allowlist entry.
+
+    Entries may be exact hostnames or ``*.example.com`` wildcards. A wildcard
+    matches any number of subdomain labels but never the bare apex domain.
+    """
+
+    normalized = (host or "").strip().lower().rstrip(".")
+    if not normalized:
+        return False
+    for raw_entry in allowed_hosts or ():
+        entry = (raw_entry or "").strip().lower().rstrip(".")
+        if not entry:
+            continue
+        if entry.startswith("*."):
+            suffix = entry[1:]  # ".example.com"
+            apex = suffix[1:]  # "example.com"
+            if normalized != apex and normalized.endswith(suffix):
+                return True
+        elif normalized == entry:
+            return True
+    return False
+
+
+def _is_private_address(address: _Address) -> bool:
+    return bool(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+async def resolve_host_addresses(host: str) -> tuple[str, ...]:
+    """Resolve ``host`` to a de-duplicated tuple of IP address strings."""
+
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise A2ANetworkPolicyError(f"Agent URL host could not be resolved: {host!r}") from exc
+    addresses: list[str] = []
+    for info in infos:
+        ip = str(info[4][0])
+        if ip not in addresses:
+            addresses.append(ip)
+    return tuple(addresses)
+
+
+async def validate_agent_url(
+    agent_url: str,
+    *,
+    allowed_hosts: Sequence[str] | None = None,
+    allow_private_hosts: bool = False,
+) -> NetworkPolicyDecision:
+    """Validate an outbound agent URL against the configured network policy."""
+
+    normalized = (agent_url or "").strip()
+    if not normalized:
+        raise A2ANetworkPolicyError("agent_url is required")
+
+    parsed = urlsplit(normalized)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise A2ANetworkPolicyError(
+            f"Agent URL scheme must be http or https, got {scheme or 'empty'}"
+        )
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        raise A2ANetworkPolicyError("Agent URL must include a host")
+    if parsed.username or parsed.password:
+        raise A2ANetworkPolicyError("Agent URL must not include userinfo credentials")
+
+    allowlist = tuple(
+        (item or "").strip().lower().rstrip(".")
+        for item in allowed_hosts or ()
+        if (item or "").strip()
+    )
+    matched = matches_allowed_host(host, allowlist)
+    if allowlist and not matched:
+        raise A2ANetworkPolicyError(
+            f"Agent URL host {host!r} is not allowed by A2A_CLIENT_ALLOWED_HOSTS"
+        )
+
+    if not allow_private_hosts:
+        try:
+            addresses = await resolve_host_addresses(host)
+        except A2ANetworkPolicyError:
+            raise
+        except OSError as exc:
+            raise A2ANetworkPolicyError(f"Agent URL host could not be resolved: {host!r}") from exc
+        private = [
+            address for address in addresses if _is_private_address(ipaddress.ip_address(address))
+        ]
+        if private:
+            raise A2ANetworkPolicyError(
+                f"Agent URL host {host!r} resolves to a private/loopback address: {private[0]}"
+            )
+
+    return NetworkPolicyDecision(
+        host=host,
+        allowed_host=matched,
+        credentials_allowed=bool(allowlist) and matched,
+    )

--- a/src/opencode_a2a/config.py
+++ b/src/opencode_a2a/config.py
@@ -281,6 +281,14 @@ class Settings(BaseSettings):
         default=("JSONRPC", "HTTP+JSON"),
         alias="A2A_CLIENT_SUPPORTED_TRANSPORTS",
     )
+    a2a_client_allowed_hosts: DeclaredStringList = Field(
+        default=(),
+        alias="A2A_CLIENT_ALLOWED_HOSTS",
+    )
+    a2a_client_allow_private_hosts: bool = Field(
+        default=False,
+        alias="A2A_CLIENT_ALLOW_PRIVATE_HOSTS",
+    )
     # Task store settings
     a2a_task_store_backend: TaskStoreBackend = Field(
         default="database",

--- a/src/opencode_a2a/server/client_manager.py
+++ b/src/opencode_a2a/server/client_manager.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import asynccontextmanager
+from dataclasses import replace
 
 from ..client import A2AClient
+from ..client.network_policy import validate_agent_url
+
+logger = logging.getLogger(__name__)
 
 
 class A2AClientManager:
@@ -26,6 +31,8 @@ class A2AClientManager:
         )
         self._cache_ttl_seconds = float(settings.a2a_client_cache_ttl_seconds)
         self._cache_maxsize = int(settings.a2a_client_cache_maxsize)
+        self._allowed_hosts = tuple(getattr(settings, "a2a_client_allowed_hosts", ()) or ())
+        self._allow_private_hosts = bool(getattr(settings, "a2a_client_allow_private_hosts", False))
         self._now = time.monotonic
         self.clients: dict[str, _ClientCacheEntry] = {}
         self._lock = asyncio.Lock()
@@ -33,8 +40,27 @@ class A2AClientManager:
     @asynccontextmanager
     async def borrow_client(self, agent_url: str):
         url = agent_url.rstrip("/")
+        policy = await validate_agent_url(
+            url,
+            allowed_hosts=self._allowed_hosts,
+            allow_private_hosts=self._allow_private_hosts,
+        )
+        client_settings = self.client_settings
+        if not policy.credentials_allowed and (
+            client_settings.bearer_token or client_settings.basic_auth
+        ):
+            logger.warning(
+                "Outbound A2A credentials are configured but host=%s is not in "
+                "A2A_CLIENT_ALLOWED_HOSTS; credentials will not be sent",
+                policy.host,
+            )
+            client_settings = replace(
+                client_settings,
+                bearer_token=None,
+                basic_auth=None,
+            )
         if self._cache_maxsize <= 0:
-            client = A2AClient(url, settings=self.client_settings)
+            client = A2AClient(url, settings=client_settings)
             try:
                 yield client
             finally:
@@ -55,7 +81,7 @@ class A2AClientManager:
             to_close.extend(self._evict_locked(now=now, protected_keys={url}))
             if entry is None:
                 entry = _ClientCacheEntry(
-                    client=A2AClient(url, settings=self.client_settings),
+                    client=A2AClient(url, settings=client_settings),
                     last_used=now,
                     expires_at=None
                     if self._cache_ttl_seconds <= 0

--- a/tests/client/test_network_policy.py
+++ b/tests/client/test_network_policy.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from opencode_a2a.client.network_policy import (
+    A2ANetworkPolicyError,
+    matches_allowed_host,
+    resolve_host_addresses,
+    validate_agent_url,
+)
+
+
+def test_matches_allowed_host_exact_and_wildcard() -> None:
+    assert not matches_allowed_host("", ["peer.example.com"])
+    assert not matches_allowed_host(None, ["peer.example.com"])
+    assert matches_allowed_host("peer.example.com", ["", "peer.example.com"])
+    assert matches_allowed_host("peer.example.com", ["peer.example.com"])
+    assert matches_allowed_host("a.example.com", ["*.example.com"])
+    assert matches_allowed_host("b.a.example.com", ["*.example.com"])
+    assert not matches_allowed_host("example.com", ["*.example.com"])
+    assert not matches_allowed_host("other.org", ["*.example.com"])
+    assert not matches_allowed_host("evil-example.com", ["*.example.com"])
+
+
+@pytest.mark.asyncio
+async def test_resolve_host_addresses_resolves_localhost() -> None:
+    addresses = await resolve_host_addresses("localhost")
+
+    assert addresses
+    assert all(address for address in addresses)
+
+
+@pytest.mark.asyncio
+async def test_resolve_host_addresses_deduplicates(monkeypatch: pytest.MonkeyPatch) -> None:
+    loop = asyncio.get_running_loop()
+    infos = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.35", 0)),
+    ]
+
+    async def fake_getaddrinfo(*args: object, **kwargs: object) -> list[tuple]:
+        del args, kwargs
+        return infos
+
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+
+    addresses = await resolve_host_addresses("peer.example.com")
+
+    assert addresses == ("93.184.216.34", "93.184.216.35")
+
+
+@pytest.mark.asyncio
+async def test_resolve_host_addresses_rejects_dns_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = asyncio.get_running_loop()
+
+    async def fake_getaddrinfo(*args: object, **kwargs: object) -> list[tuple]:
+        del args, kwargs
+        raise socket.gaierror("no such host")
+
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(A2ANetworkPolicyError, match="could not be resolved"):
+        await resolve_host_addresses("peer.example.com")
+
+
+def _patch_public_dns(monkeypatch: pytest.MonkeyPatch, *addresses: str) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        return tuple(addresses)
+
+    monkeypatch.setattr(
+        "opencode_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_non_http_schemes(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    with pytest.raises(A2ANetworkPolicyError, match="scheme"):
+        await validate_agent_url("file:///etc/passwd")
+    with pytest.raises(A2ANetworkPolicyError, match="scheme"):
+        await validate_agent_url("ftp://peer.example.com/")
+    with pytest.raises(A2ANetworkPolicyError, match="scheme"):
+        await validate_agent_url("peer.example.com/path")
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_empty_url() -> None:
+    with pytest.raises(A2ANetworkPolicyError, match="agent_url is required"):
+        await validate_agent_url("")
+    with pytest.raises(A2ANetworkPolicyError, match="agent_url is required"):
+        await validate_agent_url("   ")
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_missing_host_and_userinfo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    with pytest.raises(A2ANetworkPolicyError, match="host"):
+        await validate_agent_url("https:///path")
+    with pytest.raises(A2ANetworkPolicyError, match="userinfo"):
+        await validate_agent_url(
+            "https://user:pass@peer.example.com/"  # pragma: allowlist secret
+        )
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_host_outside_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    with pytest.raises(A2ANetworkPolicyError, match="not allowed"):
+        await validate_agent_url(
+            "https://other.org/",
+            allowed_hosts=["peer.example.com"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_allowlisted_public_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    decision = await validate_agent_url(
+        "https://peer.example.com/",
+        allowed_hosts=["*.example.com"],
+    )
+    assert decision.host == "peer.example.com"
+    assert decision.allowed_host is True
+    assert decision.credentials_allowed is True
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "169.254.169.254",
+        "192.168.1.1",
+        "172.16.0.1",
+        "0.0.0.0",
+        "::1",
+        "fd00::1",
+        "fe80::1",
+    ],
+)
+@pytest.mark.asyncio
+async def test_validate_rejects_private_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    address: str,
+) -> None:
+    _patch_public_dns(monkeypatch, address)
+
+    with pytest.raises(A2ANetworkPolicyError, match="private/loopback"):
+        await validate_agent_url("https://peer.example.com/")
+
+
+@pytest.mark.asyncio
+async def test_allow_private_hosts_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_public_dns(monkeypatch, "127.0.0.1")
+
+    decision = await validate_agent_url(
+        "https://127.0.0.1:8000/",
+        allow_private_hosts=True,
+    )
+    assert decision.credentials_allowed is False
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_dns_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        raise socket.gaierror("no such host")
+
+    monkeypatch.setattr(
+        "opencode_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+    with pytest.raises(A2ANetworkPolicyError, match="could not be resolved"):
+        await validate_agent_url("https://peer.example.com/")
+
+
+@pytest.mark.asyncio
+async def test_validate_propagates_resolver_policy_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        raise A2ANetworkPolicyError("resolver blocked")
+
+    monkeypatch.setattr(
+        "opencode_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+    with pytest.raises(A2ANetworkPolicyError, match="resolver blocked"):
+        await validate_agent_url("https://peer.example.com/")

--- a/tests/execution/test_opencode_agent_session_binding.py
+++ b/tests/execution/test_opencode_agent_session_binding.py
@@ -563,6 +563,8 @@ async def test_agent_a2a_call_uses_server_side_basic_auth_headers(
             a2a_client_supported_transports=("JSONRPC", "HTTP+JSON"),
             a2a_client_cache_ttl_seconds=60.0,
             a2a_client_cache_maxsize=1,
+            a2a_client_allowed_hosts=("remote",),
+            a2a_client_allow_private_hosts=True,
         )
     )
     results = await maybe_handle_tools(
@@ -624,6 +626,8 @@ async def test_agent_a2a_call_propagates_current_trace_headers(
             a2a_client_supported_transports=("JSONRPC", "HTTP+JSON"),
             a2a_client_cache_ttl_seconds=60.0,
             a2a_client_cache_maxsize=1,
+            a2a_client_allowed_hosts=("remote",),
+            a2a_client_allow_private_hosts=True,
         )
     )
     with bind_trace_context(

--- a/tests/server/test_a2a_client_manager.py
+++ b/tests/server/test_a2a_client_manager.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from opencode_a2a.client.network_policy import A2ANetworkPolicyError
 from opencode_a2a.server import client_manager as client_manager_module
 
 
@@ -17,6 +18,8 @@ def _make_settings(**overrides: object) -> SimpleNamespace:
         "a2a_client_supported_transports": ("JSONRPC", "HTTP+JSON"),
         "a2a_client_cache_ttl_seconds": 60.0,
         "a2a_client_cache_maxsize": 2,
+        "a2a_client_allowed_hosts": (),
+        "a2a_client_allow_private_hosts": True,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -55,6 +58,131 @@ async def test_client_manager_evicts_lru_idle_clients(monkeypatch: pytest.Monkey
     assert created[0].closed is True
     assert created[1].closed is False
     assert created[2].closed is False
+
+
+def _patch_private_dns(monkeypatch: pytest.MonkeyPatch, *addresses: str) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        return tuple(addresses)
+
+    monkeypatch.setattr(
+        "opencode_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_manager_rejects_host_outside_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeClient:
+        def __init__(self, agent_url: str, *, settings) -> None:
+            del agent_url, settings
+
+        def is_busy(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(client_manager_module, "A2AClient", _FakeClient)
+    manager = client_manager_module.A2AClientManager(
+        _make_settings(a2a_client_allowed_hosts=("peer.example.com",))
+    )
+
+    with pytest.raises(A2ANetworkPolicyError, match="not allowed"):
+        async with manager.borrow_client("https://other.org/"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_client_manager_rejects_private_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeClient:
+        def __init__(self, agent_url: str, *, settings) -> None:
+            del agent_url, settings
+
+        def is_busy(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+    _patch_private_dns(monkeypatch, "169.254.169.254")
+    monkeypatch.setattr(client_manager_module, "A2AClient", _FakeClient)
+    manager = client_manager_module.A2AClientManager(
+        _make_settings(a2a_client_allow_private_hosts=False)
+    )
+
+    with pytest.raises(A2ANetworkPolicyError, match="private/loopback"):
+        async with manager.borrow_client("https://peer.example.com/"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_client_manager_strips_credentials_without_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[_RecordingClient] = []
+
+    class _RecordingClient:
+        def __init__(self, agent_url: str, *, settings) -> None:
+            self.agent_url = agent_url
+            self.settings = settings
+            created.append(self)
+
+        def is_busy(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(client_manager_module, "A2AClient", _RecordingClient)
+    manager = client_manager_module.A2AClientManager(
+        _make_settings(
+            a2a_client_bearer_token="peer-token",
+            a2a_client_allowed_hosts=(),
+        )
+    )
+
+    async with manager.borrow_client("https://peer.example.com/"):
+        pass
+
+    assert created[0].settings.bearer_token is None
+    assert created[0].settings.basic_auth is None
+
+
+@pytest.mark.asyncio
+async def test_client_manager_keeps_credentials_for_allowlisted_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[_RecordingClient] = []
+
+    class _RecordingClient:
+        def __init__(self, agent_url: str, *, settings) -> None:
+            self.agent_url = agent_url
+            self.settings = settings
+            created.append(self)
+
+        def is_busy(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(client_manager_module, "A2AClient", _RecordingClient)
+    manager = client_manager_module.A2AClientManager(
+        _make_settings(
+            a2a_client_bearer_token="peer-token",
+            a2a_client_allowed_hosts=("peer.example.com",),
+        )
+    )
+
+    async with manager.borrow_client("https://peer.example.com/"):
+        pass
+
+    assert created[0].settings.bearer_token == "peer-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联 Issue

- Closes #500
- Relates to #499（#499 审计拆解出的最高危项）

## 背景

`a2a_call` 工具允许上游模型选择出站目标 URL。原实现无 URL 白名单或私网地址校验，且全局出站凭据（`A2A_CLIENT_BEARER_TOKEN` / `A2A_CLIENT_BASIC_AUTH`）会随请求自动附加到任意端点，形成 SSRF 与凭据外泄风险。与 codex-a2a #342 的修复方案对齐。

## 变更内容

- 新增 `src/opencode_a2a/client/network_policy.py`：出站 URL 网络策略
  - 仅允许 `http`/`https`，拒绝携带 userinfo 的 URL；
  - 配置 `A2A_CLIENT_ALLOWED_HOSTS` 后，目标 host 必须命中白名单（支持 `*.example.com` 通配符）；
  - 默认（`A2A_CLIENT_ALLOW_PRIVATE_HOSTS=false`）拒绝解析为私网/环回/链路本地/保留/组播地址的目标（DNS rebinding 防线）；
  - 返回凭据发放决策：仅白名单命中 host 可携带出站凭据。
- `src/opencode_a2a/server/client_manager.py`：`borrow_client` 在创建/复用客户端前执行策略校验；未配置白名单时凭据 fail-closed（记录 warning），不再发送到任意端点。
- `src/opencode_a2a/config.py`：新增 `A2A_CLIENT_ALLOWED_HOSTS`、`A2A_CLIENT_ALLOW_PRIVATE_HOSTS`。
- 测试：`tests/client/test_network_policy.py`（scheme/私网/白名单/凭据绑定/DNS 失败）；更新 `tests/server/test_a2a_client_manager.py` 与 `tests/execution/test_opencode_agent_session_binding.py` 适配新语义。
- 文档：`docs/guide.md` 说明新配置与安全默认；明确 `opencode-a2a call` CLI 为人工操作、不受白名单约束但共享 URL 处理。

## 验证

- `./scripts/doctor.sh` 通过：pre-commit、mypy、全量 pytest（732 通过）、覆盖率 93.14%（门槛 90%）、构建与依赖审计。

## 行为变更说明

- 默认（未配置白名单）且配置了出站凭据时，出站凭据将不再自动发送（fail-closed），需配置 `A2A_CLIENT_ALLOWED_HOSTS` 后才会发送。
- 默认拒绝解析为私网/环回地址的出站目标；内网 A2A 对端需显式设置 `A2A_CLIENT_ALLOW_PRIVATE_HOSTS=true`（仍受白名单约束）。
