### PR TITLE
fix(server): enforce inbound Origin/Host boundary (CSRF and DNS rebinding guard)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -39,6 +39,8 @@ Key variables to understand protocol behavior:
 - `A2A_WRITE_ACCESS_SCOPE` / `A2A_WRITE_ACCESS_OUTSIDE_WORKSPACE`: declarative execution-boundary metadata for write scope and whether writes may extend outside the primary workspace boundary.
 - `A2A_HOST` / `A2A_PORT`: runtime bind address. Defaults: `127.0.0.1:8000`.
 - `A2A_PUBLIC_URL`: public base URL advertised by the Agent Card. Default: `http://127.0.0.1:8000`.
+- `A2A_ALLOWED_ORIGINS`: comma-separated extra browser-origin allowlist for inbound requests. Requests carrying an `Origin` header must match the origin of `A2A_PUBLIC_URL` or an entry here; mismatches are rejected with `403` (CSRF guard). Requests without an `Origin` header (CLI/SDK clients) are unaffected.
+- `A2A_ALLOWED_HOSTS`: comma-separated `Host` header allowlist (exact names or `*.example.com` wildcards). When configured, every inbound request must present a matching `Host` header. Binding to a non-loopback address without this allowlist logs a startup warning (DNS rebinding risk).
 - `A2A_LOG_LEVEL`: runtime log level. Default: `WARNING`.
 - `A2A_LOG_PAYLOADS` / `A2A_LOG_BODY_LIMIT`: payload logging behavior and truncation. When `A2A_LOG_LEVEL=DEBUG`, upstream OpenCode stream events are also logged with preview truncation controlled by `A2A_LOG_BODY_LIMIT`.
 - The runtime accepts W3C `traceparent` / `tracestate` headers on inbound requests. When `traceparent` is missing or invalid, the runtime generates a fresh valid value and exposes it on the HTTP response header.
@@ -86,6 +88,17 @@ Key variables to understand protocol behavior:
   - `A2A_CLIENT_BEARER_TOKEN`
   - `A2A_CLIENT_BASIC_AUTH`
   - `A2A_CLIENT_SUPPORTED_TRANSPORTS`
+
+## Inbound Origin and Host Boundary
+
+Browsers store and automatically attach Basic credentials, and they send an `Origin` header with every request. Without an origin boundary, a malicious web page could cross-site trigger `SendMessage`, `CancelTask`, or task subscription against a Basic-protected service. The runtime therefore enforces:
+
+- every request carrying an `Origin` header must match the origin of `A2A_PUBLIC_URL` (scheme, host, and non-default port) or an entry in `A2A_ALLOWED_ORIGINS`; mismatches return `403` before authentication. `Origin: null` (sandboxed iframes) is rejected unless explicitly allowlisted;
+- requests without an `Origin` header — normal CLI/SDK peers — are not subject to origin checks;
+- when `A2A_ALLOWED_HOSTS` is configured, every request must present a matching `Host` header (exact names, optional `host:port`, or `*.example.com` wildcards); mismatches return `403`. This also blocks DNS rebinding, where an attacker-controlled hostname resolves to the service address and the browser sends that hostname as `Host`;
+- binding to a non-loopback address (`0.0.0.0`, `::`, or a LAN/interface address) without `A2A_ALLOWED_HOSTS` logs a startup warning: the service is then exposed to DNS rebinding and should only run behind a trusted network boundary or a reverse proxy that validates `Host`.
+
+For browser-based clients, prefer the same origin as `A2A_PUBLIC_URL`, or explicitly allow the dashboard origin via `A2A_ALLOWED_ORIGINS` and treat `A2A_ALLOWED_HOSTS` as part of the deployment contract. Basic authentication should not be relied on as the sole browser-facing boundary: combine it with the origin/host checks above, short-lived credentials, and TLS at the public URL.
 
 ## Client Initialization Facade (Preview)
 

--- a/src/opencode_a2a/config.py
+++ b/src/opencode_a2a/config.py
@@ -174,6 +174,8 @@ class Settings(BaseSettings):
 
     # A2A settings
     a2a_public_url: str = Field(default="http://127.0.0.1:8000", alias="A2A_PUBLIC_URL")
+    a2a_allowed_origins: DeclaredStringList = Field(default=(), alias="A2A_ALLOWED_ORIGINS")
+    a2a_allowed_hosts: DeclaredStringList = Field(default=(), alias="A2A_ALLOWED_HOSTS")
     a2a_project: str | None = Field(default=None, alias="A2A_PROJECT")
     a2a_title: str = Field(default="OpenCode A2A", alias="A2A_TITLE")
     a2a_description: str = Field(default="OpenCode A2A runtime", alias="A2A_DESCRIPTION")

--- a/src/opencode_a2a/server/middleware.py
+++ b/src/opencode_a2a/server/middleware.py
@@ -212,6 +212,17 @@ def add_http_boundary_middleware(app: FastAPI, settings) -> None:  # noqa: ANN00
             "set a Host allowlist to defend against DNS rebinding",
             getattr(settings, "a2a_host", "127.0.0.1"),
         )
+    if enforce_host and public_origin is not None:
+        public_host = public_origin.split("://", 1)[1]
+        if public_host.lower() not in allowed_host_headers and not matches_allowed_host(
+            _hostname_from_host_header(public_host),
+            allowed_hosts,
+        ):
+            logger.warning(
+                "A2A_PUBLIC_URL host %r is not covered by A2A_ALLOWED_HOSTS; "
+                "requests matching the public origin may be rejected on Host",
+                public_host,
+            )
 
     @app.middleware("http")
     async def enforce_http_boundary(request: Request, call_next):

--- a/src/opencode_a2a/server/middleware.py
+++ b/src/opencode_a2a/server/middleware.py
@@ -194,6 +194,15 @@ def add_http_boundary_middleware(app: FastAPI, settings) -> None:  # noqa: ANN00
     """
 
     allowed_origins = _normalized_origins(getattr(settings, "a2a_allowed_origins", ()))
+    for entry in allowed_origins:
+        canonical_entry = _origin_of_url(entry)
+        if canonical_entry is not None and canonical_entry != entry:
+            logger.warning(
+                "A2A_ALLOWED_ORIGINS entry %r is not a normalized origin "
+                "(scheme://host[:port]); only %r will match requests",
+                entry,
+                canonical_entry,
+            )
     public_origin = _origin_of_url(getattr(settings, "a2a_public_url", ""))
     if public_origin is not None:
         allowed_origins.add(public_origin)
@@ -230,7 +239,9 @@ def add_http_boundary_middleware(app: FastAPI, settings) -> None:  # noqa: ANN00
         if origin is not None:
             normalized_origin = origin.strip().lower().rstrip("/")
             if normalized_origin not in allowed_origins:
-                return _boundary_rejection_response("Cross-origin request rejected")
+                canonical_origin = _origin_of_url(origin)
+                if canonical_origin is None or canonical_origin not in allowed_origins:
+                    return _boundary_rejection_response("Cross-origin request rejected")
 
         if enforce_host:
             host = request.headers.get("host")

--- a/src/opencode_a2a/server/middleware.py
+++ b/src/opencode_a2a/server/middleware.py
@@ -5,6 +5,7 @@ import json
 import logging
 from contextvars import ContextVar, Token
 from typing import cast
+from urllib.parse import urlsplit
 
 from a2a.extensions.common import HTTP_EXTENSION_HEADER, get_requested_extensions
 from fastapi import FastAPI, Request
@@ -20,6 +21,7 @@ from ..auth import (
     authenticate_static_credential,
     build_static_auth_credentials,
 )
+from ..client.network_policy import matches_allowed_host
 from ..contracts.extensions import ALL_EXTENSION_URIS, PUBLIC_EXTENSION_URIS
 from ..execution.metrics import emit_metric
 from ..jsonrpc.error_responses import (
@@ -58,6 +60,64 @@ _REQUEST_BODY_BYTES: ContextVar[bytes | None] = ContextVar(
     "_REQUEST_BODY_BYTES",
     default=None,
 )
+
+
+def _origin_of_url(value: str) -> str | None:
+    """Return the normalized ``scheme://host[:port]`` origin of a URL."""
+
+    parsed = urlsplit((value or "").strip())
+    scheme = (parsed.scheme or "").lower()
+    hostname = parsed.hostname
+    if scheme not in {"http", "https"} or not hostname:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    hostname = hostname.lower()
+    if port is None or (scheme == "http" and port == 80) or (scheme == "https" and port == 443):
+        return f"{scheme}://{hostname}"
+    return f"{scheme}://{hostname}:{port}"
+
+
+def _normalized_origins(values) -> set[str]:  # noqa: ANN001
+    normalized: set[str] = set()
+    for raw in values or ():
+        value = (raw or "").strip().lower().rstrip("/")
+        if value:
+            normalized.add(value)
+    return normalized
+
+
+_LOOPBACK_BIND_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _is_loopback_bind(host: str) -> bool:
+    normalized = (host or "").strip().lower()
+    if normalized in _LOOPBACK_BIND_HOSTS:
+        return True
+    return normalized.startswith("127.")
+
+
+def _hostname_from_host_header(host: str) -> str:
+    try:
+        parsed = urlsplit(f"//{host.strip()}")
+    except ValueError:
+        return ""
+    return (parsed.hostname or "").lower()
+
+
+def _boundary_rejection_response(message: str) -> JSONResponse:
+    return JSONResponse(
+        {
+            "error": {
+                "code": 403,
+                "status": "FORBIDDEN",
+                "message": message,
+            }
+        },
+        status_code=403,
+    )
 
 
 def _is_http_json_rest_path(path: str) -> bool:
@@ -113,6 +173,62 @@ def add_auth_middleware(app: FastAPI, settings) -> None:  # noqa: ANN001
         request.state.user_auth_scheme = principal.auth_scheme
         if principal.credential_id:
             request.state.user_credential_id = principal.credential_id
+
+        return await call_next(request)
+
+
+def add_http_boundary_middleware(app: FastAPI, settings) -> None:  # noqa: ANN001
+    """Enforce the inbound Origin/Host boundary (CSRF and DNS rebinding guard).
+
+    Browsers attach stored Basic credentials to every request and send an
+    ``Origin`` header, so a cross-origin page could otherwise trigger task
+    submission, cancellation, or subscription. Requests carrying an ``Origin``
+    header must match the origin derived from ``A2A_PUBLIC_URL`` or an entry in
+    ``A2A_ALLOWED_ORIGINS``; requests without an ``Origin`` header (CLI/SDK
+    clients) are unaffected.
+
+    When ``A2A_ALLOWED_HOSTS`` is configured, the ``Host`` header is validated
+    for every request (exact names or ``*.example.com`` wildcards). Binding to
+    a non-loopback address without a host allowlist logs a startup warning
+    because the service is then exposed to DNS rebinding.
+    """
+
+    allowed_origins = _normalized_origins(getattr(settings, "a2a_allowed_origins", ()))
+    public_origin = _origin_of_url(getattr(settings, "a2a_public_url", ""))
+    if public_origin is not None:
+        allowed_origins.add(public_origin)
+    else:
+        logger.warning(
+            "A2A_PUBLIC_URL=%r is not a valid http(s) URL; requests carrying an "
+            "Origin header will be rejected unless A2A_ALLOWED_ORIGINS matches",
+            getattr(settings, "a2a_public_url", ""),
+        )
+    allowed_hosts = tuple(getattr(settings, "a2a_allowed_hosts", ()) or ())
+    allowed_host_headers = {entry.strip().lower() for entry in allowed_hosts if entry.strip()}
+    enforce_host = bool(allowed_hosts)
+    if not enforce_host and not _is_loopback_bind(getattr(settings, "a2a_host", "127.0.0.1")):
+        logger.warning(
+            "A2A server is bound to non-loopback host=%s without A2A_ALLOWED_HOSTS; "
+            "set a Host allowlist to defend against DNS rebinding",
+            getattr(settings, "a2a_host", "127.0.0.1"),
+        )
+
+    @app.middleware("http")
+    async def enforce_http_boundary(request: Request, call_next):
+        origin = request.headers.get("origin")
+        if origin is not None:
+            normalized_origin = origin.strip().lower().rstrip("/")
+            if normalized_origin not in allowed_origins:
+                return _boundary_rejection_response("Cross-origin request rejected")
+
+        if enforce_host:
+            host = request.headers.get("host")
+            hostname = _hostname_from_host_header(host or "")
+            host_header_allowed = (host or "").strip().lower() in allowed_host_headers
+            if not hostname or not (
+                host_header_allowed or matches_allowed_host(hostname, allowed_hosts)
+            ):
+                return _boundary_rejection_response("Host not allowed")
 
         return await call_next(request)
 
@@ -533,6 +649,7 @@ def install_runtime_middlewares(
                 _REQUEST_BODY_BYTES.reset(token)
 
     add_auth_middleware(app, settings)
+    add_http_boundary_middleware(app, settings)
 
 
 def emit_stream_request_metrics(*, active_delta: float | None = None) -> None:

--- a/tests/server/test_http_boundary.py
+++ b/tests/server/test_http_boundary.py
@@ -73,6 +73,22 @@ async def test_configured_allowed_origin_passes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_origin_with_explicit_default_port_matches_public_origin() -> None:
+    settings = make_settings(a2a_public_url="https://a2a.example.com")
+    response = await _request(_boundary_app(settings), origin="https://a2a.example.com:443")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cross_origin_with_default_port_is_rejected() -> None:
+    settings = make_settings(a2a_public_url="https://a2a.example.com")
+    response = await _request(_boundary_app(settings), origin="https://other.example:443")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_null_origin_is_rejected_by_default() -> None:
     settings = make_settings(a2a_public_url="http://127.0.0.1:8000")
     response = await _request(_boundary_app(settings), origin="null")
@@ -95,6 +111,34 @@ async def test_invalid_public_url_logs_warning(caplog: pytest.LogCaptureFixture)
         _boundary_app(settings)
 
     assert any("not a valid http(s) URL" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_allowlist_entry_with_path_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = make_settings(
+        a2a_public_url="http://127.0.0.1:8000",
+        a2a_allowed_origins=("https://dashboard.example/app",),
+    )
+    with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
+        _boundary_app(settings)
+
+    assert any("not a normalized origin" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_normalized_allowlist_entry_does_not_log_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = make_settings(
+        a2a_public_url="http://127.0.0.1:8000",
+        a2a_allowed_origins=("https://dashboard.example",),
+    )
+    with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
+        _boundary_app(settings)
+
+    assert not any("not a normalized origin" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_http_boundary.py
+++ b/tests/server/test_http_boundary.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from opencode_a2a.config import Settings
+from opencode_a2a.server.middleware import add_http_boundary_middleware
+from tests.support.settings import make_settings
+
+
+def _boundary_app(settings: Settings) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    add_http_boundary_middleware(app, settings)
+    return app
+
+
+async def _request(
+    app: FastAPI, *, origin: str | None = None, host: str | None = None
+) -> httpx.Response:
+    headers: dict[str, str] = {}
+    if origin is not None:
+        headers["Origin"] = origin
+    if host is not None:
+        headers["Host"] = host
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.get("/health", headers=headers)
+
+
+@pytest.mark.asyncio
+async def test_same_origin_request_is_allowed() -> None:
+    settings = make_settings(a2a_public_url="http://127.0.0.1:8000")
+    response = await _request(_boundary_app(settings), origin="http://127.0.0.1:8000")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cross_origin_request_is_rejected() -> None:
+    settings = make_settings(a2a_public_url="http://127.0.0.1:8000")
+    response = await _request(_boundary_app(settings), origin="https://evil.example")
+
+    assert response.status_code == 403
+    assert response.json()["error"]["message"] == "Cross-origin request rejected"
+
+
+@pytest.mark.asyncio
+async def test_request_without_origin_header_passes() -> None:
+    settings = make_settings(a2a_public_url="http://127.0.0.1:8000")
+    response = await _request(_boundary_app(settings), origin=None)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_configured_allowed_origin_passes() -> None:
+    settings = make_settings(
+        a2a_public_url="http://127.0.0.1:8000",
+        a2a_allowed_origins=("https://dashboard.example",),
+    )
+    response = await _request(_boundary_app(settings), origin="https://dashboard.example")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_null_origin_is_rejected_by_default() -> None:
+    settings = make_settings(a2a_public_url="http://127.0.0.1:8000")
+    response = await _request(_boundary_app(settings), origin="null")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invalid_public_url_rejects_origin_requests() -> None:
+    settings = make_settings(a2a_public_url="localhost:8000")
+    response = await _request(_boundary_app(settings), origin="http://127.0.0.1:8000")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invalid_public_url_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    settings = make_settings(a2a_public_url="localhost:8000")
+    with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
+        _boundary_app(settings)
+
+    assert any(
+        "not a valid http(s) URL" in record.message for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_options_preflight_with_cross_origin_is_rejected() -> None:
+    settings = make_settings(a2a_public_url="http://127.0.0.1:8000")
+    app = _boundary_app(settings)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.options(
+            "/message:send",
+            headers={"Origin": "https://evil.example", "Access-Control-Request-Method": "POST"},
+        )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_host_allowlist_accepts_matching_host() -> None:
+    settings = make_settings(a2a_allowed_hosts=("a2a.example.com",))
+    response = await _request(
+        _boundary_app(settings),
+        origin="http://127.0.0.1:8000",
+        host="a2a.example.com",
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_host_allowlist_rejects_mismatched_host() -> None:
+    settings = make_settings(a2a_allowed_hosts=("a2a.example.com",))
+    response = await _request(
+        _boundary_app(settings),
+        origin="http://127.0.0.1:8000",
+        host="evil.example",
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["message"] == "Host not allowed"
+
+
+@pytest.mark.asyncio
+async def test_host_allowlist_wildcard_matches_subdomain() -> None:
+    settings = make_settings(a2a_allowed_hosts=("*.example.com",))
+    response = await _request(
+        _boundary_app(settings),
+        origin="http://127.0.0.1:8000",
+        host="tenant-a.example.com:8000",
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_host_allowlist_rejects_apex_for_wildcard_entry() -> None:
+    settings = make_settings(a2a_allowed_hosts=("*.example.com",))
+    response = await _request(
+        _boundary_app(settings),
+        origin="http://127.0.0.1:8000",
+        host="example.com",
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_host_allowlist_accepts_entry_with_port() -> None:
+    settings = make_settings(a2a_allowed_hosts=("a2a.example.com:8000",))
+    response = await _request(
+        _boundary_app(settings),
+        origin="http://127.0.0.1:8000",
+        host="a2a.example.com:8000",
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_missing_host_is_rejected_when_allowlist_configured() -> None:
+    settings = make_settings(a2a_allowed_hosts=("a2a.example.com",))
+    response = await _request(_boundary_app(settings), origin=None, host=None)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_loopback_bind_without_allowlist_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = make_settings(a2a_host="0.0.0.0")
+    with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
+        _boundary_app(settings)
+
+    assert any(
+        "non-loopback" in record.message and "A2A_ALLOWED_HOSTS" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_loopback_bind_without_allowlist_does_not_log_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = make_settings(a2a_host="127.0.0.1")
+    with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
+        _boundary_app(settings)
+
+    assert not any(
+        "non-loopback" in record.message and "A2A_ALLOWED_HOSTS" in record.message
+        for record in caplog.records
+    )

--- a/tests/server/test_http_boundary.py
+++ b/tests/server/test_http_boundary.py
@@ -94,9 +94,7 @@ async def test_invalid_public_url_logs_warning(caplog: pytest.LogCaptureFixture)
     with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
         _boundary_app(settings)
 
-    assert any(
-        "not a valid http(s) URL" in record.message for record in caplog.records
-    )
+    assert any("not a valid http(s) URL" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -207,4 +205,34 @@ async def test_loopback_bind_without_allowlist_does_not_log_warning(
     assert not any(
         "non-loopback" in record.message and "A2A_ALLOWED_HOSTS" in record.message
         for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_url_host_not_covered_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = make_settings(
+        a2a_allowed_hosts=("a2a.example.com",),
+        a2a_public_url="http://other.example:8000",
+    )
+    with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
+        _boundary_app(settings)
+
+    assert any("not covered by A2A_ALLOWED_HOSTS" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_public_url_host_covered_does_not_log_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = make_settings(
+        a2a_allowed_hosts=("a2a.example.com",),
+        a2a_public_url="http://a2a.example.com:8000",
+    )
+    with caplog.at_level(logging.WARNING, logger="opencode_a2a.server.application"):
+        _boundary_app(settings)
+
+    assert not any(
+        "not covered by A2A_ALLOWED_HOSTS" in record.message for record in caplog.records
     )


### PR DESCRIPTION
## 背景

#499 审计拆解项 #504：HTTP 服务缺少 Origin/Host 边界校验。Basic 认证下浏览器自动携带凭据，恶意网页可跨站触发任务提交/取消/订阅；非 loopback 绑定时无 Host 校验，存在 DNS rebinding 风险。与 codex-a2a [issue #344](https://github.com/liujuanjuan1984/codex-a2a/issues/344) 为相同风险面，本次对齐修复（codex-a2a [PR #351](https://github.com/liujuanjuan1984/codex-a2a/pull/351)）。

## 改动

- 新增 `A2A_ALLOWED_ORIGINS`：携带 `Origin` 头的请求必须与 `A2A_PUBLIC_URL` 同源或命中 allowlist，否则返回 403（认证前拒绝）；无 `Origin` 头的 CLI/SDK 请求不受影响，`Origin: null` 默认拒绝。
- Origin 比较先按规范化字符串匹配，再按 `scheme://host[:port]` 语义规范化比较（显式默认端口如 `https://host:443` 与 `https://host` 等价）。
- 新增 `A2A_ALLOWED_HOSTS`：逐请求校验 `Host` 头（精确名、`*.example.com` 通配、`host:port`）；非 loopback 绑定未配置时输出启动告警。
- 边界中间件位于认证之外侧：跨源 OPTIONS 预检同样被拒。
- 启动期配置告警：`A2A_PUBLIC_URL` 非法、public host 未被 `A2A_ALLOWED_HOSTS` 覆盖、`A2A_ALLOWED_ORIGINS` 条目非规范化 origin（带路径/默认端口）时给出 warning，避免配置矛盾导致请求被静默拒绝。
- 新增 CSRF / rebinding 回归测试 22 例：同源放行、跨源拒绝、默认端口规范化、`Origin: null`、非法 public URL、Host allowlist 精确/通配/带端口、缺失 Host、各启动告警。
- `docs/guide.md` 新增 “Inbound Origin and Host Boundary” 章节，说明 Basic 认证的浏览器使用风险。

## 验收对照（#504）

- [x] 带 Origin 头的请求校验与 `A2A_PUBLIC_URL` 同源，不匹配返回 4xx（403）
- [x] 非 loopback 绑定时提供 Host allowlist 校验或启动告警（两者均提供）
- [x] 新增 CSRF/rebinding 回归测试
- [x] 文档说明 Basic 认证的浏览器使用风险

## Commits

- `64206bf` fix(server): enforce inbound Origin/Host boundary (CSRF and DNS rebinding guard)
- `114c3e1` fix(server): warn when A2A_PUBLIC_URL host is not covered by Host allowlist
- `bbe0aef` fix(server): canonicalize Origin comparison and warn on non-normalized allowlist entries

## 验证

- `bash ./scripts/doctor.sh` 通过：pre-commit、mypy、pytest 全量、覆盖率门禁、构建与 wheel smoke
- 新增测试 22 passed

## 关联

- Closes #504
- Relates to #499
- 相邻拆解项 #502（限流/SSE 预算）风险面不同，建议独立分支推进。
