### PR TITLE
fix: prevent SQLite connection leaks during setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,5 +105,5 @@ addopts = "--cov=src/opencode_a2a --cov-report=term-missing --cov-report=json:.c
 filterwarnings = [
     "error::pytest.PytestUnhandledThreadExceptionWarning",
     "error::pytest.PytestUnraisableExceptionWarning",
-    "error:.*was deleted before being closed.*:ResourceWarning:aiosqlite.core",
+    "always:.*was deleted before being closed.*:ResourceWarning:aiosqlite.core",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,8 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--cov=src/opencode_a2a --cov-report=term-missing --cov-report=json:.coverage.json --cov-fail-under=90"
+filterwarnings = [
+    "error::pytest.PytestUnhandledThreadExceptionWarning",
+    "error::pytest.PytestUnraisableExceptionWarning",
+    "error:.*was deleted before being closed.*:ResourceWarning:aiosqlite.core",
+]

--- a/src/opencode_a2a/server/database.py
+++ b/src/opencode_a2a/server/database.py
@@ -120,8 +120,8 @@ def _configure_sqlite_connection(
         finally:
             cursor.close()
     except BaseException:
-        # SQLAlchemy does not own the connection yet when a connect listener
-        # fails, so close async DBAPI resources here before re-raising.
+        # SQLAlchemy does not close a DBAPI connection when a connect listener
+        # fails, so release async driver resources before re-raising.
         with suppress(Exception):
             dbapi_connection.close()
         raise
@@ -130,7 +130,7 @@ def _configure_sqlite_connection(
 def _harden_sqlite_before_connect(
     _dialect: Any,
     _connection_record: Any,
-    _connection_args: list[Any],
+    _connection_args: tuple[Any, ...],
     _connection_params: dict[str, Any],
     *,
     database_path: Path,

--- a/src/opencode_a2a/server/database.py
+++ b/src/opencode_a2a/server/database.py
@@ -110,8 +110,12 @@ def _harden_sqlite_file(path: Path) -> None:
 def _configure_sqlite_connection(
     dbapi_connection: Any,
     _connection_record: Any,
+    *,
+    database_path: Path | None = None,
 ) -> None:
     try:
+        if database_path is not None:
+            _harden_sqlite_file(database_path)
         cursor = dbapi_connection.cursor()
         try:
             cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
@@ -168,6 +172,6 @@ def build_database_engine(settings: Settings) -> AsyncEngine:
     event.listen(
         engine.sync_engine,
         "connect",
-        _configure_sqlite_connection,
+        partial(_configure_sqlite_connection, database_path=sqlite_path),
     )
     return engine

--- a/src/opencode_a2a/server/database.py
+++ b/src/opencode_a2a/server/database.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import stat
+from contextlib import suppress
 from functools import partial
 from pathlib import Path
 from typing import Any, cast
@@ -109,18 +110,32 @@ def _harden_sqlite_file(path: Path) -> None:
 def _configure_sqlite_connection(
     dbapi_connection: Any,
     _connection_record: Any,
-    *,
-    database_path: Path | None = None,
 ) -> None:
-    if database_path is not None:
-        _harden_sqlite_file(database_path)
-    cursor = dbapi_connection.cursor()
     try:
-        cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
-        cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
-        cursor.execute(f"PRAGMA synchronous={_SQLITE_SYNCHRONOUS_MODE}")
-    finally:
-        cursor.close()
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
+            cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+            cursor.execute(f"PRAGMA synchronous={_SQLITE_SYNCHRONOUS_MODE}")
+        finally:
+            cursor.close()
+    except BaseException:
+        # SQLAlchemy does not own the connection yet when a connect listener
+        # fails, so close async DBAPI resources here before re-raising.
+        with suppress(Exception):
+            dbapi_connection.close()
+        raise
+
+
+def _harden_sqlite_before_connect(
+    _dialect: Any,
+    _connection_record: Any,
+    _connection_args: list[Any],
+    _connection_params: dict[str, Any],
+    *,
+    database_path: Path,
+) -> None:
+    _harden_sqlite_file(database_path)
 
 
 def redact_database_url_for_logs(database_url: str) -> str:
@@ -144,9 +159,15 @@ def build_database_engine(settings: Settings) -> AsyncEngine:
         _harden_sqlite_file(sqlite_path)
 
     engine = create_async_engine(database_url)
+    if sqlite_path is not None:
+        event.listen(
+            engine.sync_engine,
+            "do_connect",
+            partial(_harden_sqlite_before_connect, database_path=sqlite_path),
+        )
     event.listen(
         engine.sync_engine,
         "connect",
-        partial(_configure_sqlite_connection, database_path=sqlite_path),
+        _configure_sqlite_connection,
     )
     return engine

--- a/tests/server/test_database.py
+++ b/tests/server/test_database.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import os
 import stat
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 
+import aiosqlite
 import pytest
 
 from opencode_a2a.server import database as database_module
@@ -198,7 +201,19 @@ def test_apply_private_sqlite_modes_rejects_foreign_owned_sidecar(tmp_path, monk
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
 @pytest.mark.asyncio
-async def test_build_database_engine_rechecks_hardening_on_new_connection(tmp_path) -> None:
+async def test_build_database_engine_rechecks_hardening_on_new_connection(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    created_connections: list[aiosqlite.Connection] = []
+    original_connect = aiosqlite.connect
+
+    def tracking_connect(*args: Any, **kwargs: Any) -> aiosqlite.Connection:
+        connection = original_connect(*args, **kwargs)
+        created_connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(aiosqlite, "connect", tracking_connect)
     settings = _settings_for(tmp_path)
     engine = build_database_engine(settings)
     try:
@@ -217,3 +232,17 @@ async def test_build_database_engine_rechecks_hardening_on_new_connection(tmp_pa
                 await conn.exec_driver_sql("SELECT 1")
     finally:
         await engine.dispose()
+
+    assert len(created_connections) == 1
+
+
+def test_configure_sqlite_connection_closes_connection_on_failure() -> None:
+    dbapi_connection = MagicMock()
+    cursor = dbapi_connection.cursor.return_value
+    cursor.execute.side_effect = RuntimeError("PRAGMA failed")
+
+    with pytest.raises(RuntimeError, match="PRAGMA failed"):
+        database_module._configure_sqlite_connection(dbapi_connection, MagicMock())
+
+    cursor.close.assert_called_once_with()
+    dbapi_connection.close.assert_called_once_with()

--- a/tests/server/test_database.py
+++ b/tests/server/test_database.py
@@ -240,6 +240,7 @@ def test_configure_sqlite_connection_closes_connection_on_failure() -> None:
     dbapi_connection = MagicMock()
     cursor = dbapi_connection.cursor.return_value
     cursor.execute.side_effect = RuntimeError("PRAGMA failed")
+    dbapi_connection.close.side_effect = OSError("close failed")
 
     with pytest.raises(RuntimeError, match="PRAGMA failed"):
         database_module._configure_sqlite_connection(dbapi_connection, MagicMock())

--- a/tests/server/test_database.py
+++ b/tests/server/test_database.py
@@ -247,3 +247,22 @@ def test_configure_sqlite_connection_closes_connection_on_failure() -> None:
 
     cursor.close.assert_called_once_with()
     dbapi_connection.close.assert_called_once_with()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_configure_sqlite_connection_closes_connection_on_hardening_failure(tmp_path) -> None:
+    victim = tmp_path / "victim.db"
+    victim.write_bytes(b"")
+    database_path = tmp_path / "runtime.db"
+    database_path.symlink_to(victim)
+    dbapi_connection = MagicMock()
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        database_module._configure_sqlite_connection(
+            dbapi_connection,
+            MagicMock(),
+            database_path=database_path,
+        )
+
+    dbapi_connection.cursor.assert_not_called()
+    dbapi_connection.close.assert_called_once_with()

--- a/tests/server/test_state_store.py
+++ b/tests/server/test_state_store.py
@@ -667,12 +667,16 @@ async def test_build_runtime_state_runtime_initializes_and_preserves_shared_engi
         a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'runtime-state.db'}",
     )
     engine = build_database_engine(settings)
+    original_dispose = engine.dispose
     dispose_spy = AsyncMock()
     monkeypatch.setattr(type(engine), "dispose", dispose_spy)
 
-    runtime = build_runtime_state_runtime(settings, engine=engine)
-    await runtime.startup()
-    await runtime.shutdown()
+    try:
+        runtime = build_runtime_state_runtime(settings, engine=engine)
+        await runtime.startup()
+        await runtime.shutdown()
 
-    assert await _read_state_store_schema_version(engine) == CURRENT_STATE_STORE_SCHEMA_VERSION
-    dispose_spy.assert_not_awaited()
+        assert await _read_state_store_schema_version(engine) == CURRENT_STATE_STORE_SCHEMA_VERSION
+        dispose_spy.assert_not_awaited()
+    finally:
+        await original_dispose()

--- a/tests/server/test_task_store_factory.py
+++ b/tests/server/test_task_store_factory.py
@@ -523,13 +523,17 @@ async def test_build_task_store_does_not_dispose_shared_engine(
         a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'shared-engine.db'}",
     )
     engine = build_database_engine(settings)
+    original_dispose = engine.dispose
     dispose_spy = AsyncMock()
     monkeypatch.setattr(type(engine), "dispose", dispose_spy)
 
-    store = build_task_store(settings, engine=engine)
-    await initialize_task_store(store)
+    try:
+        store = build_task_store(settings, engine=engine)
+        await initialize_task_store(store)
 
-    dispose_spy.assert_not_awaited()
+        dispose_spy.assert_not_awaited()
+    finally:
+        await original_dispose()
 
 
 @pytest.mark.asyncio
@@ -542,14 +546,18 @@ async def test_build_task_store_runtime_does_not_dispose_shared_engine(
         a2a_task_store_database_url=f"sqlite+aiosqlite:///{tmp_path / 'shared-runtime-engine.db'}",
     )
     engine = build_database_engine(settings)
+    original_dispose = engine.dispose
     dispose_spy = AsyncMock()
     monkeypatch.setattr(type(engine), "dispose", dispose_spy)
 
-    runtime = build_task_store_runtime(settings, engine=engine)
-    await runtime.startup()
-    await runtime.shutdown()
+    try:
+        runtime = build_task_store_runtime(settings, engine=engine)
+        await runtime.startup()
+        await runtime.shutdown()
 
-    dispose_spy.assert_not_awaited()
+        dispose_spy.assert_not_awaited()
+    finally:
+        await original_dispose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

Python 3.14 测试中偶发出现 `aiosqlite` worker thread 在 event loop 关闭后回调的警告。调查确认它并非无害时序噪声，而是连接初始化失败或测试清理不完整留下的真实连接资源。

Closes #516

## 变更

- 在 SQLAlchemy `do_connect` 阶段执行 SQLite 文件安全预检，在物理连接建立前拒绝 symlink 等不安全路径。
- 保留连接建立后的安全复检，避免迁移检查时机削弱原有纵深防御；复检或 PRAGMA 配置失败时显式关闭 DBAPI 连接，并保留原始异常。
- 修正三个共享 engine ownership 测试：继续验证 runtime 不释放外部 engine，同时由测试在 `finally` 中调用真实 `dispose()` 完成清理。
- 增加回归测试，验证安全预检失败不会额外创建 aiosqlite 连接，并覆盖 PRAGMA 失败、连接后安全复检失败及关闭异常不覆盖原始异常等路径。
- 将 pytest 未处理线程异常和析构异常升级为测试错误；对 aiosqlite 未关闭连接的 `ResourceWarning` 强制展示，但不直接升级为异常，以免中断其析构器中的 worker `stop()`。

## 独立审查与查改

已完成两轮独立 PR diff 审查：

1. 修正 `do_connect` 参数类型注解及 SQLAlchemy 生命周期注释，并补充异步资源泄漏 warning gate。
2. 发现 `ResourceWarning=error` 会中断 aiosqlite 析构清理，调整为安全且可见的告警策略；同时恢复连接后的安全复检，保留纵深防御。

两轮发现均已查改、重新验证并推送，当前没有遗留的已知问题。

## 验证

- 数据库及共享 engine 生命周期定向测试：60 passed
- `bash ./scripts/doctor.sh`：821 passed，覆盖率 93.35%，依赖兼容、pre-commit、mypy、构建及 wheel smoke test 全部通过
- 全量测试剩余 4 条为既有 `EventQueue` deprecation warning，与本 PR 无关

## 相关提交

- `1867994` `fix: prevent SQLite connection leaks during setup`
- `3f1c591` `test: fail on async resource leak warnings`
- `877a4c1` `fix: preserve SQLite hardening during connection setup`

## 风险

- 正常 SQLite 连接路径仅增加一次物理连接前的文件安全预检；PRAGMA 与连接成功语义不变。
- 显式关闭仅在连接初始化异常路径触发。
- 没有添加 warning ignore，也没有修改用户可见配置或协议，因此无需新增用户文档。
