### PR TITLE
feat(server): enforce per-credential rate limits and streaming budgets (#502)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -46,6 +46,8 @@ Key variables to understand protocol behavior:
 - Logs derive a stable `trace_id` from the active `traceparent` so request-scoped log lines can be correlated without introducing high-cardinality metric labels.
 - `A2A_HTTP_GZIP_MINIMUM_SIZE`: minimum eligible response-body size in bytes for global non-streaming HTTP gzip compression. Default: `8192`.
 - `A2A_MAX_REQUEST_BODY_BYTES`: runtime request-body limit. Oversized requests return HTTP `413`.
+- `A2A_RATE_LIMIT_ENABLED` / `A2A_RATE_LIMIT_WINDOW_SECONDS` / `A2A_RATE_LIMIT_MAX_REQUESTS`: per-credential sliding-window rate limiting (per-peer-IP for the unauthenticated Agent Card surface). Defaults: `true` / `60` seconds / `120` requests. Exceeding the window returns HTTP `429` with a `Retry-After` header; `A2A_RATE_LIMIT_ENABLED=false` disables the limiter.
+- `A2A_STREAM_MAX_BYTES` / `A2A_STREAM_MAX_DURATION_SECONDS` / `A2A_STREAM_IDLE_TIMEOUT_SECONDS`: streaming (SSE) response budgets for total bytes, total duration, and idle gap. Defaults: `67108864` bytes / `3600` seconds / `120` seconds; `0` disables the respective budget.
 - `A2A_PENDING_SESSION_CLAIM_TTL_SECONDS`: lease duration for pending preferred session claims before they expire and stop blocking other identities.
 - `A2A_INTERRUPT_REQUEST_TTL_SECONDS`: active retention window for the interrupt request binding registry used by `a2a.interrupt.*` callback methods. Default: `10800` seconds (`180` minutes).
 - `A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS`: retention window for expired interrupt tombstones after active TTL has elapsed. During this window, repeated replies keep returning `INTERRUPT_REQUEST_EXPIRED` instead of falling through to `INTERRUPT_REQUEST_NOT_FOUND`. Default: `600` seconds (`10` minutes).
@@ -289,6 +291,8 @@ If one deployment works while another fails against the same upstream provider, 
 
 - Requests require either `Authorization: Bearer <token>` or a configured `Authorization: Basic <base64(username:password)>`; otherwise `401` is returned. Agent Card endpoints are public.
 - Requests above `A2A_MAX_REQUEST_BODY_BYTES` are rejected with HTTP `413` before transport handling.
+- Inbound requests are rate limited with a sliding window keyed by `credential_id` when configured, otherwise by the authenticated principal; the public Agent Card surface is keyed by the direct peer IP (never `X-Forwarded-For`). Exceeding `A2A_RATE_LIMIT_MAX_REQUESTS` within `A2A_RATE_LIMIT_WINDOW_SECONDS` returns HTTP `429` with a `Retry-After` header. The limiter is process-local; multi-process deployments should place a shared gateway in front or rely on per-instance limits.
+- Streaming responses (JSON-RPC `SendStreamingMessage` / `SubscribeToTask` and REST `/message:stream` / `/tasks/{id}:subscribe`) are bounded by `A2A_STREAM_MAX_BYTES`, `A2A_STREAM_MAX_DURATION_SECONDS`, and `A2A_STREAM_IDLE_TIMEOUT_SECONDS`; when a budget is exceeded the server ends the stream with an SSE `event: error` frame. If the very first event already exceeds the budget, REST requests are rejected with HTTP `429` `RESOURCE_EXHAUSTED` before the SSE stream starts.
 - For validation failures, missing context (`task_id` / `context_id`), or internal errors, the service attempts to return standard A2A failure events via `event_queue`.
 - Failure events include concrete error details with `failed` state.
 

--- a/src/opencode_a2a/config.py
+++ b/src/opencode_a2a/config.py
@@ -191,6 +191,32 @@ class Settings(BaseSettings):
         ge=0,
         alias="A2A_MAX_REQUEST_BODY_BYTES",
     )
+    a2a_rate_limit_enabled: bool = Field(default=True, alias="A2A_RATE_LIMIT_ENABLED")
+    a2a_rate_limit_window_seconds: float = Field(
+        default=60.0,
+        gt=0.0,
+        alias="A2A_RATE_LIMIT_WINDOW_SECONDS",
+    )
+    a2a_rate_limit_max_requests: int = Field(
+        default=120,
+        gt=0,
+        alias="A2A_RATE_LIMIT_MAX_REQUESTS",
+    )
+    a2a_stream_max_bytes: int = Field(
+        default=64 * 1024 * 1024,
+        ge=0,
+        alias="A2A_STREAM_MAX_BYTES",
+    )
+    a2a_stream_max_duration_seconds: float = Field(
+        default=3600.0,
+        ge=0.0,
+        alias="A2A_STREAM_MAX_DURATION_SECONDS",
+    )
+    a2a_stream_idle_timeout_seconds: float = Field(
+        default=120.0,
+        ge=0.0,
+        alias="A2A_STREAM_IDLE_TIMEOUT_SECONDS",
+    )
     a2a_documentation_url: str | None = Field(default=None, alias="A2A_DOCUMENTATION_URL")
     a2a_allow_directory_override: bool = Field(default=True, alias="A2A_ALLOW_DIRECTORY_OVERRIDE")
     a2a_enable_session_shell: bool = Field(default=False, alias="A2A_ENABLE_SESSION_SHELL")

--- a/src/opencode_a2a/jsonrpc/application.py
+++ b/src/opencode_a2a/jsonrpc/application.py
@@ -22,6 +22,7 @@ from ..extension_negotiation import (
     requested_extensions_from_call_context,
 )
 from ..opencode_upstream_client import OpencodeUpstreamClient
+from ..server.runtime_limits import apply_stream_budget
 from .dispatch import (
     ExtensionHandlerContext,
     build_extension_method_registry,
@@ -58,6 +59,9 @@ class OpencodeSessionManagementJSONRPCApplication(JsonRpcDispatcher):
         session_claim: Callable[..., Awaitable[bool]] | None = None,
         session_claim_finalize: Callable[..., Awaitable[None]] | None = None,
         session_claim_release: Callable[..., Awaitable[None]] | None = None,
+        stream_budget_max_bytes: int = 0,
+        stream_budget_max_duration_seconds: float = 0.0,
+        stream_budget_idle_timeout_seconds: float = 0.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(request_handler=http_handler, **kwargs)
@@ -115,6 +119,9 @@ class OpencodeSessionManagementJSONRPCApplication(JsonRpcDispatcher):
         self._session_claim = cast(Callable[..., Awaitable[bool]], session_claim)
         self._session_claim_finalize = cast(Callable[..., Awaitable[None]], session_claim_finalize)
         self._session_claim_release = cast(Callable[..., Awaitable[None]], session_claim_release)
+        self._stream_budget_max_bytes = stream_budget_max_bytes
+        self._stream_budget_max_duration_seconds = stream_budget_max_duration_seconds
+        self._stream_budget_idle_timeout_seconds = stream_budget_idle_timeout_seconds
         self._extension_handler_context = ExtensionHandlerContext(
             upstream_client=self._upstream_client,
             method_session_status=self._method_session_status,
@@ -264,7 +271,12 @@ class OpencodeSessionManagementJSONRPCApplication(JsonRpcDispatcher):
             except A2AError as error:
                 yield build_error_response(request_id, error)
 
-        return _wrap_stream(stream, first_event)
+        return apply_stream_budget(
+            _wrap_stream(stream, first_event),
+            max_bytes=self._stream_budget_max_bytes,
+            max_duration_seconds=self._stream_budget_max_duration_seconds,
+            idle_timeout_seconds=self._stream_budget_idle_timeout_seconds,
+        )
 
     async def _handle_core_request(
         self,

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -1017,19 +1017,34 @@ def create_app(settings: Settings) -> FastAPI:
                 error=error,
             )
 
+    async def rest_subscribe_route(request: Request):
+        try:
+
+            async def _handler(context):
+                params = SubscribeToTaskRequest(id=request.path_params["id"])
+                async for event in handler.on_subscribe_to_task(params, context):
+                    yield MessageToDict(proto_utils.to_stream_response(event))
+
+            return await rest_dispatcher._handle_streaming(request, _handler)
+        except Exception as error:  # noqa: BLE001 - mirrors SDK rest_stream_error_handler
+            return _rest_error_response(
+                request=request,
+                error=error,
+            )
+
     app.add_api_route(AGENT_CARD_WELL_KNOWN_PATH, public_agent_card_route, methods=["GET"])
     app.add_api_route("/message:send", rest_message_send_route, methods=["POST"])
     app.add_api_route("/message:stream", rest_message_send_stream_route, methods=["POST"])
     app.add_api_route("/tasks/{id}:cancel", rest_dispatcher.on_cancel_task, methods=["POST"])
     app.add_api_route(
         "/tasks/{id}:subscribe",
-        rest_dispatcher.on_subscribe_to_task,
+        rest_subscribe_route,
         methods=["GET"],
         operation_id="subscribe_to_task_get",
     )
     app.add_api_route(
         "/tasks/{id}:subscribe",
-        rest_dispatcher.on_subscribe_to_task,
+        rest_subscribe_route,
         methods=["POST"],
         operation_id="subscribe_to_task_post",
     )

--- a/src/opencode_a2a/server/application.py
+++ b/src/opencode_a2a/server/application.py
@@ -107,6 +107,7 @@ from .request_parsing import (
     _parse_json_body,
 )
 from .rest_tasks import build_list_tasks_route
+from .runtime_limits import StreamBudgetExceeded, apply_stream_budget
 from .state_store import (
     build_runtime_state_runtime,
 )
@@ -152,6 +153,21 @@ def _rest_error_response(
                 metadata=metadata,
             ),
             status_code=mapping.http_code,
+        )
+
+    if isinstance(error, StreamBudgetExceeded):
+        logger.warning(
+            "REST stream rejected before SSE start: %s",
+            error,
+        )
+        return JSONResponse(
+            build_http_error_body(
+                status_code=429,
+                status="RESOURCE_EXHAUSTED",
+                message=str(error),
+                reason="STREAM_BUDGET_EXCEEDED",
+            ),
+            status_code=429,
         )
 
     if isinstance(error, ParseError):
@@ -210,10 +226,12 @@ def _parse_rest_send_message_request(body: bytes):
 
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable
 
     from a2a.server.agent_execution import AgentExecutor, RequestContextBuilder
     from a2a.server.context import ServerCallContext
+    from a2a.server.request_handlers.request_handler import RequestHandler
+    from a2a.server.routes.common import ServerCallContextBuilder
     from a2a.server.tasks import (
         PushNotificationConfigStore,
         PushNotificationSender,
@@ -820,6 +838,45 @@ class IdentityAwareCallContextBuilder(DefaultServerCallContextBuilder):
         return context
 
 
+class BudgetedRestDispatcher(RestDispatcher):
+    """REST dispatcher that applies streaming output budgets to SSE streams."""
+
+    def __init__(
+        self,
+        request_handler: RequestHandler,
+        context_builder: ServerCallContextBuilder,
+        *,
+        stream_budget_max_bytes: int,
+        stream_budget_max_duration_seconds: float,
+        stream_budget_idle_timeout_seconds: float,
+    ) -> None:
+        super().__init__(
+            request_handler=request_handler,
+            context_builder=context_builder,
+        )
+        self._stream_budget_max_bytes = stream_budget_max_bytes
+        self._stream_budget_max_duration_seconds = stream_budget_max_duration_seconds
+        self._stream_budget_idle_timeout_seconds = stream_budget_idle_timeout_seconds
+
+    async def _handle_streaming(
+        self,
+        request: Request,
+        handler_func: Callable[[ServerCallContext], AsyncIterator[Any]],
+    ) -> Any:
+        async def budgeted_handler(
+            context: ServerCallContext,
+        ) -> AsyncIterator[Any]:
+            async for item in apply_stream_budget(
+                aiter(handler_func(context)),
+                max_bytes=self._stream_budget_max_bytes,
+                max_duration_seconds=self._stream_budget_max_duration_seconds,
+                idle_timeout_seconds=self._stream_budget_idle_timeout_seconds,
+            ):
+                yield item
+
+        return await super()._handle_streaming(request, budgeted_handler)
+
+
 def create_app(settings: Settings) -> FastAPI:
     install_log_record_factory()
     database_engine = (
@@ -889,11 +946,17 @@ def create_app(settings: Settings) -> FastAPI:
             "release_preferred_session_claim",
             None,
         ),
+        stream_budget_max_bytes=settings.a2a_stream_max_bytes,
+        stream_budget_max_duration_seconds=settings.a2a_stream_max_duration_seconds,
+        stream_budget_idle_timeout_seconds=settings.a2a_stream_idle_timeout_seconds,
         methods=jsonrpc_methods,
     )
-    rest_dispatcher = RestDispatcher(
+    rest_dispatcher = BudgetedRestDispatcher(
         request_handler=handler,
         context_builder=context_builder,
+        stream_budget_max_bytes=settings.a2a_stream_max_bytes,
+        stream_budget_max_duration_seconds=settings.a2a_stream_max_duration_seconds,
+        stream_budget_idle_timeout_seconds=settings.a2a_stream_idle_timeout_seconds,
     )
     public_card_etag = build_agent_card_etag(agent_card)
     extended_card_etag = build_agent_card_etag(extended_agent_card)

--- a/src/opencode_a2a/server/middleware.py
+++ b/src/opencode_a2a/server/middleware.py
@@ -50,6 +50,10 @@ from .request_parsing import (
     _request_body_too_large_response,
     _RequestBodyTooLargeError,
 )
+from .runtime_limits import (
+    SlidingWindowRateLimiter,
+    build_rate_limit_response,
+)
 
 logger = logging.getLogger("opencode_a2a.server.application")
 PUBLIC_AGENT_CARD_CACHE_CONTROL = "public, max-age=300"
@@ -69,6 +73,26 @@ def _is_http_json_rest_path(path: str) -> bool:
     carried in the A2A-Version header instead.
     """
     return path.startswith("/message:") or path.startswith("/tasks")
+
+
+def _resolve_rate_limit_key(request: Request) -> str:
+    """Key the limiter by credential, principal, or peer IP.
+
+    Authenticated requests use ``credential_id`` when declared so independent
+    credentials never share a bucket; otherwise they fall back to the stable
+    principal. The public (unauthenticated) surface is keyed by the direct
+    peer IP; ``X-Forwarded-For`` is deliberately not trusted because it can be
+    spoofed by clients when the service is not behind a trusted proxy.
+    """
+    credential_id = getattr(request.state, "user_credential_id", None)
+    if credential_id:
+        return f"credential:{credential_id}"
+    identity = getattr(request.state, "user_identity", None)
+    if identity:
+        return f"principal:{identity}"
+    client = request.client
+    host = client.host if client is not None else "unknown"
+    return f"ip:{host}"
 
 
 def add_auth_middleware(app: FastAPI, settings) -> None:  # noqa: ANN001
@@ -531,6 +555,22 @@ def install_runtime_middlewares(
         finally:
             if token is not None:
                 _REQUEST_BODY_BYTES.reset(token)
+
+    rate_limiter = SlidingWindowRateLimiter(
+        max_requests=settings.a2a_rate_limit_max_requests,
+        window_seconds=settings.a2a_rate_limit_window_seconds,
+    )
+
+    @app.middleware("http")
+    async def enforce_rate_limit(request: Request, call_next):
+        if not settings.a2a_rate_limit_enabled or request.method == "OPTIONS":
+            return await call_next(request)
+        key = _resolve_rate_limit_key(request)
+        if not await rate_limiter.check_and_record(key):
+            retry_after = await rate_limiter.retry_after(key)
+            emit_metric("a2a_rate_limit_rejected_total")
+            return build_rate_limit_response(retry_after)
+        return await call_next(request)
 
     add_auth_middleware(app, settings)
 

--- a/src/opencode_a2a/server/runtime_limits.py
+++ b/src/opencode_a2a/server/runtime_limits.py
@@ -1,0 +1,200 @@
+"""Inbound admission controls for the A2A runtime.
+
+The server exposes authenticated JSON-RPC and HTTP+JSON surfaces plus a
+public Agent Card. Without admission controls a single caller can hold every
+concurrency slot or force unbounded SSE output, starving other callers and
+accumulating memory, file descriptors, and bandwidth.
+
+This module provides:
+
+- ``SlidingWindowRateLimiter``: process-local sliding-window admission counter
+  keyed by credential/principal for authenticated requests and by peer IP for
+  the public surface.
+- ``apply_stream_budget``: async-generator wrapper that bounds a streaming
+  response (total serialized bytes, total duration, and idle gap) and raises
+  ``StreamBudgetExceeded`` when a budget is exceeded. The transport layers
+  convert that into a well-formed SSE ``error`` event and end the stream
+  through the same clean teardown path as a naturally completed stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import time
+from collections import deque
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from typing import Any
+
+from starlette.responses import JSONResponse
+
+from ..execution.metrics import emit_metric
+
+logger = logging.getLogger(__name__)
+
+RATE_LIMIT_ERROR_MESSAGE = "Too many requests"
+STREAM_BUDGET_ERROR_MESSAGE = "Stream budget exceeded"
+_DEFAULT_MAX_RATE_LIMIT_KEYS = 100_000
+# Approximate SSE framing overhead per event: ``data: `` prefix, line
+# separators, and the compact-JSON slack.
+_SSE_EVENT_FRAMING_OVERHEAD = 32
+
+
+def build_rate_limit_response(retry_after_seconds: float) -> JSONResponse:
+    """Build a 429 response carrying a client-safe Retry-After hint."""
+    retry_after = max(1, math.ceil(retry_after_seconds))
+    return JSONResponse(
+        {"error": RATE_LIMIT_ERROR_MESSAGE},
+        status_code=429,
+        headers={"Retry-After": str(retry_after), "Cache-Control": "no-store"},
+    )
+
+
+class SlidingWindowRateLimiter:
+    """Process-local sliding-window rate limiter.
+
+    Every key tracks the timestamps of admitted requests inside the window.
+    Buckets are pruned lazily on access and the key table is capped so memory
+    stays bounded even under a flood of distinct keys. All mutations are
+    serialized by an asyncio lock so concurrent request handlers observe a
+    consistent counter.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_requests: int,
+        window_seconds: float,
+        max_keys: int = _DEFAULT_MAX_RATE_LIMIT_KEYS,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if max_requests <= 0:
+            raise ValueError("max_requests must be greater than 0")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be greater than 0")
+        if max_keys <= 0:
+            raise ValueError("max_keys must be greater than 0")
+        self._max_requests = max_requests
+        self._window_seconds = float(window_seconds)
+        self._max_keys = max_keys
+        self._clock = clock or time.monotonic
+        self._entries: dict[str, deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def check_and_record(self, key: str) -> bool:
+        """Return True when the request is admitted and record it."""
+        async with self._lock:
+            now = self._clock()
+            entries = self._entries.setdefault(key, deque())
+            self._prune(entries, now)
+            if len(entries) >= self._max_requests:
+                return False
+            entries.append(now)
+            self._evict_if_needed()
+            return True
+
+    async def retry_after(self, key: str) -> float:
+        """Return the seconds until the oldest recorded request expires."""
+        async with self._lock:
+            entries = self._entries.get(key)
+            if not entries:
+                return self._window_seconds
+            now = self._clock()
+            self._prune(entries, now)
+            if not entries:
+                return self._window_seconds
+            return max(0.0, entries[0] + self._window_seconds - now)
+
+    def _prune(self, entries: deque[float], now: float) -> None:
+        while entries and now - entries[0] >= self._window_seconds:
+            entries.popleft()
+
+    def _evict_if_needed(self) -> None:
+        if len(self._entries) <= self._max_keys:
+            return
+        # dict preserves insertion order; evict the oldest-inserted key.
+        stale_key = next(iter(self._entries))
+        del self._entries[stale_key]
+
+
+class StreamBudgetExceeded(Exception):
+    """Raised when a streaming response exceeds its configured budget."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"{STREAM_BUDGET_ERROR_MESSAGE}: {reason}")
+        self.reason = reason
+
+
+def json_event_size(item: Any) -> int:
+    """Approximate the on-wire SSE bytes for one serialized event item."""
+    serialized = json.dumps(
+        item,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+    return len(serialized) + _SSE_EVENT_FRAMING_OVERHEAD
+
+
+async def apply_stream_budget(
+    stream: AsyncIterator[Any],
+    *,
+    max_bytes: int,
+    max_duration_seconds: float,
+    idle_timeout_seconds: float,
+    clock: Callable[[], float] | None = None,
+    size_of: Callable[[Any], int] = json_event_size,
+) -> AsyncGenerator[Any, None]:
+    """Yield events while enforcing byte, duration, and idle budgets.
+
+    A value of ``0`` disables the corresponding budget. When a budget is
+    exceeded ``StreamBudgetExceeded`` is raised and the underlying stream is
+    closed first, so the application runs the same cleanup/drain path as a
+    client disconnect and the transport emits a well-formed SSE ``error``
+    event before ending the response normally.
+    """
+    resolve_clock = clock or time.monotonic
+    started_at: float | None = None
+    total_bytes = 0
+
+    try:
+        while True:
+            try:
+                if idle_timeout_seconds > 0:
+                    event = await asyncio.wait_for(
+                        anext(stream),
+                        timeout=idle_timeout_seconds,
+                    )
+                else:
+                    event = await anext(stream)
+            except StopAsyncIteration:
+                return
+            except TimeoutError:
+                _reject_budget("idle timeout")
+                return
+
+            now = resolve_clock()
+            if started_at is None:
+                started_at = now
+            elif max_duration_seconds > 0 and now - started_at >= max_duration_seconds:
+                _reject_budget("duration budget")
+                return
+
+            total_bytes += size_of(event)
+            if max_bytes > 0 and total_bytes > max_bytes:
+                _reject_budget("byte budget")
+                return
+
+            yield event
+    finally:
+        # Close the inner generator so its handler observes GeneratorExit and
+        # runs the normal disconnect/drain cleanup.
+        close = getattr(stream, "aclose", None)
+        if close is not None:
+            await close()
+
+
+def _reject_budget(reason: str) -> None:
+    emit_metric("a2a_stream_budget_rejected_total")
+    raise StreamBudgetExceeded(reason)

--- a/src/opencode_a2a/server/runtime_limits.py
+++ b/src/opencode_a2a/server/runtime_limits.py
@@ -26,7 +26,7 @@ import math
 import time
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
-from typing import Any
+from typing import Any, NoReturn
 
 from starlette.responses import JSONResponse
 
@@ -172,19 +172,18 @@ async def apply_stream_budget(
                 return
             except TimeoutError:
                 _reject_budget("idle timeout")
-                return
 
-            now = resolve_clock()
-            if started_at is None:
-                started_at = now
-            elif max_duration_seconds > 0 and now - started_at >= max_duration_seconds:
-                _reject_budget("duration budget")
-                return
+            if max_duration_seconds > 0:
+                now = resolve_clock()
+                if started_at is None:
+                    started_at = now
+                elif now - started_at >= max_duration_seconds:
+                    _reject_budget("duration budget")
 
-            total_bytes += size_of(event)
-            if max_bytes > 0 and total_bytes > max_bytes:
-                _reject_budget("byte budget")
-                return
+            if max_bytes > 0:
+                total_bytes += size_of(event)
+                if total_bytes > max_bytes:
+                    _reject_budget("byte budget")
 
             yield event
     finally:
@@ -195,6 +194,6 @@ async def apply_stream_budget(
             await close()
 
 
-def _reject_budget(reason: str) -> None:
+def _reject_budget(reason: str) -> NoReturn:
     emit_metric("a2a_stream_budget_rejected_total")
     raise StreamBudgetExceeded(reason)

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -31,6 +31,17 @@ def test_settings_use_bounded_upstream_defaults() -> None:
     assert settings.opencode_max_concurrent_streams == 8
 
 
+def test_settings_use_bounded_admission_defaults() -> None:
+    settings = make_settings()
+
+    assert settings.a2a_rate_limit_enabled is True
+    assert settings.a2a_rate_limit_window_seconds == 60.0
+    assert settings.a2a_rate_limit_max_requests == 120
+    assert settings.a2a_stream_max_bytes == 64 * 1024 * 1024
+    assert settings.a2a_stream_max_duration_seconds == 3600.0
+    assert settings.a2a_stream_idle_timeout_seconds == 120.0
+
+
 def test_settings_valid():
     env = {
         "A2A_STATIC_AUTH_CREDENTIALS": json.dumps(
@@ -51,6 +62,12 @@ def test_settings_valid():
         "OPENCODE_WORKSPACE_ROOT": "/srv/workspaces/alpha",
         "A2A_HTTP_GZIP_MINIMUM_SIZE": "2048",
         "A2A_MAX_REQUEST_BODY_BYTES": "2048",
+        "A2A_RATE_LIMIT_ENABLED": "false",
+        "A2A_RATE_LIMIT_WINDOW_SECONDS": "30",
+        "A2A_RATE_LIMIT_MAX_REQUESTS": "45",
+        "A2A_STREAM_MAX_BYTES": "1048576",
+        "A2A_STREAM_MAX_DURATION_SECONDS": "900",
+        "A2A_STREAM_IDLE_TIMEOUT_SECONDS": "45",
         "A2A_PENDING_SESSION_CLAIM_TTL_SECONDS": "45",
         "A2A_INTERRUPT_REQUEST_TTL_SECONDS": "7200",
         "A2A_INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS": "120",
@@ -80,6 +97,12 @@ def test_settings_valid():
         assert settings.opencode_workspace_root == "/srv/workspaces/alpha"
         assert settings.a2a_http_gzip_minimum_size == 2048
         assert settings.a2a_max_request_body_bytes == 2048
+        assert settings.a2a_rate_limit_enabled is False
+        assert settings.a2a_rate_limit_window_seconds == 30.0
+        assert settings.a2a_rate_limit_max_requests == 45
+        assert settings.a2a_stream_max_bytes == 1_048_576
+        assert settings.a2a_stream_max_duration_seconds == 900.0
+        assert settings.a2a_stream_idle_timeout_seconds == 45.0
         assert settings.a2a_pending_session_claim_ttl_seconds == 45.0
         assert settings.a2a_interrupt_request_ttl_seconds == 7200.0
         assert settings.a2a_interrupt_request_tombstone_ttl_seconds == 120.0
@@ -335,6 +358,33 @@ def test_settings_reject_negative_max_request_body_bytes():
 
     field_names = [e["loc"][0] for e in excinfo.value.errors()]
     assert "A2A_MAX_REQUEST_BODY_BYTES" in field_names
+
+
+def test_settings_reject_invalid_admission_limits() -> None:
+    env = {
+        "A2A_STATIC_AUTH_CREDENTIALS": json.dumps(
+            [
+                {
+                    "scheme": "bearer",
+                    "token": "test-token",
+                    "principal": "automation",
+                }
+            ]
+        ),
+        "A2A_RATE_LIMIT_WINDOW_SECONDS": "0",
+        "A2A_RATE_LIMIT_MAX_REQUESTS": "0",
+        "A2A_STREAM_MAX_BYTES": "-1",
+        "A2A_STREAM_MAX_DURATION_SECONDS": "-1",
+        "A2A_STREAM_IDLE_TIMEOUT_SECONDS": "-1",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValidationError) as excinfo:
+            Settings()
+
+    field_names = {e["loc"][0] for e in excinfo.value.errors()}
+    assert {"A2A_RATE_LIMIT_WINDOW_SECONDS", "A2A_RATE_LIMIT_MAX_REQUESTS"} <= field_names
+    assert {"A2A_STREAM_MAX_BYTES", "A2A_STREAM_MAX_DURATION_SECONDS"} <= field_names
+    assert "A2A_STREAM_IDLE_TIMEOUT_SECONDS" in field_names
 
 
 def test_settings_reject_negative_http_gzip_minimum_size():

--- a/tests/server/test_runtime_limits.py
+++ b/tests/server/test_runtime_limits.py
@@ -11,6 +11,10 @@ from opencode_a2a.server.runtime_limits import (
     StreamBudgetExceeded,
     apply_stream_budget,
 )
+from tests.server.test_transport_contract import (
+    _authenticated_task_context,
+    _task_for_listing,
+)
 from tests.support.helpers import DummyChatOpencodeUpstreamClient, make_basic_auth_header
 from tests.support.settings import make_settings
 
@@ -374,3 +378,50 @@ async def test_streaming_byte_budget_integration_terminates_jsonrpc_sse(monkeypa
 
     assert b"event: error" in body
     assert b"byte budget" in body
+
+
+@pytest.mark.asyncio
+async def test_subscribe_missing_task_returns_not_found(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = _create_rate_limited_app(test_bearer_token="test-token")
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/tasks/missing:subscribe", headers=headers)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_streaming_byte_budget_integration_rejects_subscribe_before_sse(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = _create_rate_limited_app(
+        test_bearer_token="test-token",
+        a2a_stream_max_bytes=128,
+        a2a_stream_max_duration_seconds=0,
+        a2a_stream_idle_timeout_seconds=0,
+    )
+    task_store = app.state.task_store
+    await task_store.save(
+        _task_for_listing(
+            task_id="task-sub",
+            context_id="ctx-sub",
+            timestamp="2026-08-22T00:00:00+00:00",
+        ),
+        _authenticated_task_context(),
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/tasks/task-sub:subscribe", headers=headers)
+
+    assert response.status_code == 429
+    error_payload = response.json()["error"]
+    assert error_payload["status"] == "RESOURCE_EXHAUSTED"
+    assert error_payload["message"] == "Stream budget exceeded: byte budget"

--- a/tests/server/test_runtime_limits.py
+++ b/tests/server/test_runtime_limits.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from opencode_a2a.server.runtime_limits import (
+    SlidingWindowRateLimiter,
+    StreamBudgetExceeded,
+    apply_stream_budget,
+)
+from tests.support.helpers import DummyChatOpencodeUpstreamClient, make_basic_auth_header
+from tests.support.settings import make_settings
+
+
+class FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.value = start
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class IdleTerminatingChatClient(DummyChatOpencodeUpstreamClient):
+    """Dummy upstream client whose stream terminates like a real OpenCode run."""
+
+    async def stream_events(  # noqa: ANN001
+        self,
+        stop_event=None,
+        *,
+        directory: str | None = None,
+        workspace_id: str | None = None,
+    ):
+        del stop_event, directory, workspace_id
+        yield {"type": "session.idle", "properties": {"sessionID": "ses-created-1"}}
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_admits_until_window_capacity() -> None:
+    clock = FakeClock()
+    limiter = SlidingWindowRateLimiter(
+        max_requests=3,
+        window_seconds=60.0,
+        clock=clock,
+    )
+
+    for _ in range(3):
+        assert await limiter.check_and_record("credential:alice") is True
+
+    assert await limiter.check_and_record("credential:alice") is False
+    assert await limiter.check_and_record("credential:bob") is True
+    assert await limiter.retry_after("credential:alice") == pytest.approx(60.0)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_window_slides() -> None:
+    clock = FakeClock()
+    limiter = SlidingWindowRateLimiter(
+        max_requests=2,
+        window_seconds=10.0,
+        clock=clock,
+    )
+
+    assert await limiter.check_and_record("ip:1.2.3.4") is True
+    clock.advance(5.0)
+    assert await limiter.check_and_record("ip:1.2.3.4") is True
+    assert await limiter.check_and_record("ip:1.2.3.4") is False
+
+    clock.advance(5.0)
+    assert await limiter.check_and_record("ip:1.2.3.4") is True
+    assert await limiter.retry_after("ip:1.2.3.4") == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_evicts_oldest_key_when_full() -> None:
+    clock = FakeClock()
+    limiter = SlidingWindowRateLimiter(
+        max_requests=1,
+        window_seconds=60.0,
+        max_keys=2,
+        clock=clock,
+    )
+
+    assert await limiter.check_and_record("ip:a") is True
+    assert await limiter.check_and_record("ip:b") is True
+    assert await limiter.check_and_record("ip:c") is True
+    # The oldest-inserted key was evicted, so it is admitted again.
+    assert await limiter.check_and_record("ip:a") is True
+
+
+def test_rate_limiter_rejects_invalid_configuration() -> None:
+    with pytest.raises(ValueError):
+        SlidingWindowRateLimiter(max_requests=0, window_seconds=60.0)
+    with pytest.raises(ValueError):
+        SlidingWindowRateLimiter(max_requests=1, window_seconds=0.0)
+    with pytest.raises(ValueError):
+        SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0, max_keys=0)
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_byte_limit_raises_and_closes_source() -> None:
+    state = {"closed": False}
+
+    async def tracked():
+        try:
+            yield "a" * 40
+            yield "b" * 40
+            yield "c" * 40
+        finally:
+            state["closed"] = True
+
+    received = []
+    with pytest.raises(StreamBudgetExceeded) as excinfo:
+        async for item in apply_stream_budget(
+            tracked(),
+            max_bytes=50,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0,
+            size_of=len,
+        ):
+            received.append(item)
+
+    assert excinfo.value.reason == "byte budget"
+    assert received == ["a" * 40]
+    assert state["closed"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_duration_limit_raises() -> None:
+    clock = FakeClock()
+
+    async def delayed():
+        yield "first"
+        clock.advance(30.0)
+        yield "second"
+        clock.advance(30.0)
+        yield "third"
+
+    received = []
+    with pytest.raises(StreamBudgetExceeded) as excinfo:
+        async for item in apply_stream_budget(
+            delayed(),
+            max_bytes=0,
+            max_duration_seconds=45.0,
+            idle_timeout_seconds=0,
+            clock=clock,
+            size_of=len,
+        ):
+            received.append(item)
+
+    assert excinfo.value.reason == "duration budget"
+    assert received == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_idle_timeout_raises() -> None:
+    async def slow():
+        yield "first"
+        await asyncio.sleep(0.08)
+        yield "second"
+
+    received = []
+    with pytest.raises(StreamBudgetExceeded) as excinfo:
+        async for item in apply_stream_budget(
+            slow(),
+            max_bytes=0,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0.02,
+            size_of=len,
+        ):
+            received.append(item)
+
+    assert excinfo.value.reason == "idle timeout"
+    assert received == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_within_limits_passes_through() -> None:
+    async def source():
+        yield "hello"
+        yield "world"
+
+    received = [
+        item
+        async for item in apply_stream_budget(
+            source(),
+            max_bytes=10_000,
+            max_duration_seconds=60.0,
+            idle_timeout_seconds=30.0,
+            size_of=len,
+        )
+    ]
+
+    assert received == ["hello", "world"]
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_disabled_values_pass_through() -> None:
+    async def source():
+        for _ in range(20):
+            yield "x" * 10
+
+    received = [
+        item
+        async for item in apply_stream_budget(
+            source(),
+            max_bytes=0,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0,
+            size_of=len,
+        )
+    ]
+
+    assert received == ["x" * 10] * 20
+
+
+def _create_rate_limited_app(**settings_overrides: Any) -> Any:
+    import opencode_a2a.server.application as app_module
+
+    return app_module.create_app(make_settings(**settings_overrides))
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_rejects_excess_authenticated_requests(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = _create_rate_limited_app(
+        test_bearer_token="test-token",
+        a2a_rate_limit_max_requests=3,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(3):
+            response = await client.get("/health", headers=headers)
+            assert response.status_code == 200
+        limited = await client.get("/health", headers=headers)
+
+    assert limited.status_code == 429
+    assert limited.headers["retry-after"] == "60"
+    assert limited.json() == {"error": "Too many requests"}
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_per_credential(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = _create_rate_limited_app(
+        test_bearer_token="test-token",
+        test_basic_username="operator",
+        test_basic_password="op-pass",  # pragma: allowlist secret
+        a2a_rate_limit_max_requests=2,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    bearer_headers = {"Authorization": "Bearer test-token"}
+    basic_headers = make_basic_auth_header("operator", "op-pass")  # pragma: allowlist secret
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(2):
+            assert (await client.get("/health", headers=bearer_headers)).status_code == 200
+        assert (await client.get("/health", headers=bearer_headers)).status_code == 429
+        # A different credential keeps its own bucket.
+        assert (await client.get("/health", headers=basic_headers)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_public_card_keyed_by_peer_ip(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = _create_rate_limited_app(
+        test_bearer_token="test-token",
+        a2a_rate_limit_max_requests=2,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(2):
+            assert (await client.get("/.well-known/agent-card.json")).status_code == 200
+        assert (await client.get("/.well-known/agent-card.json")).status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_can_be_disabled(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", DummyChatOpencodeUpstreamClient)
+    app = _create_rate_limited_app(
+        test_bearer_token="test-token",
+        a2a_rate_limit_enabled=False,
+        a2a_rate_limit_max_requests=1,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(3):
+            assert (await client.get("/health", headers=headers)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_streaming_byte_budget_integration_rejects_rest_before_sse(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", IdleTerminatingChatClient)
+    app = _create_rate_limited_app(
+        test_bearer_token="test-token",
+        a2a_stream_max_bytes=128,
+        a2a_stream_max_duration_seconds=0,
+        a2a_stream_idle_timeout_seconds=0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "message": {
+            "messageId": "m-rest",
+            "role": "ROLE_USER",
+            "parts": [{"text": "hello from rest"}],
+        }
+    }
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/message:stream", headers=headers, json=payload)
+
+    assert response.status_code == 429
+    error_payload = response.json()["error"]
+    assert error_payload["status"] == "RESOURCE_EXHAUSTED"
+    assert error_payload["message"] == "Stream budget exceeded: byte budget"
+
+
+@pytest.mark.asyncio
+async def test_streaming_byte_budget_integration_terminates_jsonrpc_sse(monkeypatch) -> None:
+    import opencode_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "OpencodeUpstreamClient", IdleTerminatingChatClient)
+    app = _create_rate_limited_app(
+        test_bearer_token="test-token",
+        a2a_stream_max_bytes=128,
+        a2a_stream_max_duration_seconds=0,
+        a2a_stream_idle_timeout_seconds=0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "SendStreamingMessage",
+        "params": {
+            "message": {
+                "messageId": "m-rpc",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello from jsonrpc"}],
+            }
+        },
+    }
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream("POST", "/", headers=headers, json=payload) as resp:
+            assert resp.status_code == 200
+            assert "text/event-stream" in resp.headers.get("content-type", "")
+            body = b"".join([chunk async for chunk in resp.aiter_bytes()])
+
+    assert b"event: error" in body
+    assert b"byte budget" in body

--- a/tests/server/test_runtime_limits.py
+++ b/tests/server/test_runtime_limits.py
@@ -223,6 +223,29 @@ async def test_stream_budget_disabled_values_pass_through() -> None:
     assert received == ["x" * 10] * 20
 
 
+@pytest.mark.asyncio
+async def test_stream_budget_disabled_does_not_measure_events() -> None:
+    def exploding_size(_item: object) -> int:
+        raise AssertionError("size_of must not run when the byte budget is disabled")
+
+    async def source():
+        yield "x" * 10
+        yield "y" * 10
+
+    received = [
+        item
+        async for item in apply_stream_budget(
+            source(),
+            max_bytes=0,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0,
+            size_of=exploding_size,
+        )
+    ]
+
+    assert received == ["x" * 10, "y" * 10]
+
+
 def _create_rate_limited_app(**settings_overrides: Any) -> Any:
     import opencode_a2a.server.application as app_module
 


### PR DESCRIPTION
## 概述

按 #502 验收标准，为运行时补齐入站限流与流式输出预算：

- **按凭据/IP 的滑动窗口限流**（默认开启）：认证请求按 `credential_id`（未配置时按 principal）分桶，公开 Agent Card 按直连 peer IP 分桶；进程内实现、内存有界；超限返回 HTTP 429 + `Retry-After`。
- **SSE/流式输出预算**（默认有界）：对 JSON-RPC `SendStreamingMessage` / `SubscribeToTask` 与 REST `/message:stream` / `/tasks/{id}:subscribe` 施加总字节 / 总时长 / 空闲超时预算；超限时以 SSE `event: error` 帧终止并走正常清理路径（REST 首事件即超限时返回 429 RESOURCE_EXHAUSTED JSON）。
- **配置项**：`A2A_RATE_LIMIT_ENABLED` / `A2A_RATE_LIMIT_WINDOW_SECONDS` / `A2A_RATE_LIMIT_MAX_REQUESTS` / `A2A_STREAM_MAX_BYTES` / `A2A_STREAM_MAX_DURATION_SECONDS` / `A2A_STREAM_IDLE_TIMEOUT_SECONDS`（`0` 关闭对应预算）。
- **测试与文档**：`tests/server/test_runtime_limits.py`（限流器、预算包装器、REST/JSON-RPC/subscribe 集成）、配置校验用例、`docs/guide.md` 同步说明。

实现上流式预算在事件生成器层执行，避免传输层强制终止导致的会话清理挂起。

## 独立审查与收敛

- 流式预算改为生成器层执行（传输层强制终止会触发 SDK/SQLAlchemy 会话关闭死锁，已收敛）。
- REST 首事件超预算统一映射为 429 RESOURCE_EXHAUSTED：`message:stream` 与 `/tasks/{id}:subscribe` 行为一致；subscribe 改用自定义路由并保留 SDK 错误语义（缺失任务仍 404）。
- 预算禁用时不再对每个事件执行序列化测量与时钟读取（消除无谓开销）；`_reject_budget` 声明为 `NoReturn` 并移除不可达代码；补充防回归测试。
- 补充 subscribe 预算与 404 回归测试。

## 验收对照

- [x] 按凭据/IP 的滑动窗口限流（可配置、默认开启）
- [x] SSE/流式响应总字节或时长预算（默认有界）
- [x] 订阅连接空闲超时
- [x] 测试与文档

## 验证

- `./scripts/doctor.sh` 全绿：mypy、770+ 项测试、覆盖率 93%+、构建与 smoke 通过。

Closes #502
Relates to #499
