### PR TITLE
docs: add security surface and residual risk register (#499)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Read before deployment:
 - [docs/maintainer-architecture.md](docs/maintainer-architecture.md) Internal module boundaries and maintainer call chains.
 - [docs/compatibility.md](docs/compatibility.md) Compatibility-sensitive surface and contract-honesty guidance.
 - [docs/guide.md](docs/guide.md) Usage guide, transport details, streaming behavior, extensions, and examples.
+- [docs/security-audit-499.md](docs/security-audit-499.md) Security audit #499 network-surface mapping and residual-risk register.
 - [docs/conformance.md](docs/conformance.md) External TCK experiment workflow and artifact handling.
 - [SECURITY.md](SECURITY.md) Threat model, deployment caveats, and vulnerability disclosure guidance.
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Read before deployment:
 - [docs/maintainer-architecture.md](docs/maintainer-architecture.md) Internal module boundaries and maintainer call chains.
 - [docs/compatibility.md](docs/compatibility.md) Compatibility-sensitive surface and contract-honesty guidance.
 - [docs/guide.md](docs/guide.md) Usage guide, transport details, streaming behavior, extensions, and examples.
-- [docs/security-audit-499.md](docs/security-audit-499.md) Security audit #499 network-surface mapping and residual-risk register.
+- [docs/security-architecture.md](docs/security-architecture.md) Security surface, boundaries, and residual-risk register.
 - [docs/conformance.md](docs/conformance.md) External TCK experiment workflow and artifact handling.
 - [SECURITY.md](SECURITY.md) Threat model, deployment caveats, and vulnerability disclosure guidance.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,8 @@ This project is currently best suited for trusted or internal environments. Impo
 - static credential auth only by default; stronger identity propagation is still a follow-up hardening area
 - operators remain responsible for host hardening, secret rotation, process access controls, and reverse-proxy exposure strategy
 
-For the consolidated audit network-surface mapping and residual-risk register,
-see [docs/security-audit-499.md](./docs/security-audit-499.md).
+For the security surface mapping and residual-risk register, see
+[docs/security-architecture.md](./docs/security-architecture.md).
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,9 @@ This project is currently best suited for trusted or internal environments. Impo
 - static credential auth only by default; stronger identity propagation is still a follow-up hardening area
 - operators remain responsible for host hardening, secret rotation, process access controls, and reverse-proxy exposure strategy
 
+For the consolidated audit network-surface mapping and residual-risk register,
+see [docs/security-audit-499.md](./docs/security-audit-499.md).
+
 ## Reporting a Vulnerability
 
 Please avoid posting active secrets, bearer tokens, or reproduction payloads that contain private data in public issues.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,7 @@ Use the docs by responsibility:
 - [Usage Guide](guide.md): runtime configuration, transport contracts, extensions, and examples
 - [Maintainer Architecture Guide](maintainer-architecture.md): internal module boundaries, request call chains, and persistence touchpoints
 - [Extension Specifications](extension-specifications.md): stable extension URI/spec index and disclosure policy
+- [Security Audit #499](security-audit-499.md): audit network-surface mapping and residual-risk register
 - [Conformance Notes](conformance.md): external TCK experiment workflow
 - [Contributing Guide](../CONTRIBUTING.md): contributor workflow and validation
 - [Security Policy](../SECURITY.md): threat model and disclosure guidance

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,7 +96,7 @@ Use the docs by responsibility:
 - [Usage Guide](guide.md): runtime configuration, transport contracts, extensions, and examples
 - [Maintainer Architecture Guide](maintainer-architecture.md): internal module boundaries, request call chains, and persistence touchpoints
 - [Extension Specifications](extension-specifications.md): stable extension URI/spec index and disclosure policy
-- [Security Audit #499](security-audit-499.md): audit network-surface mapping and residual-risk register
+- [Security Architecture](security-architecture.md): security surface mapping and residual-risk register
 - [Conformance Notes](conformance.md): external TCK experiment workflow
 - [Contributing Guide](../CONTRIBUTING.md): contributor workflow and validation
 - [Security Policy](../SECURITY.md): threat model and disclosure guidance

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -102,6 +102,9 @@ Browsers store and automatically attach Basic credentials, and they send an `Ori
 
 For browser-based clients, prefer the same origin as `A2A_PUBLIC_URL`, or explicitly allow the dashboard origin via `A2A_ALLOWED_ORIGINS` and treat `A2A_ALLOWED_HOSTS` as part of the deployment contract. Basic authentication should not be relied on as the sole browser-facing boundary: combine it with the origin/host checks above, short-lived credentials, and TLS at the public URL.
 
+The consolidated audit network-surface mapping and residual-risk register live
+in [security-audit-499.md](./security-audit-499.md).
+
 ## Client Initialization Facade (Preview)
 
 `opencode-a2a` now includes a minimal client bootstrap module in `src/opencode_a2a/client/` to support downstream consumer usage while keeping server and client concerns separate.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -102,8 +102,8 @@ Browsers store and automatically attach Basic credentials, and they send an `Ori
 
 For browser-based clients, prefer the same origin as `A2A_PUBLIC_URL`, or explicitly allow the dashboard origin via `A2A_ALLOWED_ORIGINS` and treat `A2A_ALLOWED_HOSTS` as part of the deployment contract. Basic authentication should not be relied on as the sole browser-facing boundary: combine it with the origin/host checks above, short-lived credentials, and TLS at the public URL.
 
-The consolidated audit network-surface mapping and residual-risk register live
-in [security-audit-499.md](./security-audit-499.md).
+The security surface mapping and residual-risk register live in
+[security-architecture.md](./security-architecture.md).
 
 ## Client Initialization Facade (Preview)
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -128,4 +128,7 @@ For maintainers new to the codebase, this order usually gives the fastest payoff
 3. `src/opencode_a2a/server/application.py`
 4. `src/opencode_a2a/execution/executor.py`
 5. `src/opencode_a2a/contracts/extensions/`
+
+For security-focused contributors, `docs/security-audit-499.md` additionally
+consolidates the audit network-surface mapping and residual-risk register.
 6. `docs/guide.md`

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -129,6 +129,6 @@ For maintainers new to the codebase, this order usually gives the fastest payoff
 4. `src/opencode_a2a/execution/executor.py`
 5. `src/opencode_a2a/contracts/extensions/`
 
-For security-focused contributors, `docs/security-audit-499.md` additionally
-consolidates the audit network-surface mapping and residual-risk register.
+For security-focused contributors, `docs/security-architecture.md` additionally
+consolidates the security surface mapping and residual-risk register.
 6. `docs/guide.md`

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -1,38 +1,23 @@
-# Security Audit #499 — Network Surface Mapping and Residual Risk Register
+# Security Architecture, Surface, and Residual Risks
 
-This document consolidates the audit-mapping deliverables of
-[issue #499](https://github.com/Intelligent-Internet/opencode-a2a/issues/499)
-(system security audit aligned with codex-a2a #331):
+This document is the single source of truth for the adapter's security
+surface: network listeners and routes, authentication and authorization, input
+limits and boundary guards, outbound side effects, the end-to-end mapping from
+remote A2A input to OpenCode side effects, and the residual-risk register.
 
-- full network-surface mapping: listeners, routes, authentication and
-  authorization, input limits, and outbound side effects;
-- end-to-end mapping of remote A2A input to OpenCode session/tool/file side
-  effects;
-- the residual-risk register, including the risks called out during audit
-  close-out.
+It is a living document. Security-relevant changes must update the mapping and
+the risk register in the same change that alters the behavior. It complements,
+and does not replace:
 
-It is the single source of truth for the audit mapping and risk register.
-Operational configuration details live in [guide.md](./guide.md), the threat
-model lives in [SECURITY.md](../SECURITY.md), and the one-off security report,
-test plan, and supply-chain review record live in issue #499 and its closing PR
-(per maintainer decision, audit conclusions are not duplicated into repository
-docs to avoid drift).
+- [SECURITY.md](../SECURITY.md) — threat model, trust boundary, and
+  vulnerability reporting;
+- [guide.md](./guide.md) — operational configuration, defaults, and runbooks;
+- [compatibility.md](./compatibility.md) — wire-level compatibility promises.
 
-## Audit Scope and Baseline
+One-off audit conclusions, review records, and test plans are intentionally
+not stored here; they live in the issue/PR history of the repository.
 
-- Audit start baseline: `adf2a9b` (recorded in #499).
-- Reviewed head: `23f8968` (main).
-- Fixes landed via merged PRs:
-
-| Audit item | Issue | Fix PR |
-| --- | --- | --- |
-| Outbound SSRF / credential exfiltration | #500 | #505 |
-| SQLite persistence hardening | #501 | #507 |
-| Rate limits and streaming budgets | #502 | #509 |
-| Discovery response normalization | #503 | #506 |
-| Inbound Origin/Host boundary | #504 | #508 |
-
-## Network Surface Mapping
+## Network Surface
 
 ### Listeners and Bind
 
@@ -134,5 +119,15 @@ All REST routes are served at the root path (no `/v1` prefix).
 | R-3 | Non-loopback bind without `A2A_ALLOWED_HOSTS` only warns at startup | Accepted | Operator contract: trusted network or reverse proxy validates Host. [guide.md](./guide.md) "Inbound Origin and Host Boundary" |
 | R-4 | Single-tenant shared-workspace boundary; static credentials only by default | Accepted by design | Threat model and tenant guidance in [SECURITY.md](../SECURITY.md) |
 | R-5 | Payload logging can capture sensitive data when enabled | Accepted | Opt-in with `A2A_LOG_BODY_LIMIT` cap; treat logs as sensitive. [SECURITY.md](../SECURITY.md) |
-| R-6 | Push notification config surface exposed-but-unsupported (HTTP 501 / JSON-RPC unsupported) | Accepted | Contract kept explicit; capability recovery tracked separately in #451 |
+| R-6 | Push notification config surface exposed-but-unsupported (HTTP 501 / JSON-RPC unsupported) | Accepted | Contract kept explicitly unsupported; capability recovery is intentionally deferred |
 | R-7 | SQLite hardening exempts `:memory:` / `file:` URIs and non-POSIX platforms | Accepted | Plain absolute file path recommended for deployments. [guide.md](./guide.md) "SQLite Persistence Hardening" |
+
+## Maintenance Rules
+
+- This document is the canonical security-surface reference. Update the route
+  table, mapping, or risk register in the same change that alters listeners,
+  routes, authentication/authorization, input limits, outbound policy,
+  persistence hardening, or known residual risks.
+- Do not turn this document into a report for a specific review cycle: keep it
+  focused on facts that remain true for the current code and must stay
+  maintainable. One-off conclusions belong in issue/PR history.

--- a/docs/security-audit-499.md
+++ b/docs/security-audit-499.md
@@ -1,0 +1,138 @@
+# Security Audit #499 — Network Surface Mapping and Residual Risk Register
+
+This document consolidates the audit-mapping deliverables of
+[issue #499](https://github.com/Intelligent-Internet/opencode-a2a/issues/499)
+(system security audit aligned with codex-a2a #331):
+
+- full network-surface mapping: listeners, routes, authentication and
+  authorization, input limits, and outbound side effects;
+- end-to-end mapping of remote A2A input to OpenCode session/tool/file side
+  effects;
+- the residual-risk register, including the risks called out during audit
+  close-out.
+
+It is the single source of truth for the audit mapping and risk register.
+Operational configuration details live in [guide.md](./guide.md), the threat
+model lives in [SECURITY.md](../SECURITY.md), and the one-off security report,
+test plan, and supply-chain review record live in issue #499 and its closing PR
+(per maintainer decision, audit conclusions are not duplicated into repository
+docs to avoid drift).
+
+## Audit Scope and Baseline
+
+- Audit start baseline: `adf2a9b` (recorded in #499).
+- Reviewed head: `23f8968` (main).
+- Fixes landed via merged PRs:
+
+| Audit item | Issue | Fix PR |
+| --- | --- | --- |
+| Outbound SSRF / credential exfiltration | #500 | #505 |
+| SQLite persistence hardening | #501 | #507 |
+| Rate limits and streaming budgets | #502 | #509 |
+| Discovery response normalization | #503 | #506 |
+| Inbound Origin/Host boundary | #504 | #508 |
+
+## Network Surface Mapping
+
+### Listeners and Bind
+
+- The service is a FastAPI/uvicorn app bound to `A2A_HOST:A2A_PORT`
+  (defaults `127.0.0.1:8000`).
+- Binding to a non-loopback address without `A2A_ALLOWED_HOSTS` logs a startup
+  warning (DNS-rebinding exposure); see residual risk R-3.
+
+### HTTP+JSON (REST) Routes
+
+All REST routes are served at the root path (no `/v1` prefix).
+
+| Method | Path | Purpose | Auth |
+| --- | --- | --- | --- |
+| GET | `/.well-known/agent-card.json` | Public Agent Card | Anonymous |
+| GET | `/extendedAgentCard` | Authenticated extended Agent Card | Credential |
+| POST | `/message:send` | Send a task message (unary) | Credential |
+| POST | `/message:stream` | Send a task message (SSE stream) | Credential |
+| POST | `/tasks/{id}:cancel` | Cancel a task | Credential |
+| GET/POST | `/tasks/{id}:subscribe` | Subscribe to a task stream | Credential |
+| GET | `/tasks/{id}` | Get a task | Credential |
+| GET | `/tasks` | List tasks | Credential |
+| GET/POST/DELETE | `/tasks/{id}/pushNotificationConfigs[/{push_id}]` | Push notification config (exposed-but-unsupported) | Credential |
+| POST | `/` | JSON-RPC endpoint (core + extensions) | Credential |
+| GET | `/health` | Health / runtime profile | Anonymous |
+| GET | `/openapi.json` | Sanitized OpenAPI contract | Anonymous |
+
+### JSON-RPC Surface
+
+- Core A2A methods from the SDK dispatcher: `message/send`, `message/stream`,
+  `tasks/get`, `tasks/cancel`, `tasks/list`, `tasks/subscribe`,
+  `tasks/pushNotificationConfig/*`.
+- Provider-private `opencode.*` extensions (authenticated extended card only):
+  - `opencode.sessions.*`: `status`, `list`, `messages.list`, `get`, `children`,
+    `todo`, `diff`, `message.get`, `prompt_async`, `command`, `fork`, `share`,
+    `unshare`, `summarize`, `revert`, `unrevert`, `shell`
+    (deployment-conditional);
+  - `opencode.providers.*` / `opencode.models.*`: `list_providers`,
+    `list_models`;
+  - `opencode.projects.*` / `opencode.workspaces.*` / `opencode.worktrees.*`:
+    discovery plus gated mutations (`create_workspace`, `remove_workspace`,
+    `create_worktree`, `remove_worktree`, `reset_worktree`);
+  - `opencode.interrupt.*`: `list_permissions`, `list_questions`,
+    `reply_permission`, `reply_question`, `reject_question`.
+
+### Authentication and Authorization
+
+- `A2A_STATIC_AUTH_CREDENTIALS` (Basic/Bearer) is enforced before routing on
+  every credential-protected endpoint; the public Agent Card and `/health` are
+  anonymous.
+- `credential_id` is carried as runtime metadata for audit/logging/rotation; it
+  does not participate in principal resolution or authorization.
+- Capability gates:
+  - `A2A_ENABLE_SESSION_SHELL` → `CAPABILITY_SESSION_SHELL`;
+  - `A2A_ENABLE_WORKSPACE_MUTATIONS` → `CAPABILITY_WORKSPACE_MUTATION`;
+  - enforced via `request_has_capability` at the handler boundary.
+- The runtime is a single-tenant trust boundary by design; see
+  [SECURITY.md](../SECURITY.md) for the threat model.
+
+### Input Limits and Boundary Guards
+
+| Guard | Mechanism | Defaults / Notes |
+| --- | --- | --- |
+| CSRF / Origin | `A2A_ALLOWED_ORIGINS` + `A2A_PUBLIC_URL` origin | `Origin`-bearing requests must match; `Origin: null` rejected |
+| DNS rebinding / Host | `A2A_ALLOWED_HOSTS` | Enforced when configured; startup warning otherwise on non-loopback bind |
+| Body size | `A2A_MAX_REQUEST_BODY_BYTES` | 1 MiB |
+| Rate limit | `A2A_RATE_LIMIT_ENABLED` / `_WINDOW_SECONDS` / `_MAX_REQUESTS` | On by default; 60 s window, 120 requests; 429 + `Retry-After` |
+| Stream budgets | `A2A_STREAM_MAX_BYTES` / `_MAX_DURATION_SECONDS` / `_IDLE_TIMEOUT_SECONDS` | 64 MiB / 3600 s / 120 s; `0` disables |
+| Payload logging | `A2A_LOG_PAYLOADS` / `A2A_LOG_BODY_LIMIT` | Opt-in; logs treated as sensitive |
+
+### Outbound Side Effects
+
+- `a2a_call` tool execution → `server/client_manager.py` (`borrow_client`) →
+  `client/network_policy.py` validation: http/https only, no userinfo,
+  `A2A_CLIENT_ALLOWED_HOSTS` allowlist, private/loopback address rejection, and
+  credentials attached to allowlisted hosts only.
+- CLI `opencode-a2a call` is operator-invoked and shares URL handling, but is
+  not allowlist-bound.
+- The upstream OpenCode client (`OPENCODE_BASE_URL`, auth, timeouts, concurrency
+  caps) is the only other outbound path.
+
+## End-to-End Mapping: Remote A2A Input → OpenCode Side Effects
+
+| A2A input | Adapter path | OpenCode / host side effects |
+| --- | --- | --- |
+| `message/send` / `message/stream` | REST or JSON-RPC → middleware guards → `execution/executor.py` → `opencode_upstream_client.py` | Upstream OpenCode session prompt/command; stream normalization; task/message persistence |
+| Session extension queries/mutations | `jsonrpc/handlers/session_*.py` | Read/shape session state; `fork`/`share`/`revert` mutate upstream session state |
+| Workspace/worktree control | `jsonrpc/handlers/workspace_control.py` (mutation gated) | Project/workspace/worktree create/remove/reset → filesystem side effects inside the OpenCode workspace; responses normalized (no local paths) |
+| Interrupt recovery/callback | `jsonrpc/handlers/interrupt_*.py` | Request-ID lifecycle, expiry, identity-scoped state |
+| Tool execution during a session | `execution/tool_orchestration.py` | `a2a_call` may trigger remote agent work; other tools remain OpenCode-runtime behavior |
+| Task/session persistence | `server/task_store.py`, `state_store.py`, `migrations.py` | SQLite task/state rows (hardened file access) |
+
+## Residual Risk Register
+
+| ID | Risk | Status | Mitigation / Reference |
+| --- | --- | --- | --- |
+| R-1 | Outbound DNS-rebinding TOCTOU: `a2a_call` validation resolves the host, then the connection re-resolves (resolve-then-connect) | Accepted | Allowlist + private-IP rejection reduce exposure; pinned-IP connect is not implemented. [guide.md](./guide.md) "Client Initialization Facade" |
+| R-2 | Rate limiter is process-local; multi-process deployments bypass per-credential limits | Accepted | Documented; use a gateway-level limiter or per-instance limits. [guide.md](./guide.md) "Auth, Limits, and Failure Contract" |
+| R-3 | Non-loopback bind without `A2A_ALLOWED_HOSTS` only warns at startup | Accepted | Operator contract: trusted network or reverse proxy validates Host. [guide.md](./guide.md) "Inbound Origin and Host Boundary" |
+| R-4 | Single-tenant shared-workspace boundary; static credentials only by default | Accepted by design | Threat model and tenant guidance in [SECURITY.md](../SECURITY.md) |
+| R-5 | Payload logging can capture sensitive data when enabled | Accepted | Opt-in with `A2A_LOG_BODY_LIMIT` cap; treat logs as sensitive. [SECURITY.md](../SECURITY.md) |
+| R-6 | Push notification config surface exposed-but-unsupported (HTTP 501 / JSON-RPC unsupported) | Accepted | Contract kept explicit; capability recovery tracked separately in #451 |
+| R-7 | SQLite hardening exempts `:memory:` / `file:` URIs and non-POSIX platforms | Accepted | Plain absolute file path recommended for deployments. [guide.md](./guide.md) "SQLite Persistence Hardening" |


### PR DESCRIPTION
## 关联 Issue

Closes #499

## 背景

#499 系统安全审计的五个拆解子项（#500/#501/#502/#503/#504）已分别由 PR #505/#507/#509/#506/#508 修复并合并。本次为审计收口，按维护决策区分「一次性记录」与「可持久化文档」：

- 一次性审计结论（报告、测试计划、供应链记录）以本 issue + PR 记录交付，不写入仓库；
- 需要随代码持续维护的安全事实落库为持久文档。

## 变更内容

新增 `docs/security-architecture.md`（持久化活文档，非某次审计的报告），集中承载安全面与残余风险，作为单一权威源；README / architecture / maintainer-architecture / guide / SECURITY 均交叉引用：

- 网络面映射：监听器与绑定、REST 路由表、JSON-RPC 面、认证与授权（含 capability 门控）、输入限制与边界防护（Origin/Host、请求体大小、限流、流式预算、日志上限）、出站副作用（`a2a_call` 网络策略、CLI、上游 OpenCode 客户端）
- 端到端映射：远程 A2A 输入 → OpenCode 会话/工具/文件副作用（消息流、session 扩展、workspace/worktree 变更、中断、持久化）
- 残余风险登记 R-1..R-7（见下）
- 维护规则：本文档随安全相关改动同步更新；不承载一次性评审结论

文档刻意不包含审计基线、修复 PR 对照表等过程性 issue 信息，避免退化为特定 issue 的报告。

## 残余风险（同步登记于 `docs/security-architecture.md`）

- R-1 出站 `a2a_call` DNS-rebinding 校验为 resolve-then-connect，存在 TOCTOU；白名单 + 私网拒绝已降低暴露，pinned-IP 连接未实现
- R-2 限流为进程内实现，多进程部署需网关级限流或按实例限额
- R-3 非 loopback 绑定且未配置 `A2A_ALLOWED_HOSTS` 时仅启动告警，依赖部署方 Host 校验
- R-4 单租户共享工作区边界、默认仅静态凭据（威胁模型见 SECURITY.md）
- R-5 开启 `A2A_LOG_PAYLOADS` 后日志可能含敏感数据
- R-6 push notification config 面 exposed-but-unsupported（501/unsupported），能力恢复有意推迟
- R-7 SQLite 加固豁免 `:memory:`/`file:` URI 与非 POSIX 平台

## 验收对照

- [x] 映射全部监听器、路由、认证、授权、输入限制和出站副作用 → `docs/security-architecture.md`
- [x] 端到端映射远程 A2A 输入到 OpenCode 会话/工具/文件副作用 → `docs/security-architecture.md`
- [x] 交付安全报告与测试计划 → 本 issue + PR 记录（不落库）
- [x] 供应链/CI 审计结果记录 → 本 issue + PR（不落库）
- [x] issue 验收 checkbox 同步勾选

## 验证

- `bash ./scripts/doctor.sh` 全绿：pre-commit、mypy、793 passed、覆盖率 93.31%、构建与 wheel smoke 通过（文档改动为主，回归全量验证）
