### PR TITLE
fix(server): normalize discovery responses and gate workspace root

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -100,7 +100,7 @@ The supported persistence profile is one application process using its own local
 - Deployment-conditional methods must be declared as conditional rather than silently disappearing.
 - `opencode.sessions.prompt_async` input-part passthrough is compatibility-sensitive. Changes to supported part types, passthrough field semantics, or rejection behavior should be treated as wire-level changes.
 - `opencode.sessions.shell` is compatibility-sensitive as a deployment-conditional shell snapshot surface. It should not silently widen into a general interactive shell API.
-- `opencode.workspaces.*` and `opencode.worktrees.*` are boundary-sensitive and should remain explicitly provider-private, operator-scoped, and deployment-conditional where applicable.
+- `opencode.workspaces.*` and `opencode.worktrees.*` are boundary-sensitive and should remain explicitly provider-private, operator-scoped, and deployment-conditional where applicable. Discovery responses are normalized summaries that exclude upstream local paths (`directory`, `canonical`, worktree paths) and raw/internal fields.
 - Interrupt callback and recovery methods are compatibility-sensitive because clients may depend on request ID lifecycle, expiry semantics, and identity scoping.
 - Agent Card media modes and `acceptedOutputModes` handling are compatibility-sensitive. Changes to declared chat modes, to task-scoped negotiation persistence, or to output filtering of structured tool payloads should be treated as wire-level changes.
 - Agent Card and OpenAPI publication of `protocol_compatibility`, `service_behaviors`, and runtime feature toggles is compatibility-sensitive discoverability surface.

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -130,6 +130,7 @@ Extension URI: `urn:opencode-a2a:extension:workspace-control:v1`
 - Methods: stable project discovery plus experimental workspace/worktree discovery and deployment-conditional mutation methods
 - Dependencies: none declared by this version
 - Security boundary: this extension is provider-private, operator-scoped, and partly deployment-conditional
+- Response hygiene: discovery responses are normalized summaries; upstream local paths (`directory`, `canonical`, worktree paths), raw entries, and credential-like fields are excluded
 - Versioning: breaking changes require a new versioned URI
 
 ## OpenCode Interrupt Recovery v1

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1068,8 +1068,8 @@ curl -sS http://127.0.0.1:8000/ \
 
 Response:
 
-- `opencode.projects.list` => `{"items": [{"id", "name", "vcs"}]}` (normalized summaries; no local paths)
-- `opencode.projects.current` => `{"item": {"id", "name", "vcs"}}` (normalized summary; no local paths)
+- `opencode.projects.list` => `{"items": [{"id": "<id>", "name": "<name>", "vcs": "<vcs>"}]}` (normalized summaries; no local paths)
+- `opencode.projects.current` => `{"item": {"id": "<id>", "name": "<name>", "vcs": "<vcs>"}}` (normalized summary; no local paths)
 
 ### Workspace Discovery
 
@@ -1087,7 +1087,7 @@ curl -sS http://127.0.0.1:8000/ \
 
 Response:
 
-- `opencode.workspaces.list` => `{"items": [{"id", "type", "name", "branch"}]}` (normalized summaries; no local paths)
+- `opencode.workspaces.list` => `{"items": [{"id": "<id>", "type": "<type>", "name": "<name>", "branch": "<branch>"}]}` (normalized summaries; no local paths)
 
 ### Workspace Mutation
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -32,6 +32,7 @@ Key variables to understand protocol behavior:
 - `A2A_ALLOW_DIRECTORY_OVERRIDE`: controls whether clients may pass `metadata.opencode.directory`.
 - `A2A_ENABLE_SESSION_SHELL`: gates high-risk JSON-RPC method `opencode.sessions.shell`.
 - `A2A_ENABLE_WORKSPACE_MUTATIONS`: gates operator-only workspace/worktree mutation methods such as `opencode.workspaces.create` and `opencode.worktrees.reset`.
+- `A2A_EXPOSE_WORKSPACE_ROOT_IN_CARD`: default `false`; controls whether the authenticated extended Agent Card includes the local `OPENCODE_WORKSPACE_ROOT` in the structured profile `runtime_context`. Keep disabled unless trusted callers explicitly need the host path.
 - `A2A_SANDBOX_MODE` / `A2A_SANDBOX_FILESYSTEM_SCOPE` / `A2A_SANDBOX_WRITABLE_ROOTS`: declarative execution-boundary metadata for sandbox mode, filesystem scope, and optional writable roots.
 - `A2A_NETWORK_ACCESS` / `A2A_NETWORK_ALLOWED_DOMAINS`: declarative execution-boundary metadata for network policy and optional allowlist disclosure.
 - `A2A_APPROVAL_POLICY` / `A2A_APPROVAL_ESCALATION_BEHAVIOR`: declarative execution-boundary metadata for approval workflow.
@@ -1049,6 +1050,7 @@ Behavior notes:
 - `metadata.opencode.workspace.id` is declared consistently across the adapter, but current workspace-control methods do not use it to change the target project.
 - `opencode.workspaces.*` and `opencode.worktrees.*` currently wrap upstream `/experimental/workspace` and `/experimental/worktree` endpoints; treat them as experimental-upstream surfaces even when declared by the adapter.
 - Mutating methods should be treated as operator-only control-plane actions and are disabled by default.
+- Discovery responses are normalized provider-private summaries: upstream entries are filtered to stable fields only (`id`/`name`/`vcs` for projects, `id`/`type`/`name`/`branch` for workspaces, `name`/`branch` for worktrees) and never include upstream local paths (`directory`, `canonical`, worktree paths), raw entries, or credential-like fields.
 
 ### Project Discovery (`opencode.projects.list`, `opencode.projects.current`)
 
@@ -1066,8 +1068,8 @@ curl -sS http://127.0.0.1:8000/ \
 
 Response:
 
-- `opencode.projects.list` => `{"items": [...]}`
-- `opencode.projects.current` => `{"item": {...}}`
+- `opencode.projects.list` => `{"items": [{"id", "name", "vcs"}]}` (normalized summaries; no local paths)
+- `opencode.projects.current` => `{"item": {"id", "name", "vcs"}}` (normalized summary; no local paths)
 
 ### Workspace Discovery
 
@@ -1085,7 +1087,7 @@ curl -sS http://127.0.0.1:8000/ \
 
 Response:
 
-- `opencode.workspaces.list` => `{"items": [...]}`
+- `opencode.workspaces.list` => `{"items": [{"id", "type", "name", "branch"}]}` (normalized summaries; no local paths)
 
 ### Workspace Mutation
 

--- a/src/opencode_a2a/config.py
+++ b/src/opencode_a2a/config.py
@@ -198,6 +198,10 @@ class Settings(BaseSettings):
         default=False,
         alias="A2A_ENABLE_WORKSPACE_MUTATIONS",
     )
+    a2a_expose_workspace_root_in_card: bool = Field(
+        default=False,
+        alias="A2A_EXPOSE_WORKSPACE_ROOT_IN_CARD",
+    )
     a2a_sandbox_mode: SandboxMode = Field(default="unknown", alias="A2A_SANDBOX_MODE")
     a2a_sandbox_filesystem_scope: SandboxFilesystemScope = Field(
         default="unknown",

--- a/src/opencode_a2a/jsonrpc/handlers/workspace_control.py
+++ b/src/opencode_a2a/jsonrpc/handlers/workspace_control.py
@@ -28,6 +28,19 @@ ERR_UPSTREAM_UNREACHABLE = WORKSPACE_CONTROL_ERROR_BUSINESS_CODES["UPSTREAM_UNRE
 ERR_UPSTREAM_HTTP_ERROR = WORKSPACE_CONTROL_ERROR_BUSINESS_CODES["UPSTREAM_HTTP_ERROR"]
 ERR_UPSTREAM_PAYLOAD_ERROR = WORKSPACE_CONTROL_ERROR_BUSINESS_CODES["UPSTREAM_PAYLOAD_ERROR"]
 
+_PROJECT_SUMMARY_FIELDS = ("id", "name", "vcs")
+_WORKSPACE_SUMMARY_FIELDS = ("id", "type", "name", "branch")
+_WORKTREE_SUMMARY_FIELDS = ("name", "branch")
+
+_LIST_METHODS = {"list_projects", "list_workspaces", "list_worktrees"}
+_ITEM_METHODS = {
+    "get_current_project",
+    "create_workspace",
+    "remove_workspace",
+    "create_worktree",
+}
+_BOOL_METHODS = {"remove_worktree", "reset_worktree"}
+
 
 def _invalid_field_response(
     context: ExtensionHandlerContext,
@@ -170,16 +183,55 @@ def _validate_allowed_fields(
     )
 
 
-def _validate_response_payload(method: str, payload: Any) -> dict[str, Any]:
-    if method in {"list_projects", "list_workspaces", "list_worktrees"}:
+def _pick_summary_fields(
+    item: dict[str, Any],
+    allowed_fields: tuple[str, ...],
+) -> dict[str, Any]:
+    return {key: item[key] for key in allowed_fields if key in item and item[key] is not None}
+
+
+def _project_summary(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise ValueError("Upstream project items must be objects")
+    return _pick_summary_fields(item, _PROJECT_SUMMARY_FIELDS)
+
+
+def _workspace_summary(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise ValueError("Upstream workspace items must be objects")
+    return _pick_summary_fields(item, _WORKSPACE_SUMMARY_FIELDS)
+
+
+def _worktree_summary(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise ValueError("Upstream worktree items must be objects")
+    return _pick_summary_fields(item, _WORKTREE_SUMMARY_FIELDS)
+
+
+def _normalize_response_payload(method: str, payload: Any) -> dict[str, Any]:
+    if method in _LIST_METHODS:
         if not isinstance(payload, list):
             raise ValueError("Upstream list response must be an array")
-        return {"items": payload}
-    if method in {"get_current_project", "create_workspace", "remove_workspace", "create_worktree"}:
+        if method == "list_projects":
+            items = [_project_summary(item) for item in payload]
+        elif method == "list_workspaces":
+            items = [_workspace_summary(item) for item in payload]
+        else:
+            items = [_worktree_summary(item) for item in payload]
+        return {"items": items}
+    if method in _ITEM_METHODS:
         if payload is not None and not isinstance(payload, dict):
             raise ValueError("Upstream item response must be an object or null")
-        return {"item": payload}
-    if method in {"remove_worktree", "reset_worktree"}:
+        if payload is None:
+            return {"item": None}
+        if method == "get_current_project":
+            item = _project_summary(payload)
+        elif method == "create_worktree":
+            item = _worktree_summary(payload)
+        else:
+            item = _workspace_summary(payload)
+        return {"item": item}
+    if method in _BOOL_METHODS:
         if not isinstance(payload, bool):
             raise ValueError("Upstream boolean response must be a boolean")
         return {"ok": payload}
@@ -302,7 +354,7 @@ async def handle_workspace_control_request(
     assert raw_result is not None
 
     try:
-        result = _validate_response_payload(method_key, raw_result)
+        result = _normalize_response_payload(method_key, raw_result)
     except ValueError as exc:
         logger.warning("Upstream OpenCode workspace payload mismatch: %s", exc)
         return build_upstream_payload_error_response(

--- a/src/opencode_a2a/jsonrpc/handlers/workspace_control.py
+++ b/src/opencode_a2a/jsonrpc/handlers/workspace_control.py
@@ -193,18 +193,24 @@ def _pick_summary_fields(
 def _project_summary(item: Any) -> dict[str, Any]:
     if not isinstance(item, dict):
         raise ValueError("Upstream project items must be objects")
+    if not isinstance(item.get("id"), str) or not item["id"].strip():
+        raise ValueError("Upstream project items must include string field 'id'")
     return _pick_summary_fields(item, _PROJECT_SUMMARY_FIELDS)
 
 
 def _workspace_summary(item: Any) -> dict[str, Any]:
     if not isinstance(item, dict):
         raise ValueError("Upstream workspace items must be objects")
+    if not isinstance(item.get("id"), str) or not item["id"].strip():
+        raise ValueError("Upstream workspace items must include string field 'id'")
     return _pick_summary_fields(item, _WORKSPACE_SUMMARY_FIELDS)
 
 
 def _worktree_summary(item: Any) -> dict[str, Any]:
     if not isinstance(item, dict):
         raise ValueError("Upstream worktree items must be objects")
+    if not isinstance(item.get("name"), str) or not item["name"].strip():
+        raise ValueError("Upstream worktree items must include string field 'name'")
     return _pick_summary_fields(item, _WORKTREE_SUMMARY_FIELDS)
 
 

--- a/src/opencode_a2a/profile/runtime.py
+++ b/src/opencode_a2a/profile/runtime.py
@@ -294,7 +294,11 @@ def build_runtime_profile(settings: Settings) -> RuntimeProfile:
         ),
         runtime_context=RuntimeContext(
             project=settings.a2a_project,
-            workspace_root=settings.opencode_workspace_root,
+            workspace_root=(
+                settings.opencode_workspace_root
+                if settings.a2a_expose_workspace_root_in_card
+                else None
+            ),
             agent=settings.opencode_agent,
             variant=settings.opencode_variant,
         ),

--- a/src/opencode_a2a/server/agent_card.py
+++ b/src/opencode_a2a/server/agent_card.py
@@ -115,9 +115,6 @@ def _build_agent_card_description(
     project = runtime_context.get("project")
     if isinstance(project, str) and project.strip():
         parts.append(f"Deployment project: {project}.")
-    workspace_root = runtime_context.get("workspace_root")
-    if isinstance(workspace_root, str) and workspace_root.strip():
-        parts.append(f"Workspace root: {workspace_root}.")
     return " ".join(parts)
 
 

--- a/tests/jsonrpc/test_opencode_session_extension_queries.py
+++ b/tests/jsonrpc/test_opencode_session_extension_queries.py
@@ -440,6 +440,11 @@ async def test_provider_discovery_extension_returns_normalized_catalog(monkeypat
         assert providers_payload["connected"] == ["openai"]
         assert providers_payload["items"][0]["provider_id"] == "openai"
         assert providers_payload["items"][0]["default_model_id"] == "gpt-5"
+        assert "apiKey" not in str(providers_payload)
+        assert "sk-secret" not in str(providers_payload)
+        assert "internal" not in str(providers_payload)
+        assert "configPath" not in str(providers_payload)
+        assert "/home/user" not in str(providers_payload)
         assert dummy.workspace_control_calls[0]["workspace_id"] == "wrk-1"
 
         models_resp = await client.post(
@@ -458,6 +463,8 @@ async def test_provider_discovery_extension_returns_normalized_catalog(monkeypat
         assert models_payload["items"][0]["provider_id"] == "google"
         assert models_payload["items"][0]["model_id"] == "gemini-2.5-flash"
         assert models_payload["items"][0]["supports_attachments"] is True
+        assert "apiKey" not in str(models_payload)
+        assert "configPath" not in str(models_payload)
 
 
 @pytest.mark.asyncio

--- a/tests/jsonrpc/test_opencode_workspace_control_extension.py
+++ b/tests/jsonrpc/test_opencode_workspace_control_extension.py
@@ -55,13 +55,70 @@ async def test_workspace_control_extension_supports_read_only_methods(monkeypatc
         )
 
     assert projects.status_code == 200
-    assert projects.json()["result"]["items"][0]["id"] == "proj-1"
+    assert projects.json()["result"]["items"][0] == {
+        "id": "proj-1",
+        "name": "Alpha",
+        "vcs": "git",
+    }
     assert current.status_code == 200
-    assert current.json()["result"]["item"]["id"] == "proj-1"
+    assert current.json()["result"]["item"] == {
+        "id": "proj-1",
+        "name": "Alpha",
+        "vcs": "git",
+    }
     assert workspaces.status_code == 200
-    assert workspaces.json()["result"]["items"][0]["id"] == "wrk-1"
+    assert workspaces.json()["result"]["items"][0] == {
+        "id": "wrk-1",
+        "type": "git",
+        "name": "Alpha workspace",
+        "branch": "main",
+    }
     assert worktrees.status_code == 200
-    assert worktrees.json()["result"]["items"] == ["/tmp/worktrees/alpha"]
+    assert worktrees.json()["result"]["items"] == [{"name": "alpha", "branch": "opencode/alpha"}]
+
+
+@pytest.mark.asyncio
+async def test_workspace_control_discovery_responses_exclude_internal_fields(
+    monkeypatch,
+) -> None:
+    import opencode_a2a.server.application as app_module
+
+    dummy = DummyOpencodeUpstreamClient(
+        make_settings(test_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", lambda _settings, **_kwargs: dummy)
+    app = app_module.create_app(
+        make_settings(test_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = _extension_headers({"Authorization": "Bearer t-1"})
+        responses = []
+        for method, request_id in (
+            ("opencode.projects.list", 1),
+            ("opencode.projects.current", 2),
+            ("opencode.workspaces.list", 3),
+            ("opencode.worktrees.list", 4),
+        ):
+            response = await client.post(
+                "/",
+                headers=headers,
+                json={"jsonrpc": "2.0", "id": request_id, "method": method, "params": {}},
+            )
+            assert response.status_code == 200
+            responses.append(response.json())
+
+    for payload in responses:
+        serialized = str(payload)
+        assert "directory" not in serialized
+        assert "canonical" not in serialized
+        assert "apiKey" not in serialized
+        assert "sk-secret" not in serialized
+        assert "icon" not in serialized
+        assert "internal.local" not in serialized
+        assert "/workspace" not in serialized
+        assert "/tmp/worktrees" not in serialized
 
 
 @pytest.mark.asyncio
@@ -139,10 +196,15 @@ async def test_workspace_control_extension_supports_mutating_methods(monkeypatch
 
     assert create_workspace.status_code == 200
     assert create_workspace.json()["result"]["item"]["type"] == "git"
+    assert "directory" not in str(create_workspace.json())
     assert remove_workspace.status_code == 200
     assert remove_workspace.json()["result"]["item"]["id"] == "wrk-1"
+    assert "directory" not in str(remove_workspace.json())
     assert create_worktree.status_code == 200
-    assert create_worktree.json()["result"]["item"]["directory"] == "/tmp/worktrees/feature-branch"
+    assert create_worktree.json()["result"]["item"] == {
+        "name": "feature-branch",
+        "branch": "opencode/feature-branch",
+    }
     assert remove_worktree.status_code == 200
     assert remove_worktree.json()["result"] == {"ok": True}
     assert reset_worktree.status_code == 200

--- a/tests/jsonrpc/test_opencode_workspace_control_extension.py
+++ b/tests/jsonrpc/test_opencode_workspace_control_extension.py
@@ -379,15 +379,39 @@ async def test_workspace_control_extension_maps_upstream_http_error(monkeypatch)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "upstream_payload"),
+    (
+        ("opencode.projects.list", [{"name": "Alpha", "vcs": "git"}]),
+        ("opencode.workspaces.list", ["/workspace/raw-path"]),
+        ("opencode.worktrees.list", [{"branch": "opencode/alpha"}]),
+    ),
+)
 async def test_workspace_control_extension_maps_malformed_upstream_items_to_payload_error(
     monkeypatch,
+    method: str,
+    upstream_payload: list[object],
 ) -> None:
     import opencode_a2a.server.application as app_module
 
     class MalformedUpstreamClient(DummyOpencodeUpstreamClient):
-        async def list_workspaces(self):
-            self.workspace_control_calls.append({"method": "list_workspaces"})
-            return ["/workspace/raw-path"]
+        pass
+
+    async def _list_projects(self):
+        return upstream_payload
+
+    async def _list_workspaces(self):
+        return upstream_payload
+
+    async def _list_worktrees(self):
+        return upstream_payload
+
+    if method == "opencode.projects.list":
+        MalformedUpstreamClient.list_projects = _list_projects
+    elif method == "opencode.workspaces.list":
+        MalformedUpstreamClient.list_workspaces = _list_workspaces
+    else:
+        MalformedUpstreamClient.list_worktrees = _list_worktrees
 
     monkeypatch.setattr(app_module, "OpencodeUpstreamClient", MalformedUpstreamClient)
     app = app_module.create_app(
@@ -402,7 +426,7 @@ async def test_workspace_control_extension_maps_malformed_upstream_items_to_payl
             json={
                 "jsonrpc": "2.0",
                 "id": 22,
-                "method": "opencode.workspaces.list",
+                "method": method,
                 "params": {},
             },
         )

--- a/tests/jsonrpc/test_opencode_workspace_control_extension.py
+++ b/tests/jsonrpc/test_opencode_workspace_control_extension.py
@@ -376,3 +376,38 @@ async def test_workspace_control_extension_maps_upstream_http_error(monkeypatch)
         reason="UPSTREAM_HTTP_ERROR",
         metadata={"upstream_status": 503},
     )
+
+
+@pytest.mark.asyncio
+async def test_workspace_control_extension_maps_malformed_upstream_items_to_payload_error(
+    monkeypatch,
+) -> None:
+    import opencode_a2a.server.application as app_module
+
+    class MalformedUpstreamClient(DummyOpencodeUpstreamClient):
+        async def list_workspaces(self):
+            self.workspace_control_calls.append({"method": "list_workspaces"})
+            return ["/workspace/raw-path"]
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", MalformedUpstreamClient)
+    app = app_module.create_app(
+        make_settings(test_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/",
+            headers=_extension_headers({"Authorization": "Bearer t-1"}),
+            json={
+                "jsonrpc": "2.0",
+                "id": 22,
+                "method": "opencode.workspaces.list",
+                "params": {},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["error"]["code"] == -32005
+    assert_v1_error_reason(payload["error"], reason="UPSTREAM_PAYLOAD_ERROR")

--- a/tests/profile/test_profile_runtime.py
+++ b/tests/profile/test_profile_runtime.py
@@ -21,6 +21,7 @@ def test_profile_runtime_splits_deployment_runtime_features_and_health_payload()
         opencode_workspace_root="/workspace",
         opencode_agent="planner",
         opencode_variant="fast",
+        a2a_expose_workspace_root_in_card=True,
     )
 
     profile = build_runtime_profile(settings)
@@ -132,6 +133,18 @@ def test_profile_runtime_uses_conservative_execution_environment_defaults() -> N
         "availability": "disabled",
         "toggle": "A2A_ENABLE_WORKSPACE_MUTATIONS",
     }
+
+
+def test_profile_runtime_omits_workspace_root_from_runtime_context_by_default() -> None:
+    settings = make_settings(
+        test_bearer_token="test-token",
+        a2a_project="alpha",
+        opencode_workspace_root="/workspace",
+    )
+
+    profile = build_runtime_profile(settings)
+
+    assert profile.runtime_context.as_dict() == {"project": "alpha"}
 
 
 def test_profile_runtime_disables_shell_when_policy_is_read_only() -> None:

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -221,6 +221,7 @@ def test_agent_card_injects_profile_into_extensions() -> None:
             a2a_approval_escalation_behavior="unsupported",
             a2a_write_access_scope="workspace_and_declared_roots",
             a2a_write_access_outside_workspace="disallowed",
+            a2a_expose_workspace_root_in_card=True,
         ),
         include_detailed_contracts=True,
     )
@@ -806,6 +807,23 @@ def test_agent_card_injects_profile_into_extensions() -> None:
         },
     }
     assert wire_contract.description.endswith("unified error contracts.")
+
+
+def test_agent_card_omits_workspace_root_by_default() -> None:
+    card = build_agent_card(
+        make_settings(
+            test_bearer_token="test-token",
+            a2a_project="alpha",
+            opencode_workspace_root="/srv/workspaces/alpha",
+        ),
+        include_detailed_contracts=True,
+    )
+
+    assert "Workspace root" not in card.description
+    assert "/srv/workspaces/alpha" not in card.description
+    ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
+    profile = ext_by_uri[SESSION_BINDING_EXTENSION_URI].params["profile"]
+    assert profile["runtime_context"] == {"project": "alpha"}
 
 
 def test_agent_card_chat_examples_include_project_hint_when_configured() -> None:

--- a/tests/server/test_app_behaviors.py
+++ b/tests/server/test_app_behaviors.py
@@ -323,6 +323,7 @@ def test_agent_card_helper_builders_cover_optional_branches() -> None:
         opencode_workspace_root="/workspace",
         opencode_agent="planner",
         opencode_variant="fast",
+        a2a_expose_workspace_root_in_card=True,
     )
 
     runtime_profile = build_runtime_profile(settings)
@@ -413,7 +414,7 @@ def test_agent_card_helper_builders_cover_optional_branches() -> None:
         include_detailed_contracts=True,
     )
     assert "Deployment project: alpha." in extended_description
-    assert "Workspace root: /workspace." in extended_description
+    assert "Workspace root" not in extended_description
     assert "currently return unsupported" in extended_description
     assert any("project alpha" in item for item in _build_chat_examples("alpha"))
     assert all(

--- a/tests/support/session_query_client.py
+++ b/tests/support/session_query_client.py
@@ -95,10 +95,15 @@ class DummySessionQueryOpencodeUpstreamClient(
                     "id": "openai",
                     "name": "OpenAI",
                     "source": "api",
+                    "apiKey": "sk-secret",  # pragma: allowlist secret
+                    "internal": {
+                        "configPath": "/home/user/.config/opencode/providers.json",
+                    },
                     "models": {
                         "gpt-5": {
                             "name": "GPT-5",
                             "status": "active",
+                            "apiKey": "sk-secret",  # pragma: allowlist secret
                             "limit": {"context": 200000, "output": 8192},
                             "capabilities": {
                                 "reasoning": True,
@@ -112,6 +117,7 @@ class DummySessionQueryOpencodeUpstreamClient(
                     "id": "google",
                     "name": "Google",
                     "source": "config",
+                    "configPath": "/home/user/.config/opencode/google.json",
                     "models": {
                         "gemini-2.5-flash": {
                             "name": "Gemini 2.5 Flash",

--- a/tests/support/workspace_control_client.py
+++ b/tests/support/workspace_control_client.py
@@ -24,29 +24,73 @@ class WorkspaceControlClientMixin:
 
     async def list_projects(self):
         self.workspace_control_calls.append({"method": "list_projects"})
-        return [{"id": "proj-1", "name": "Alpha", "directory": "/workspace"}]
+        return [
+            {
+                "id": "proj-1",
+                "name": "Alpha",
+                "vcs": "git",
+                "canonical": "/workspace/alpha",
+                "directory": "/workspace/alpha",
+                "icon": {"url": "https://internal.local/icon.png"},
+                "apiKey": "sk-secret",  # pragma: allowlist secret
+            }
+        ]
 
     async def get_current_project(self):
         self.workspace_control_calls.append({"method": "get_current_project"})
-        return {"id": "proj-1", "name": "Alpha", "directory": "/workspace"}
+        return {
+            "id": "proj-1",
+            "name": "Alpha",
+            "vcs": "git",
+            "canonical": "/workspace/alpha",
+            "directory": "/workspace/alpha",
+            "apiKey": "sk-secret",  # pragma: allowlist secret
+        }
 
     async def list_workspaces(self):
         self.workspace_control_calls.append({"method": "list_workspaces"})
-        return [{"id": "wrk-1", "type": "git", "branch": "main", "directory": None}]
+        return [
+            {
+                "id": "wrk-1",
+                "type": "git",
+                "name": "Alpha workspace",
+                "branch": "main",
+                "directory": "/workspace/alpha",
+            }
+        ]
 
     async def create_workspace(self, request: dict[str, Any]):
         self.workspace_control_calls.append({"method": "create_workspace", "request": request})
-        return {"id": "wrk-2", **request}
+        return {
+            "id": "wrk-2",
+            "type": "git",
+            "name": "Created workspace",
+            "branch": "main",
+            "directory": "/tmp/created-workspace",
+            **request,
+        }
 
     async def remove_workspace(self, workspace_id: str):
         self.workspace_control_calls.append(
             {"method": "remove_workspace", "workspace_id": workspace_id}
         )
-        return {"id": workspace_id, "type": "git", "branch": "main", "directory": None}
+        return {
+            "id": workspace_id,
+            "type": "git",
+            "name": "Removed workspace",
+            "branch": "main",
+            "directory": None,
+        }
 
     async def list_worktrees(self):
         self.workspace_control_calls.append({"method": "list_worktrees"})
-        return ["/tmp/worktrees/alpha"]
+        return [
+            {
+                "name": "alpha",
+                "branch": "opencode/alpha",
+                "directory": "/tmp/worktrees/alpha",
+            }
+        ]
 
     async def create_worktree(self, request: dict[str, Any]):
         self.workspace_control_calls.append({"method": "create_worktree", "request": request})


### PR DESCRIPTION
## 关联 issues

- Closes #503（[bug] provider/workspace discovery 响应透传上游原始条目，需字段过滤审查）
- Relates to #499（对 opencode-a2a 执行系统安全审计）

## 背景

#503 指出 provider/workspace discovery 响应透传上游原始条目，含本机路径等内部字段。经核查（基线 `adf2a9b` 与当前 `main`）：

- Provider discovery（`opencode.providers.list` / `opencode.models.list`）在基线与当前 main 上均已被白名单归一化覆盖，无需功能改动，本次补充敏感字段回归断言；
- 真正缺口在 workspace control：`opencode.projects.list/current`、`opencode.workspaces.list`、`opencode.worktrees.list` 及对应 mutation 返回值原样透传上游条目，其中含本地绝对路径（`directory`、`canonical`、worktree 路径）等内部字段；
- 扩展 Agent Card（`/extendedAgentCard`）描述文本与结构化 `runtime_context` 暴露本机 `workspace_root`。

## 变更

- `workspace_control.py`：响应改为“校验 + 白名单归一化”——项目仅保留 `id/name/vcs`，工作区仅保留 `id/type/name/branch`，worktree 仅保留 `name/branch`；`directory`、`canonical`、raw/凭据类字段一律不进入响应，mutation 返回值同样归一化。列表/详情条目必须包含稳定标识（项目/工作区 `id`、worktree `name`），畸形上游条目映射为 `UPSTREAM_PAYLOAD_ERROR`（-32005）。
- Agent Card：描述文本不再包含 `Workspace root`；结构化 `runtime_context.workspace_root` 由新增 `A2A_EXPOSE_WORKSPACE_ROOT_IN_CARD`（默认 `false`）控制，默认不暴露本机路径。
- 测试：mock 上游携带 `directory/canonical/apiKey/configPath` 等敏感字段，新增回归断言响应不含这些字段；覆盖字符串条目、缺 `id` 的 project、缺 `name` 的 worktree 等畸形上游分支；同步更新 worktree/workspace/project 响应断言与 profile/Agent Card 默认不暴露 workspace_root 的测试。
- 文档：`docs/guide.md` 新增环境变量说明并明确 workspace control 归一化响应形态；`docs/extension-specifications.md` 补充响应卫生边界；`docs/compatibility.md` 补充 workspace/worktree discovery 归一化说明。

## 验证

`./scripts/doctor.sh` 全绿：738 passed，覆盖率 93.17%，mypy / ruff / pre-commit / 构建与 wheel 冒烟均通过。

## 相关 commits

- `3daeb75` fix(server): normalize discovery responses and gate workspace root
- `6cd0244` test(workspace-control): cover malformed upstream item mapping
- `d2f2ead` fix(workspace-control): require stable identity in discovery items

## 说明

- 行为变化：`opencode.worktrees.list` 从“原样返回上游绝对路径字符串数组”改为归一化对象数组（`{name, branch}`），属本 issue 修复的预期契约变化，已同步文档。
- 未纳入本 PR：#501 / #502 / #504 为同一审计批次拆解项，代码路径独立，建议并行分支处理。
